### PR TITLE
fix: add metadata so sse/stdio shows up with description in code.quarkus and maven central

### DIFF
--- a/transports/sse/pom.xml
+++ b/transports/sse/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>quarkus-mcp-server-sse-parent</artifactId>
     <packaging>pom</packaging>
     <name>Quarkus MCP Server Transport - SSE - Parent</name>
-
+    <description>This extension enables developers to implement the MCP server features easily using server side events (SSE).</description>
     <modules>
         <module>deployment</module>
         <module>runtime</module>

--- a/transports/sse/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/transports/sse/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -2,7 +2,7 @@ name: Model Context Protocol (MCP) Server for server side events (SSE)
 metadata:
   keywords:
     - mcp-server
-  guide: https://docs.quarkiverse.io/quarkus-mcp-server/dev/index.html # To create and publish this guide, see https://github.com/quarkiverse/quarkiverse/wiki#documenting-your-extension
+  guide: https://docs.quarkiverse.io/quarkus-mcp-server/dev/index.html
   categories:
     - "miscellaneous"
   status: "preview"

--- a/transports/sse/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/transports/sse/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,8 @@
+name: Model Context Protocol (MCP) Server for server side events (SSE)
+metadata:
+  keywords:
+    - mcp-server
+  guide: https://docs.quarkiverse.io/quarkus-mcp-server/dev/index.html # To create and publish this guide, see https://github.com/quarkiverse/quarkiverse/wiki#documenting-your-extension
+  categories:
+    - "miscellaneous"
+  status: "preview"

--- a/transports/stdio/pom.xml
+++ b/transports/stdio/pom.xml
@@ -11,6 +11,7 @@
     <artifactId>quarkus-mcp-server-stdio-parent</artifactId>
     <packaging>pom</packaging>
     <name>Quarkus MCP Server Transport - stdio - Parent</name>
+    <description>This extension enables developers to implement the MCP server features easily using stanard input/output (stdio).</description>
 
     <modules>
         <module>deployment</module>

--- a/transports/stdio/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/transports/stdio/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -2,7 +2,7 @@ name: Model Context Protocol (MCP) Server for standard input/output (stdio)
 metadata:
   keywords:
     - mcp-server
-  guide: https://docs.quarkiverse.io/quarkus-mcp-server/dev/index.html # To create and publish this guide, see https://github.com/quarkiverse/quarkiverse/wiki#documenting-your-extension
+  guide: https://docs.quarkiverse.io/quarkus-mcp-server/dev/index.html
   categories:
     - "miscellaneous"
   status: "preview"

--- a/transports/stdio/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/transports/stdio/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,8 @@
+name: Model Context Protocol (MCP) Server for standard input/output (stdio)
+metadata:
+  keywords:
+    - mcp-server
+  guide: https://docs.quarkiverse.io/quarkus-mcp-server/dev/index.html # To create and publish this guide, see https://github.com/quarkiverse/quarkiverse/wiki#documenting-your-extension
+  categories:
+    - "miscellaneous"
+  status: "preview"


### PR DESCRIPTION
follow up to #26 which missed that the new sse and stdio extensions doesn't have any metadata so the descriptions are generic/wrong.

This fixes it - but does require new release.
