### PR TITLE
stdio: make it possible to disable the transport completely

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-mcp-server-stdio.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-mcp-server-stdio.adoc
@@ -7,6 +7,27 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
+a| [[quarkus-mcp-server-stdio_quarkus-mcp-server-stdio-enabled]] [.property-path]##link:#quarkus-mcp-server-stdio_quarkus-mcp-server-stdio-enabled[`quarkus.mcp.server.stdio.enabled`]##
+
+[.description]
+--
+If set to `false` then the stdio transport is completely disabled, i.e. the application does not read/write messages
+from/to the standard input/output.
+
+Keep in mind that console logging is still automatically redirected to the standard error. You will need to set the
+`quarkus.log.console.stderr` to `false` to suppress this behavior.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_STDIO_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_STDIO_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
 a| [[quarkus-mcp-server-stdio_quarkus-mcp-server-stdio-null-system-out]] [.property-path]##link:#quarkus-mcp-server-stdio_quarkus-mcp-server-stdio-null-system-out[`quarkus.mcp.server.stdio.null-system-out`]##
 
 [.description]

--- a/docs/modules/ROOT/pages/includes/quarkus-mcp-server-stdio_quarkus.mcp.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-mcp-server-stdio_quarkus.mcp.adoc
@@ -7,6 +7,27 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
+a| [[quarkus-mcp-server-stdio_quarkus-mcp-server-stdio-enabled]] [.property-path]##link:#quarkus-mcp-server-stdio_quarkus-mcp-server-stdio-enabled[`quarkus.mcp.server.stdio.enabled`]##
+
+[.description]
+--
+If set to `false` then the stdio transport is completely disabled, i.e. the application does not read/write messages
+from/to the standard input/output.
+
+Keep in mind that console logging is still automatically redirected to the standard error. You will need to set the
+`quarkus.log.console.stderr` to `false` to suppress this behavior.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_STDIO_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_STDIO_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
 a| [[quarkus-mcp-server-stdio_quarkus-mcp-server-stdio-null-system-out]] [.property-path]##link:#quarkus-mcp-server-stdio_quarkus-mcp-server-stdio-null-system-out[`quarkus.mcp.server.stdio.null-system-out`]##
 
 [.description]

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -12,7 +12,7 @@ MCP currently defines two standard transports for client-server communication.
 This extension supports both transports and defines a unified declarative API.
 In other words, the server features are defined with the same API but the selected transport determines the way the MCP server communicates with clients. 
 
-If you want to use the https://spec.modelcontextprotocol.io/specification/basic/transports/#stdio[stdio] transport you'll need to add the `io.quarkiverse.mcp:quarkus-mcp-server-stdio` extension to your build file first.
+If you want to use the https://spec.modelcontextprotocol.io/specification/2024-11-05/basic/transports/#stdio[stdio] transport you'll need to add the `io.quarkiverse.mcp:quarkus-mcp-server-stdio` extension to your build file first.
 For instance, with Maven, add the following dependency to your POM file:
 
 [source,xml,subs=attributes+]
@@ -26,7 +26,7 @@ For instance, with Maven, add the following dependency to your POM file:
 
 IMPORTANT: If you use the `stdio` transport then your app should not write anything to the standard output. Quarkus console logging is automatically redirected to the standard error. And the standard output stream is set to "null" when the app is started by default. 
 
-If you want to use the https://modelcontextprotocol.io/docs/concepts/transports#server-sent-events-sse[HTTP/SSE] transport you'll need to add the `io.quarkiverse.mcp:quarkus-mcp-server-sse` extension to your build file first.
+If you want to use the https://spec.modelcontextprotocol.io/specification/2024-11-05/basic/transports/#http-with-sse[HTTP/SSE] transport you'll need to add the `io.quarkiverse.mcp:quarkus-mcp-server-sse` extension to your build file first.
 For instance, with Maven, add the following dependency to your POM file:
 
 [source,xml,subs=attributes+]

--- a/transports/stdio/runtime/src/main/java/io/quarkiverse/mcp/server/stdio/runtime/config/McpStdioRuntimeConfig.java
+++ b/transports/stdio/runtime/src/main/java/io/quarkiverse/mcp/server/stdio/runtime/config/McpStdioRuntimeConfig.java
@@ -10,6 +10,18 @@ import io.smallrye.config.WithDefault;
 public interface McpStdioRuntimeConfig {
 
     /**
+     * If set to `false` then the stdio transport is completely disabled, i.e. the application does not read/write messages
+     * from/to the standard input/output.
+     *
+     * Keep in mind that console logging is still automatically redirected to the standard error. You will need to set the
+     * `quarkus.log.console.stderr` to `false` to suppress this behavior.
+     *
+     * @asciidoclet
+     */
+    @WithDefault("true")
+    boolean enabled();
+
+    /**
      * If set to `true` then the standard output stream is set to "null" when the app is started.
      *
      * @asciidoclet


### PR DESCRIPTION
It's a draft for now - the missing part is disabling the `StdioConfigBuilderCustomizer` that sets `quarkus.log.console.stderr=true`.

CC @maxandersen 