### PR TITLE
core: introduce API to encode return values as response objects

### DIFF
--- a/core/deployment/src/test/java/io/quarkiverse/mcp/server/deployment/McpServerProcessorTest.java
+++ b/core/deployment/src/test/java/io/quarkiverse/mcp/server/deployment/McpServerProcessorTest.java
@@ -12,15 +12,16 @@ public class McpServerProcessorTest {
 
     @Test
     public void testCreateMapperField() {
-        assertEquals("RESOURCE_CONTENT",
-                McpServerProcessor.createMapperField(Feature.RESOURCE, ClassType.create(DotNames.TEXT_RESOURCE_CONTENTS),
+        assertEquals("ResourceContent",
+                McpServerProcessor.createMapperClassSimpleName(Feature.RESOURCE,
+                        ClassType.create(DotNames.TEXT_RESOURCE_CONTENTS),
                         DotNames.RESOURCE_RESPONSE,
-                        c -> "CONTENT"));
-        assertEquals("IDENTITY",
-                McpServerProcessor.createMapperField(Feature.RESOURCE,
+                        c -> "Content"));
+        assertEquals("Identity",
+                McpServerProcessor.createMapperClassSimpleName(Feature.RESOURCE,
                         ParameterizedType.create(DotNames.UNI, ClassType.create(DotNames.RESOURCE_RESPONSE)),
                         DotNames.RESOURCE_RESPONSE,
-                        c -> "CONTENT"));
+                        c -> "Content"));
     }
 
 }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/ContentEncoder.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/ContentEncoder.java
@@ -1,0 +1,20 @@
+package io.quarkiverse.mcp.server;
+
+import jakarta.annotation.Priority;
+
+/**
+ * Encodes an object as {@link Content}.
+ * <p>
+ * Implementation classes must be CDI beans. Qualifiers are ignored. {@link jakarta.enterprise.context.Dependent} beans are
+ * reused during encoding.
+ * <p>
+ * Encoders may define the priority with {@link Priority}. An encoder with higher priority takes precedence.
+ *
+ * @param <TYPE>
+ * @see Content
+ * @see Tool
+ * @see Prompt
+ */
+public interface ContentEncoder<TYPE> extends Encoder<TYPE, Content> {
+
+}

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/Encoder.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/Encoder.java
@@ -1,0 +1,24 @@
+package io.quarkiverse.mcp.server;
+
+/**
+ *
+ * @param <TYPE> The type to be encoded
+ * @param <ENCODED> The resulting type of encoding
+ */
+public interface Encoder<TYPE, ENCODED> {
+
+    /**
+     *
+     * @param runtimeType The runtime class of an object that should be encoded, must not be {@code null}
+     * @return {@code true} if this encoder can encode the provided type, {@code false} otherwise
+     */
+    boolean supports(Class<?> runtimeType);
+
+    /**
+     *
+     * @param value
+     * @return the encoded value
+     */
+    ENCODED encode(TYPE value);
+
+}

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/Prompt.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/Prompt.java
@@ -14,25 +14,19 @@ import io.smallrye.mutiny.Uni;
  * <p>
  * The result of a "prompt get" operation is always represented as a {@link PromptResponse}. However, the annotated method can
  * also return other types that are converted according to the following rules.
+ * <p>
  * <ul>
- * <li>If the method returns a {@link PromptMessage} then the reponse has no description and contains the single
+ * <li>If it returns a {@link PromptMessage} then the reponse has no description and contains the single
  * message object.</li>
- * <li>If the method returns a {@link List} of {@link PromptMessage}s then the reponse has no description and contains the
+ * <li>If it returns a {@link List} of {@link PromptMessage}s then the reponse has no description and contains the
  * list of messages.</li>
- * <li>The method may return a {@link Uni} that wraps any of the type mentioned above.</li>
- * </ul>
- * In other words, the return type must be one of the following list:
- * <ul>
- * <li>{@code PromptResponse}</li>
- * <li>{@code PromptMessage}</li>
- * <li>{@code List<PromptMessage>}</li>
- * <li>{@code Uni<PromptResponse>}</li>
- * <li>{@code Uni<PromptMessage>}</li>
- * <li>{@code Uni<List<PromptMessage>>}</li>
+ * <li>If it returns any other type {@code X} then {@code X} is encoded using the {@link PromptResponseEncoder} API.</li>
+ * <li>It may also return a {@link Uni} that wraps any of the type mentioned above.</li>
  * </ul>
  *
  * @see PromptResponse
  * @see PromptArg
+ * @see PromptResponseEncoder
  */
 @Retention(RUNTIME)
 @Target(METHOD)

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/PromptResponseEncoder.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/PromptResponseEncoder.java
@@ -1,0 +1,22 @@
+package io.quarkiverse.mcp.server;
+
+import jakarta.annotation.Priority;
+
+/**
+ * Encodes an object as {@link PromptResponse}.
+ * <p>
+ * If a propmpt response encoder exists and matches a specific return type then it always takes precedence over matching
+ * {@link ContentEncoder}.
+ * <p>
+ * Implementation classes must be CDI beans. Qualifiers are ignored. {@link jakarta.enterprise.context.Dependent} beans are
+ * reused during encoding.
+ * <p>
+ * Encoders may define the priority with {@link Priority}. An encoder with higher priority takes precedence.
+ *
+ * @param <TYPE>
+ * @see PromptResponse
+ * @see Prompt
+ */
+public interface PromptResponseEncoder<TYPE> extends Encoder<TYPE, PromptResponse> {
+
+}

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/Resource.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/Resource.java
@@ -16,13 +16,21 @@ import io.smallrye.mutiny.Uni;
  * can also return other types that are converted according to the following rules.
  *
  * <ul>
- * <li>If the method returns an implementation of {@link ResourceContents} then the reponse contains the single contents
+ * <li>If it returns an implementation of {@link ResourceContents} then the reponse contains the single contents
  * object.</li>
- * <li>If the method returns a {@link List} of {@link ResourceContents} implementations then the reponse contains the list of
+ * <li>If it returns a {@link List} of {@link ResourceContents} implementations then the reponse contains the list of
  * contents objects.</li>
+ * <li>If it returns any other type {@code X} or {@code List<X>} then {@code X} is encoded using the
+ * {@link ResourceContentsEncoder} API and afterwards the rules above apply.</li>
  * <li>The method may return a {@link Uni} that wraps any of the type mentioned above.</li>
  * </ul>
  *
+ * <p>
+ * There is a default resource contents encoder registered; it encodes the returned value as JSON.
+ *
+ * @see ResourceTemplate
+ * @see ResourceResponse
+ * @see ResourceContentsEncoder
  */
 @Retention(RUNTIME)
 @Target(METHOD)

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/ResourceContentsEncoder.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/ResourceContentsEncoder.java
@@ -1,0 +1,25 @@
+package io.quarkiverse.mcp.server;
+
+import jakarta.annotation.Priority;
+
+import io.quarkiverse.mcp.server.ResourceContentsEncoder.ResourceContentsData;
+
+/**
+ * Encodes an object as {@link ResourceContents}.
+ * <p>
+ * Implementation classes must be CDI beans. Qualifiers are ignored. {@link jakarta.enterprise.context.Dependent} beans are
+ * reused during encoding.
+ * <p>
+ * Encoders may define the priority with {@link Priority}. An encoder with higher priority takes precedence.
+ *
+ * @param <TYPE>
+ * @see ResourceContents
+ * @see Resource
+ * @see ResourceTemplate
+ */
+public interface ResourceContentsEncoder<TYPE> extends Encoder<ResourceContentsData<TYPE>, ResourceContents> {
+
+    record ResourceContentsData<TYPE>(RequestUri uri, TYPE data) {
+    }
+
+}

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/ResourceTemplate.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/ResourceTemplate.java
@@ -16,12 +16,21 @@ import io.smallrye.mutiny.Uni;
  * can also return other types that are converted according to the following rules.
  *
  * <ul>
- * <li>If the method returns an implementation of {@link ResourceContents} then the reponse contains the single contents
+ * <li>If it returns an implementation of {@link ResourceContents} then the reponse contains the single contents
  * object.</li>
- * <li>If the method returns a {@link List} of {@link ResourceContents} implementations then the reponse contains the list of
+ * <li>If it returns a {@link List} of {@link ResourceContents} implementations then the reponse contains the list of
  * contents objects.</li>
+ * <li>If it returns any other type {@code X} or {@code List<X>} then {@code X} is encoded using the
+ * {@link ResourceContentsEncoder} API and afterwards the rules above apply.</li>
  * <li>The method may return a {@link Uni} that wraps any of the type mentioned above.</li>
  * </ul>
+ *
+ * <p>
+ * There is a default resource contents encoder registered; it encodes the returned value as JSON.
+ *
+ * @see Resource
+ * @see ResourceResponse
+ * @see ResourceContentsEncoder
  */
 @Retention(RUNTIME)
 @Target(METHOD)

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/Tool.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/Tool.java
@@ -12,21 +12,27 @@ import io.smallrye.mutiny.Uni;
 /**
  * Annotates a business method of a CDI bean as an exposed tool.
  * <p>
- * The result of a "tool call" operation is always represented as a {@link ToolResponse}. However, the annotated method can also
+ * A result of a "tool call" operation is always represented as a {@link ToolResponse}. However, the annotated method can also
  * return other types that are converted according to the following rules.
- *
+ * <p>
  * <ul>
- * <li>If the method returns {@link String} then the reponse is {@code success} and contains the single {@link TextContent}
- * object.</li>
- * <li>If the method returns an implementation of {@link Content} then the reponse is {@code success} and contains the single
+ * <li>If it returns {@link String} then the reponse is {@code success} and contains a single {@link TextContent}.</li>
+ * <li>If it returns an implementation of {@link Content} then the reponse is {@code success} and contains a single
  * content object.</li>
- * <li>If the method returns a {@link List} of {@link Content} implementations or {@link String}s then the reponse is
- * {@code success} and contains the list of relevant content objects.</li>
- * <li>The method may return a {@link Uni} that wraps any of the type mentioned above.</li>
+ * <li>If it returns a {@link List} of {@link Content} implementations or strings then the reponse is
+ * {@code success} and contains a list of relevant content objects.</li>
+ * <li>If it returns any other type {@code X} or {@code List<X>} then {@code X} is encoded using the {@link ToolResponseEncoder}
+ * and {@link ContentEncoder} API and afterwards the rules above apply.</li>
+ * <li>It may also return a {@link Uni} that wraps any of the type mentioned above.</li>
  * </ul>
+ *
+ * <p>
+ * There is a default content encoder registered; it encodes the returned value as JSON.
  *
  * @see ToolResponse
  * @see ToolArg
+ * @see ToolResponseEncoder
+ * @see ContentEncoder
  */
 @Retention(RUNTIME)
 @Target(METHOD)

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/ToolResponseEncoder.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/ToolResponseEncoder.java
@@ -1,0 +1,22 @@
+package io.quarkiverse.mcp.server;
+
+import jakarta.annotation.Priority;
+
+/**
+ * Encodes an object as {@link ToolResponse}.
+ * <p>
+ * If a tool response encoder exists and matches a specific return type then it always takes precedence over matching
+ * {@link ContentEncoder}.
+ * <p>
+ * Implementation classes must be CDI beans. Qualifiers are ignored. {@link jakarta.enterprise.context.Dependent} beans are
+ * reused during encoding.
+ * <p>
+ * Encoders may define the priority with {@link Priority}. An encoder with higher priority takes precedence.
+ *
+ * @param <TYPE>
+ * @see ToolResponse
+ * @see Tool
+ */
+public interface ToolResponseEncoder<TYPE> extends Encoder<TYPE, ToolResponse> {
+
+}

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/EncoderMapper.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/EncoderMapper.java
@@ -1,0 +1,13 @@
+package io.quarkiverse.mcp.server.runtime;
+
+import java.util.function.Function;
+
+import io.quarkiverse.mcp.server.Encoder;
+import io.smallrye.mutiny.Uni;
+
+/**
+ * Marker interface for all mappers based on {@link Encoder}.
+ */
+public interface EncoderMapper<TYPE, RESPONSE> extends Function<TYPE, Uni<RESPONSE>> {
+
+}

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/EncoderResultMapper.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/EncoderResultMapper.java
@@ -1,0 +1,71 @@
+package io.quarkiverse.mcp.server.runtime;
+
+import java.util.List;
+
+import io.quarkiverse.mcp.server.Encoder;
+import io.quarkus.arc.All;
+import io.smallrye.mutiny.Uni;
+
+/**
+ * Result mapper based on {@link Encoder}.
+ *
+ * @param <ENCODED> The type of the value encoded by the encoder
+ * @param <ENCODER> The type of the injected encoder
+ * @param <RESPONSE> The type of the serialized response
+ */
+abstract class EncoderResultMapper<ENCODED, ENCODER extends Encoder<?, ENCODED>, RESPONSE>
+        implements EncoderMapper<Object, RESPONSE> {
+
+    @All
+    List<ENCODER> encoders;
+
+    final EncoderMapper<Uni<Object>, RESPONSE> uni;
+
+    protected EncoderResultMapper() {
+        this.uni = new EncoderMapper<Uni<Object>, RESPONSE>() {
+
+            @Override
+            public Uni<RESPONSE> apply(Uni<Object> uni) {
+                return uni.map(o -> toResponse(EncoderResultMapper.this.convert(o)));
+            }
+        };
+    }
+
+    @Override
+    public Uni<RESPONSE> apply(Object obj) {
+        return Uni.createFrom().item(toResponse(convert(obj)));
+    }
+
+    public EncoderMapper<Uni<Object>, RESPONSE> uni() {
+        return uni;
+    }
+
+    protected abstract RESPONSE toResponse(ENCODED encoded);
+
+    protected ENCODED convert(Object obj) {
+        Class<?> type = obj.getClass();
+        for (ENCODER encoder : encoders) {
+            if (encoder.supports(type)) {
+                ENCODED encoded;
+                try {
+                    encoded = encoder.encode(cast(obj));
+                } catch (Exception e) {
+                    throw new McpException("Unable to encode object of type " + type + " with " + encoder.getClass().getName(),
+                            e, JsonRPC.INTERNAL_ERROR);
+                }
+                return encoded;
+            }
+        }
+        return encoderNotFound(obj);
+    }
+
+    protected ENCODED encoderNotFound(Object obj) {
+        throw new McpException("No encoder found for " + obj.getClass(), JsonRPC.INTERNAL_ERROR);
+    }
+
+    @SuppressWarnings("unchecked")
+    static <T> T cast(Object obj) {
+        return (T) obj;
+    }
+
+}

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/FeatureManager.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/FeatureManager.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.function.Function;
 
 import jakarta.enterprise.invoke.Invoker;
 
@@ -54,12 +55,19 @@ public abstract class FeatureManager<R> {
             @Override
             public Uni<R> call() throws Exception {
                 try {
-                    return metadata.resultMapper().apply(invoker.invoke(null, arguments));
+                    Function<Object, Uni<R>> resultMapper = metadata.resultMapper();
+                    Object ret = invoker.invoke(null, arguments);
+                    ret = wrapResult(ret, metadata, argProviders);
+                    return resultMapper.apply(ret);
                 } catch (Throwable e) {
                     return Uni.createFrom().failure(e);
                 }
             }
         });
+    }
+
+    protected Object wrapResult(Object ret, FeatureMetadata<R> metadata, ArgumentProviders argProviders) {
+        return ret;
     }
 
     public abstract List<FeatureMetadata<R>> list();

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/JsonTextContentEncoder.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/JsonTextContentEncoder.java
@@ -1,0 +1,35 @@
+package io.quarkiverse.mcp.server.runtime;
+
+import jakarta.annotation.Priority;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.quarkiverse.mcp.server.Content;
+import io.quarkiverse.mcp.server.ContentEncoder;
+import io.quarkiverse.mcp.server.TextContent;
+
+@Singleton
+@Priority(0)
+public class JsonTextContentEncoder implements ContentEncoder<Object> {
+
+    @Inject
+    ObjectMapper mapper;
+
+    @Override
+    public boolean supports(Class<?> runtimeType) {
+        return true;
+    }
+
+    @Override
+    public Content encode(Object value) {
+        try {
+            return new TextContent(mapper.writeValueAsString(value));
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+}

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/JsonTextResourceContentsEncoder.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/JsonTextResourceContentsEncoder.java
@@ -1,0 +1,35 @@
+package io.quarkiverse.mcp.server.runtime;
+
+import jakarta.annotation.Priority;
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.quarkiverse.mcp.server.ResourceContents;
+import io.quarkiverse.mcp.server.ResourceContentsEncoder;
+import io.quarkiverse.mcp.server.TextResourceContents;
+
+@Singleton
+@Priority(0)
+public class JsonTextResourceContentsEncoder implements ResourceContentsEncoder<Object> {
+
+    @Inject
+    ObjectMapper mapper;
+
+    @Override
+    public boolean supports(Class<?> runtimeType) {
+        return true;
+    }
+
+    @Override
+    public ResourceContents encode(ResourceContentsData<Object> data) {
+        try {
+            return TextResourceContents.create(data.uri().value(), mapper.writeValueAsString(data.data()));
+        } catch (JsonProcessingException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+}

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ListEncoderResultMapper.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ListEncoderResultMapper.java
@@ -1,0 +1,61 @@
+package io.quarkiverse.mcp.server.runtime;
+
+import java.util.List;
+
+import io.quarkiverse.mcp.server.Encoder;
+import io.smallrye.mutiny.Uni;
+
+/**
+ * Unlike {@link EncoderResultMapper} this mapper can also process {@code List<X>} and {@code Uni<List<X>>}.
+ *
+ * @param <ENCODED> The type of the value encoded by the encoder
+ * @param <ENCODER> The type of the injected encoder
+ * @param <RESPONSE> The type of the serialized response
+ */
+abstract class ListEncoderResultMapper<ENCODED, ENCODER extends Encoder<?, ENCODED>, RESPONSE>
+        extends EncoderResultMapper<ENCODED, Encoder<?, ENCODED>, RESPONSE> {
+
+    final EncoderMapper<List<Object>, RESPONSE> list;
+    final EncoderMapper<Uni<List<Object>>, RESPONSE> uniList;
+
+    protected ListEncoderResultMapper() {
+        this.list = new EncoderMapper<List<Object>, RESPONSE>() {
+
+            @Override
+            public Uni<RESPONSE> apply(List<Object> list) {
+                return Uni.createFrom()
+                        .item(toResponse(list.stream().map(ListEncoderResultMapper.this::convert).toList()));
+            }
+        };
+        this.uniList = new EncoderMapper<Uni<List<Object>>, RESPONSE>() {
+
+            @Override
+            public Uni<RESPONSE> apply(Uni<List<Object>> uni) {
+                return uni.map(
+                        list -> toResponse(list.stream().map(ListEncoderResultMapper.this::convert).toList()));
+            }
+        };
+    }
+
+    public EncoderMapper<List<Object>, RESPONSE> list() {
+        if (list == null) {
+            throw new UnsupportedOperationException();
+        }
+        return list;
+    }
+
+    public EncoderMapper<Uni<List<Object>>, RESPONSE> uniList() {
+        if (uniList == null) {
+            throw new UnsupportedOperationException();
+        }
+        return uniList;
+    }
+
+    @Override
+    protected RESPONSE toResponse(ENCODED encoded) {
+        return toResponse(List.of(encoded));
+    }
+
+    protected abstract RESPONSE toResponse(List<ENCODED> encoded);
+
+}

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpException.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpException.java
@@ -1,6 +1,6 @@
 package io.quarkiverse.mcp.server.runtime;
 
-class McpException extends Exception {
+class McpException extends RuntimeException {
 
     private static final long serialVersionUID = 3142589829095593984L;
 

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/PromptEncoderResultMapper.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/PromptEncoderResultMapper.java
@@ -1,0 +1,16 @@
+package io.quarkiverse.mcp.server.runtime;
+
+import jakarta.inject.Singleton;
+
+import io.quarkiverse.mcp.server.PromptResponse;
+import io.quarkiverse.mcp.server.PromptResponseEncoder;
+
+@Singleton
+public class PromptEncoderResultMapper extends EncoderResultMapper<PromptResponse, PromptResponseEncoder<?>, PromptResponse> {
+
+    @Override
+    protected PromptResponse toResponse(PromptResponse encoded) {
+        return encoded;
+    }
+
+}

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceContentsEncoderResultMapper.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceContentsEncoderResultMapper.java
@@ -1,0 +1,20 @@
+package io.quarkiverse.mcp.server.runtime;
+
+import java.util.List;
+
+import jakarta.inject.Singleton;
+
+import io.quarkiverse.mcp.server.ResourceContents;
+import io.quarkiverse.mcp.server.ResourceContentsEncoder;
+import io.quarkiverse.mcp.server.ResourceResponse;
+
+@Singleton
+public class ResourceContentsEncoderResultMapper
+        extends ListEncoderResultMapper<ResourceContents, ResourceContentsEncoder<?>, ResourceResponse> {
+
+    @Override
+    protected ResourceResponse toResponse(List<ResourceContents> contents) {
+        return new ResourceResponse(contents);
+    }
+
+}

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResultMappers.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResultMappers.java
@@ -15,70 +15,248 @@ import io.smallrye.mutiny.Uni;
 
 public class ResultMappers {
 
-    public static final Function<PromptMessage, Uni<PromptResponse>> PROMPT_MESSAGE = message -> Uni.createFrom()
-            .item(new PromptResponse(null, List.of(message)));
+    public static class PromptOfMessage implements Function<PromptMessage, Uni<PromptResponse>> {
 
-    public static final Function<List<PromptMessage>, Uni<PromptResponse>> PROMPT_LIST_MESSAGE = messages -> Uni.createFrom()
-            .item(PromptResponse.withMessages(messages));
+        public static final PromptOfMessage INSTANCE = new PromptOfMessage();
 
-    public static final Function<Uni<PromptMessage>, Uni<PromptResponse>> PROMPT_UNI_MESSAGE = uni -> {
-        return uni.map(m -> new PromptResponse(null, List.of(m)));
-    };
+        @Override
+        public Uni<PromptResponse> apply(PromptMessage message) {
+            return Uni.createFrom()
+                    .item(new PromptResponse(null, List.of(message)));
+        }
 
-    public static final Function<Uni<List<PromptMessage>>, Uni<PromptResponse>> PROMPT_UNI_LIST_MESSAGE = uni -> uni
-            .map(messages -> PromptResponse.withMessages(messages));
+    }
 
-    @SuppressWarnings("unchecked")
-    public static final Function<Object, Uni<Object>> IDENTITY = o -> (Uni<Object>) o;
+    public static class PromptListOfMessage implements Function<List<PromptMessage>, Uni<PromptResponse>> {
 
-    public static final Function<Object, Uni<Object>> TO_UNI = o -> Uni.createFrom().item(o);
+        public static final PromptListOfMessage INSTANCE = new PromptListOfMessage();
 
-    public static final Function<Content, Uni<Object>> TOOL_CONTENT = content -> Uni.createFrom()
-            .item(ToolResponse.success(content));
+        @Override
+        public Uni<PromptResponse> apply(List<PromptMessage> list) {
+            return Uni.createFrom().item(PromptResponse.withMessages(list));
+        }
 
-    public static final Function<String, Uni<ToolResponse>> TOOL_STRING = str -> Uni.createFrom()
-            .item(ToolResponse.success(new TextContent(str)));
+    }
 
-    public static final Function<List<Content>, Uni<ToolResponse>> TOOL_LIST_CONTENT = list -> Uni.createFrom()
-            .item(ToolResponse.success(list));
+    public static class PromptUniOfMessage implements Function<Uni<PromptMessage>, Uni<PromptResponse>> {
 
-    public static final Function<List<String>, Uni<ToolResponse>> TOOL_LIST_STRING = list -> Uni.createFrom()
-            .item(ToolResponse.success(list.stream().map(TextContent::new).toList()));
+        public static final PromptUniOfMessage INSTANCE = new PromptUniOfMessage();
 
-    public static final Function<Uni<Content>, Uni<ToolResponse>> TOOL_UNI_CONTENT = uni -> uni
-            .map(c -> ToolResponse.success(c));
+        @Override
+        public Uni<PromptResponse> apply(Uni<PromptMessage> uni) {
+            return uni.map(m -> new PromptResponse(null, List.of(m)));
+        }
 
-    public static final Function<Uni<String>, Uni<ToolResponse>> TOOL_UNI_STRING = uni -> uni
-            .map(str -> ToolResponse.success(new TextContent(str)));
+    }
 
-    public static final Function<Uni<List<Content>>, Uni<ToolResponse>> TOOL_UNI_LIST_CONTENT = uni -> uni
-            .map(l -> ToolResponse.success(l));
+    public static class PromptUniListOfMessage implements Function<Uni<List<PromptMessage>>, Uni<PromptResponse>> {
 
-    public static final Function<Uni<List<String>>, Uni<ToolResponse>> TOOL_UNI_LIST_STRING = uni -> uni
-            .map(l -> ToolResponse.success(l.stream().map(TextContent::new).toList()));
+        public static final PromptUniListOfMessage INSTANCE = new PromptUniListOfMessage();
 
-    public static final Function<ResourceContents, Uni<ResourceResponse>> RESOURCE_CONTENT = content -> Uni.createFrom()
-            .item(new ResourceResponse(List.of(content)));
+        @Override
+        public Uni<PromptResponse> apply(Uni<List<PromptMessage>> uni) {
+            return uni.map(messages -> PromptResponse.withMessages(messages));
+        }
 
-    public static final Function<List<ResourceContents>, Uni<ResourceResponse>> RESOURCE_LIST_CONTENT = list -> Uni.createFrom()
-            .item(new ResourceResponse(list));
+    }
 
-    public static final Function<Uni<ResourceContents>, Uni<ResourceResponse>> RESOURCE_UNI_CONTENT = uni -> uni
-            .map(c -> new ResourceResponse(List.of(c)));
+    public static class Identity implements Function<Object, Uni<Object>> {
 
-    public static final Function<Uni<List<ResourceContents>>, Uni<ResourceResponse>> RESOURCE_UNI_LIST_CONTENT = uni -> uni
-            .map(l -> new ResourceResponse(l));
+        public static final Identity INSTANCE = new Identity();
 
-    public static final Function<String, Uni<CompletionResponse>> COMPLETE_STRING = str -> Uni.createFrom()
-            .item(new CompletionResponse(List.of(str), null, null));
+        @SuppressWarnings("unchecked")
+        @Override
+        public Uni<Object> apply(Object o) {
+            return (Uni<Object>) o;
+        }
 
-    public static final Function<List<String>, Uni<CompletionResponse>> COMPLETE_LIST_STRING = list -> Uni.createFrom()
-            .item(new CompletionResponse(list, null, null));
+    }
 
-    public static final Function<Uni<String>, Uni<CompletionResponse>> COMPLETE_UNI_STRING = uni -> uni
-            .map(str -> new CompletionResponse(List.of(str), null, null));
+    public static class ToUni implements Function<Object, Uni<Object>> {
 
-    public static final Function<Uni<List<String>>, Uni<CompletionResponse>> COMPLETE_UNI_LIST_STRING = uni -> uni
-            .map(list -> new CompletionResponse(list, null, null));
+        public static final ToUni INSTANCE = new ToUni();
+
+        @Override
+        public Uni<Object> apply(Object o) {
+            return Uni.createFrom().item(o);
+        }
+
+    }
+
+    public static class ToolContent implements Function<Content, Uni<ToolResponse>> {
+
+        public static final ToolContent INSTANCE = new ToolContent();
+
+        @Override
+        public Uni<ToolResponse> apply(Content content) {
+            return Uni.createFrom().item(ToolResponse.success(content));
+        }
+
+    }
+
+    public static class ToolString implements Function<String, Uni<ToolResponse>> {
+
+        public static final ToolString INSTANCE = new ToolString();
+
+        @Override
+        public Uni<ToolResponse> apply(String str) {
+            return Uni.createFrom().item(ToolResponse.success(new TextContent(str)));
+        }
+
+    }
+
+    public static class ToolListContent implements Function<List<Content>, Uni<ToolResponse>> {
+
+        public static final ToolListContent INSTANCE = new ToolListContent();
+
+        @Override
+        public Uni<ToolResponse> apply(List<Content> list) {
+            return Uni.createFrom().item(ToolResponse.success(list));
+        }
+
+    }
+
+    public static class ToolListString implements Function<List<String>, Uni<ToolResponse>> {
+
+        public static final ToolListString INSTANCE = new ToolListString();
+
+        @Override
+        public Uni<ToolResponse> apply(List<String> list) {
+            return Uni.createFrom().item(ToolResponse.success(list.stream().map(TextContent::new).toList()));
+        }
+
+    }
+
+    public static class ToolUniContent implements Function<Uni<Content>, Uni<ToolResponse>> {
+
+        public static final ToolUniContent INSTANCE = new ToolUniContent();
+
+        @Override
+        public Uni<ToolResponse> apply(Uni<Content> uni) {
+            return uni.map(c -> ToolResponse.success(c));
+        }
+
+    }
+
+    public static class ToolUniString implements Function<Uni<String>, Uni<ToolResponse>> {
+
+        public static final ToolUniString INSTANCE = new ToolUniString();
+
+        @Override
+        public Uni<ToolResponse> apply(Uni<String> uni) {
+            return uni.map(str -> ToolResponse.success(new TextContent(str)));
+        }
+
+    }
+
+    public static class ToolUniListContent implements Function<Uni<List<Content>>, Uni<ToolResponse>> {
+
+        public static final ToolUniListContent INSTANCE = new ToolUniListContent();
+
+        @Override
+        public Uni<ToolResponse> apply(Uni<List<Content>> uni) {
+            return uni.map(l -> ToolResponse.success(l));
+        }
+
+    }
+
+    public static class ToolUniListString implements Function<Uni<List<String>>, Uni<ToolResponse>> {
+
+        public static final ToolUniListString INSTANCE = new ToolUniListString();
+
+        @Override
+        public Uni<ToolResponse> apply(Uni<List<String>> uni) {
+            return uni.map(l -> ToolResponse.success(l.stream().map(TextContent::new).toList()));
+        }
+
+    }
+
+    public static class ResourceContent implements Function<ResourceContents, Uni<ResourceResponse>> {
+
+        public static final ResourceContent INSTANCE = new ResourceContent();
+
+        @Override
+        public Uni<ResourceResponse> apply(ResourceContents contents) {
+            return Uni.createFrom().item(new ResourceResponse(List.of(contents)));
+        }
+
+    }
+
+    public static class ResourceListContent implements Function<List<ResourceContents>, Uni<ResourceResponse>> {
+
+        public static final ResourceListContent INSTANCE = new ResourceListContent();
+
+        @Override
+        public Uni<ResourceResponse> apply(List<ResourceContents> list) {
+            return Uni.createFrom().item(new ResourceResponse(list));
+        }
+
+    }
+
+    public static class ResourceUniContent implements Function<Uni<ResourceContents>, Uni<ResourceResponse>> {
+
+        public static final ResourceUniContent INSTANCE = new ResourceUniContent();
+
+        @Override
+        public Uni<ResourceResponse> apply(Uni<ResourceContents> uni) {
+            return uni.map(c -> new ResourceResponse(List.of(c)));
+        }
+
+    }
+
+    public static class ResourceUniListContent implements Function<Uni<List<ResourceContents>>, Uni<ResourceResponse>> {
+
+        public static final ResourceUniListContent INSTANCE = new ResourceUniListContent();
+
+        @Override
+        public Uni<ResourceResponse> apply(Uni<List<ResourceContents>> uni) {
+            return uni.map(l -> new ResourceResponse(l));
+        }
+
+    }
+
+    public static class CompleteString implements Function<String, Uni<CompletionResponse>> {
+
+        public static final CompleteString INSTANCE = new CompleteString();
+
+        @Override
+        public Uni<CompletionResponse> apply(String str) {
+            return Uni.createFrom().item(new CompletionResponse(List.of(str), null, null));
+        }
+
+    }
+
+    public static class CompleteListString implements Function<List<String>, Uni<CompletionResponse>> {
+
+        public static final CompleteListString INSTANCE = new CompleteListString();
+
+        @Override
+        public Uni<CompletionResponse> apply(List<String> list) {
+            return Uni.createFrom().item(new CompletionResponse(list, null, null));
+        }
+
+    }
+
+    public static class CompleteUniString implements Function<Uni<String>, Uni<CompletionResponse>> {
+
+        public static final CompleteUniString INSTANCE = new CompleteUniString();
+
+        @Override
+        public Uni<CompletionResponse> apply(Uni<String> uni) {
+            return uni.map(str -> new CompletionResponse(List.of(str), null, null));
+        }
+
+    }
+
+    public static class CompleteUniListString implements Function<Uni<List<String>>, Uni<CompletionResponse>> {
+
+        public static final CompleteUniListString INSTANCE = new CompleteUniListString();
+
+        @Override
+        public Uni<CompletionResponse> apply(Uni<List<String>> uni) {
+            return uni.map(list -> new CompletionResponse(list, null, null));
+        }
+
+    }
 
 }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ToolEncoderResultMapper.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ToolEncoderResultMapper.java
@@ -1,0 +1,70 @@
+package io.quarkiverse.mcp.server.runtime;
+
+import java.util.List;
+
+import jakarta.inject.Singleton;
+
+import io.quarkiverse.mcp.server.Content;
+import io.quarkiverse.mcp.server.ContentEncoder;
+import io.quarkiverse.mcp.server.ToolResponse;
+import io.quarkiverse.mcp.server.ToolResponseEncoder;
+import io.quarkus.arc.All;
+import io.smallrye.mutiny.Uni;
+
+@Singleton
+public class ToolEncoderResultMapper extends ListEncoderResultMapper<Content, ContentEncoder<?>, ToolResponse> {
+
+    @All
+    List<ToolResponseEncoder<?>> toolResponseEncoders;
+
+    final EncoderMapper<Uni<Object>, ToolResponse> uni;
+
+    private ToolEncoderResultMapper() {
+        this.uni = new EncoderMapper<Uni<Object>, ToolResponse>() {
+
+            @Override
+            public Uni<ToolResponse> apply(Uni<Object> uni) {
+                return uni.chain(o -> ToolEncoderResultMapper.this.apply(o));
+            }
+        };
+    }
+
+    @Override
+    public Uni<ToolResponse> apply(Object obj) {
+        Uni<ToolResponse> ret = null;
+        ToolResponse toolResponse = convertToolResponse(obj);
+        if (toolResponse != null) {
+            ret = Uni.createFrom().item(toolResponse);
+        } else {
+            ret = super.apply(obj);
+        }
+        return ret;
+    }
+
+    @Override
+    public EncoderMapper<Uni<Object>, ToolResponse> uni() {
+        return uni;
+    }
+
+    @Override
+    protected ToolResponse toResponse(List<Content> content) {
+        return ToolResponse.success(content);
+    }
+
+    private ToolResponse convertToolResponse(Object obj) {
+        Class<?> type = obj.getClass();
+        for (ToolResponseEncoder<?> encoder : toolResponseEncoders) {
+            if (encoder.supports(type)) {
+                ToolResponse encoded;
+                try {
+                    encoded = encoder.encode(cast(obj));
+                } catch (Exception e) {
+                    throw new McpException("Unable to encode object of type " + type + " with " + encoder.getClass().getName(),
+                            JsonRPC.INTERNAL_ERROR);
+                }
+                return encoded;
+            }
+        }
+        return null;
+    }
+}

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -57,7 +57,7 @@ The execution model is determined by the method signature and additional annotat
 * Methods annotated with `@NonBlocking` are considered non-blocking.
 * Methods declared in a class annotated with `@Transactional` are considered blocking unless annotated with `@NonBlocking`.
 * If the method does not declare any of the annotations listed above the execution model is derived from the return type:
-** Methods returning `Uni` and `Multi` are considered non-blocking.
+** Methods returning `Uni` are considered non-blocking.
 ** Methods returning any other type are considered blocking.
 * Kotlin `suspend` functions are always considered non-blocking and may not be annotated with `@Blocking`, `@NonBlocking`
  or `@RunOnVirtualThread` and may not be in a class annotated with `@RunOnVirtualThread`.
@@ -199,7 +199,10 @@ However, the annotated method can also return other types that are converted acc
 
 * If the method returns an implementation of `ResourceContents` then the reponse contains the single contents object.
 * If the method returns a `List` of `ResourceContents` implementations then the reponse contains the list of contents objects.
-* The method may return a `Uni` that wraps any of the type mentioned above.
+* If it returns any other type `X` or `List<X>` then `X` is encoded using the `ResourceContentsEncoder` API and afterwards the rules above apply.
+* It may also return a `Uni` that wraps any of the type mentioned above.
+
+TIP: There is a default resource contents encoder registered; it encodes the returned value as JSON.
 
 ==== Method parameters
 
@@ -245,7 +248,8 @@ However, the annotated method can also return other types that are converted acc
 
 * If the method returns an implementation of `ResourceContents` then the reponse contains the single contents object.
 * If the method returns a `List` of `ResourceContents` implementations then the reponse contains the list of contents objects.
-* The method may return a `Uni` that wraps any of the type mentioned above.
+* If it returns any other type `X` or `List<X>` then `X` is encoded using the `ResourceContentsEncoder` API and afterwards the rules above apply.
+* It may also return a `Uni` that wraps any of the type mentioned above.
 
 A `@ResourceTemplate` method must only accept `String` parameters that represent template variables.
 However, it may also accept the following parameters:
@@ -328,6 +332,8 @@ public class MyTools {
 <2> `MyTools` is an ordinary CDI bean. It can inject other beans, use interceptors, etc.
 <3> `@Tool` annotates a business method of a CDI bean that should be exposed as a tool. By default, the name of the tool is derived from the method name.
 
+TIP: If a method annotated with `@Tool` throws a `io.quarkiverse.mcp.server.ToolCallException` then the response "failure" and the message of the exception is used as the text of the result content.
+
 A result of a "tool call" operation is always represented as a `ToolResponse`.
 However, the annotated method can also return other types that are converted according to the following rules.
 
@@ -336,7 +342,13 @@ However, the annotated method can also return other types that are converted acc
 * If the method returns a `List` of `Content` implementations or `String`s then the reponse is "success" and contains the list of relevant content objects.
 * The method may return a `Uni` that wraps any of the type mentioned above.
 
-TIP: If a method annotated with `@Tool` throws a `io.quarkiverse.mcp.server.ToolCallException` then the response "failure" and the message of the exception is used as the text of the result content.
+* If it returns `java.lang.String` then the reponse is "success" and contains a single `TextContent`.
+* If it returns an implementation of `Content` then the reponse is "success" and contains a single content object.
+* If it returns a `List` of `Content` implementations or strings then the reponse is "success" and contains a list of relevant content objects.
+* If it returns any other type `X` or `List<X>` then `X` is encoded using the `ToolResponseEncoder` and `ContentEncoder` API and afterwards the rules above apply.
+* It may also return a `Uni` that wraps any of the type mentioned above.
+
+TIP: There is a default content encoder registered; it encodes the returned value as JSON.
 
 ==== Method parameters
 

--- a/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/prompts/PromptCustomResponseEncoderTest.java
+++ b/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/prompts/PromptCustomResponseEncoderTest.java
@@ -1,0 +1,82 @@
+package io.quarkiverse.mcp.server.test.prompts;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.net.URISyntaxException;
+import java.util.List;
+
+import jakarta.annotation.Priority;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.Prompt;
+import io.quarkiverse.mcp.server.PromptMessage;
+import io.quarkiverse.mcp.server.PromptResponse;
+import io.quarkiverse.mcp.server.PromptResponseEncoder;
+import io.quarkiverse.mcp.server.TextContent;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+public class PromptCustomResponseEncoderTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .withApplicationRoot(
+                    root -> root.addClasses(MyPrompts.class, MyObject.class, MyObjectEncoder.class));
+
+    @Test
+    public void testEncoder() throws URISyntaxException {
+        initClient();
+        JsonObject message = newMessage("prompts/get")
+                .put("params", new JsonObject()
+                        .put("name", "bravo")
+                        .put("arguments", new JsonObject()
+                                .put("price", "10")));
+        send(message);
+        JsonObject response = waitForLastResponse();
+        JsonObject result = assertResponseMessage(message, response);
+        assertNotNull(result);
+        JsonArray messages = result.getJsonArray("messages");
+        assertEquals(1, messages.size());
+        JsonObject m = messages.getJsonObject(0);
+        assertEquals("user", m.getString("role"));
+        JsonObject content = m.getJsonObject("content");
+        assertEquals("text", content.getString("type"));
+        assertEquals("MyObject[name=foo, sum=20, valid=true]", content.getString("text"));
+    }
+
+    public record MyObject(String name, int sum, boolean valid) {
+
+    }
+
+    public static class MyPrompts {
+
+        @Prompt
+        MyObject bravo(String price) {
+            return new MyObject("foo", Integer.parseInt(price) * 2, true);
+        }
+
+    }
+
+    @Singleton
+    @Priority(1)
+    public static class MyObjectEncoder implements PromptResponseEncoder<MyObject> {
+
+        @Override
+        public boolean supports(Class<?> runtimeType) {
+            return MyObject.class.equals(runtimeType);
+        }
+
+        @Override
+        public PromptResponse encode(MyObject value) {
+            return new PromptResponse(null, List.of(PromptMessage.withUserRole(new TextContent(value.toString()))));
+        }
+
+    }
+
+}

--- a/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/resources/ResourceJsonTextContentEncoderTest.java
+++ b/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/resources/ResourceJsonTextContentEncoderTest.java
@@ -1,0 +1,80 @@
+package io.quarkiverse.mcp.server.test.resources;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.net.URISyntaxException;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.Resource;
+import io.quarkiverse.mcp.server.ResourceTemplate;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+public class ResourceJsonTextContentEncoderTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .withApplicationRoot(
+                    root -> root.addClasses(MyResources.class, MyObject.class));
+
+    @Test
+    public void testEncoder() throws URISyntaxException {
+        initClient();
+        assertResourceReadResponse("file:///bravo", 2);
+        assertResourceReadResponse("file:///1", 3);
+        assertResourceReadResponse("file:///list_bravo", 4);
+        assertResourceReadResponse("file:///uni_list_bravo", 5);
+    }
+
+    private void assertResourceReadResponse(String uri, int expectedSum) {
+        JsonObject message = newMessage("resources/read")
+                .put("params", new JsonObject()
+                        .put("uri", uri));
+        send(message);
+        JsonObject resourceResponse = waitForLastResponse();
+        JsonObject resourceResult = assertResponseMessage(message, resourceResponse);
+        assertNotNull(resourceResult);
+        JsonArray contents = resourceResult.getJsonArray("contents");
+        assertEquals(1, contents.size());
+        JsonObject textContent = contents.getJsonObject(0);
+        assertEquals(uri, textContent.getString("uri"));
+        // Note that quotation marks in the original message must be escaped
+        assertEquals("{\"name\":\"foo\",\"sum\":" + expectedSum + ",\"valid\":true}", textContent.getString("text"));
+    }
+
+    public record MyObject(String name, int sum, boolean valid) {
+
+    }
+
+    public static class MyResources {
+
+        @Resource(uri = "file:///bravo")
+        MyObject bravo() {
+            return new MyObject("foo", 2, true);
+        }
+
+        @ResourceTemplate(uriTemplate = "file:///{price}")
+        Uni<MyObject> uni_bravo(String price) {
+            return Uni.createFrom().item(new MyObject("foo", Integer.parseInt(price) * 3, true));
+        }
+
+        @Resource(uri = "file:///list_bravo")
+        List<MyObject> list_bravo() {
+            return List.of(new MyObject("foo", 4, true));
+        }
+
+        @Resource(uri = "file:///uni_list_bravo")
+        Uni<List<MyObject>> uni_list_bravo() {
+            return Uni.createFrom().item(List.of(new MyObject("foo", 5, true)));
+        }
+
+    }
+
+}

--- a/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/ToolCustomContentEncoderTest.java
+++ b/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/ToolCustomContentEncoderTest.java
@@ -1,0 +1,80 @@
+package io.quarkiverse.mcp.server.test.tools;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.net.URISyntaxException;
+
+import jakarta.annotation.Priority;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.Content;
+import io.quarkiverse.mcp.server.ContentEncoder;
+import io.quarkiverse.mcp.server.TextContent;
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+public class ToolCustomContentEncoderTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .withApplicationRoot(
+                    root -> root.addClasses(MyTools.class, MyObject.class, MyObjectEncoder.class));
+
+    @Test
+    public void testError() throws URISyntaxException {
+        initClient();
+        JsonObject message = newMessage("tools/call")
+                .put("params", new JsonObject()
+                        .put("name", "bravo")
+                        .put("arguments", new JsonObject()
+                                .put("price", 10)));
+        send(message);
+        JsonObject toolCallResponse = waitForLastResponse();
+        JsonObject toolCallResult = assertResponseMessage(message, toolCallResponse);
+        assertNotNull(toolCallResult);
+        assertFalse(toolCallResult.getBoolean("isError"));
+        JsonArray content = toolCallResult.getJsonArray("content");
+        assertEquals(1, content.size());
+        JsonObject textContent = content.getJsonObject(0);
+        assertEquals("text", textContent.getString("type"));
+        assertEquals("MyObject[name=foo, sum=20, valid=true]", textContent.getString("text"));
+    }
+
+    public record MyObject(String name, int sum, boolean valid) {
+
+    }
+
+    public static class MyTools {
+
+        @Tool
+        MyObject bravo(int price) {
+            return new MyObject("foo", price * 2, true);
+        }
+
+    }
+
+    @Singleton
+    @Priority(1)
+    public static class MyObjectEncoder implements ContentEncoder<MyObject> {
+
+        @Override
+        public boolean supports(Class<?> runtimeType) {
+            return MyObject.class.equals(runtimeType);
+        }
+
+        @Override
+        public Content encode(MyObject value) {
+            return new TextContent(value.toString());
+        }
+
+    }
+
+}

--- a/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/ToolCustomResponseEncoderTest.java
+++ b/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/ToolCustomResponseEncoderTest.java
@@ -1,0 +1,81 @@
+package io.quarkiverse.mcp.server.test.tools;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URISyntaxException;
+import java.util.List;
+
+import jakarta.annotation.Priority;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.TextContent;
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolResponse;
+import io.quarkiverse.mcp.server.ToolResponseEncoder;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+public class ToolCustomResponseEncoderTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .withApplicationRoot(
+                    root -> root.addClasses(MyTools.class, MyObject.class, MyObjectEncoder.class));
+
+    @Test
+    public void testEncoder() throws URISyntaxException {
+        initClient();
+        JsonObject message = newMessage("tools/call")
+                .put("params", new JsonObject()
+                        .put("name", "bravo")
+                        .put("arguments", new JsonObject()
+                                .put("price", 10)));
+        send(message);
+        JsonObject toolCallResponse = waitForLastResponse();
+        JsonObject toolCallResult = assertResponseMessage(message, toolCallResponse);
+        assertNotNull(toolCallResult);
+        assertTrue(toolCallResult.getBoolean("isError"));
+        JsonArray content = toolCallResult.getJsonArray("content");
+        assertEquals(1, content.size());
+        JsonObject textContent = content.getJsonObject(0);
+        assertEquals("text", textContent.getString("type"));
+        assertEquals("MyObject[name=foo, sum=20, valid=true]", textContent.getString("text"));
+    }
+
+    public record MyObject(String name, int sum, boolean valid) {
+
+    }
+
+    public static class MyTools {
+
+        @Tool
+        MyObject bravo(int price) {
+            return new MyObject("foo", price * 2, true);
+        }
+
+    }
+
+    @Singleton
+    @Priority(1)
+    public static class MyObjectEncoder implements ToolResponseEncoder<MyObject> {
+
+        @Override
+        public boolean supports(Class<?> runtimeType) {
+            return MyObject.class.equals(runtimeType);
+        }
+
+        @Override
+        public ToolResponse encode(MyObject value) {
+            return new ToolResponse(true, List.of(new TextContent(value.toString())));
+        }
+
+    }
+
+}

--- a/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/ToolJsonTextContentEncoderTest.java
+++ b/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/ToolJsonTextContentEncoderTest.java
@@ -1,0 +1,83 @@
+package io.quarkiverse.mcp.server.test.tools;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.net.URISyntaxException;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+public class ToolJsonTextContentEncoderTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .withApplicationRoot(
+                    root -> root.addClasses(MyTools.class, MyObject.class));
+
+    @Test
+    public void testEncoder() throws URISyntaxException {
+        initClient();
+        assertToolCallResponse("bravo", 2);
+        assertToolCallResponse("uni_bravo", 3);
+        assertToolCallResponse("list_bravo", 4);
+        assertToolCallResponse("uni_list_bravo", 5);
+    }
+
+    private void assertToolCallResponse(String name, int expectedSum) {
+        JsonObject message = newMessage("tools/call")
+                .put("params", new JsonObject()
+                        .put("name", name)
+                        .put("arguments", new JsonObject()
+                                .put("price", 1)));
+        send(message);
+        JsonObject toolCallResponse = waitForLastResponse();
+        JsonObject toolCallResult = assertResponseMessage(message, toolCallResponse);
+        assertNotNull(toolCallResult);
+        assertFalse(toolCallResult.getBoolean("isError"));
+        JsonArray content = toolCallResult.getJsonArray("content");
+        assertEquals(1, content.size());
+        JsonObject textContent = content.getJsonObject(0);
+        assertEquals("text", textContent.getString("type"));
+        // Note that quotation marks in the original message must be escaped
+        assertEquals("{\"name\":\"foo\",\"sum\":" + expectedSum + ",\"valid\":true}", textContent.getString("text"));
+    }
+
+    public record MyObject(String name, int sum, boolean valid) {
+
+    }
+
+    public static class MyTools {
+
+        @Tool
+        MyObject bravo(int price) {
+            return new MyObject("foo", price * 2, true);
+        }
+
+        @Tool
+        Uni<MyObject> uni_bravo(int price) {
+            return Uni.createFrom().item(new MyObject("foo", price * 3, true));
+        }
+
+        @Tool
+        List<MyObject> list_bravo(int price) {
+            return List.of(new MyObject("foo", price * 4, true));
+        }
+
+        @Tool
+        Uni<List<MyObject>> uni_list_bravo(int price) {
+            return Uni.createFrom().item(List.of(new MyObject("foo", price * 5, true)));
+        }
+
+    }
+
+}


### PR DESCRIPTION
- resolves #85

We introduce several encoders that can be used to encode any return value to a relevant response type. 

Specifically, there is `ToolResponseEncoder` that could be used to encode any return value to a `ToolResponse`; `ContentEncoder` to encode any return value to `Content`; `ResourceContentsEncoder` to `ResourceContents` and `PromptResponseEncoder` to `PromptResponse`. 

We also register `JsonTextContentEncoder` and `JsonTextResourceContentsEncoder` by default. As a result, any "custom" return value returned from a `@Tool` method is encoded as `TextContent` containing the value encoded as JSON (using Jackson), and any "custom" return value returned from a `@Resource` method is encoded as `TextResourceContents` containing the value encoded as JSON (using Jackson).