### PR TITLE
Code adjustment - typos, method names, links

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/McpServerProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/McpServerProcessor.java
@@ -631,7 +631,7 @@ class McpServerProcessor {
         // where the RESPONSE is one of ToolResponse, PromptResponse, ResourceResponse, CompleteResponse
         // IMPL NOTE: at this point the method return type is already validated
         return switch (feature) {
-            case PROMPT -> propmpResultMapper(bytecode, returnType);
+            case PROMPT -> promptResultMapper(bytecode, returnType);
             case PROMPT_COMPLETE -> readResultMapper(bytecode,
                     createMapperClassSimpleName(PROMPT_COMPLETE, returnType, DotNames.COMPLETE_RESPONSE, c -> "String"));
             case TOOL -> toolResultMapper(bytecode, returnType);
@@ -687,7 +687,7 @@ class McpServerProcessor {
         }
     }
 
-    ResultHandle propmpResultMapper(BytecodeCreator bytecode, org.jboss.jandex.Type returnType) {
+    ResultHandle promptResultMapper(BytecodeCreator bytecode, org.jboss.jandex.Type returnType) {
         if (useEncoder(returnType, PROMPT_TYPES)) {
             return encoderResultMapper(bytecode, returnType, PromptEncoderResultMapper.class);
         } else {

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/CompletePrompt.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/CompletePrompt.java
@@ -15,8 +15,8 @@ import io.smallrye.mutiny.Uni;
  * The result of a "complete" operation is always represented as a {@link CompletionResponse}. However, the annotated method can
  * also return other types that are converted according to the following rules.
  * <ul>
- * <li>If the method returns {@link String} then the reponse contains the single value.</li>
- * <li>If the method returns a {@link List} of {@link String}s then the reponse contains the list of values.</li>
+ * <li>If the method returns {@link String} then the response contains the single value.</li>
+ * <li>If the method returns a {@link List} of {@link String}s then the response contains the list of values.</li>
  * <li>The method may return a {@link Uni} that wraps any of the type mentioned above.</li>
  * </ul>
  * In other words, the return type must be one of the following list:

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/CompleteResourceTemplate.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/CompleteResourceTemplate.java
@@ -15,8 +15,8 @@ import io.smallrye.mutiny.Uni;
  * The result of a "complete" operation is always represented as a {@link CompletionResponse}. However, the annotated method can
  * also return other types that are converted according to the following rules.
  * <ul>
- * <li>If the method returns {@link String} then the reponse contains the single value.</li>
- * <li>If the method returns a {@link List} of {@link String}s then the reponse contains the list of values.</li>
+ * <li>If the method returns {@link String} then the response contains the single value.</li>
+ * <li>If the method returns a {@link List} of {@link String}s then the response contains the list of values.</li>
  * <li>The method may return a {@link Uni} that wraps any of the type mentioned above.</li>
  * </ul>
  * In other words, the return type must be one of the following list:

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/McpLog.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/McpLog.java
@@ -46,7 +46,7 @@ public interface McpLog {
     void debug(String format, Object... params);
 
     /**
-     * Logs a message and and sends a {@link LogLevel#INFO} log message notification to the client.
+     * Logs a message and sends a {@link LogLevel#INFO} log message notification to the client.
      *
      * @param format
      * @param params

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/McpLog.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/McpLog.java
@@ -23,7 +23,6 @@ public interface McpLog {
      * Sends a log message notification to the client if the specified level is higher or equal to the current level.
      *
      * @param level
-     * @param logger
      * @param data
      */
     void send(LogLevel level, Object data);
@@ -32,8 +31,8 @@ public interface McpLog {
      * Sends a log message notification to the client if the specified level is higher or equal to the current level.
      *
      * @param level
-     * @param logger
-     * @param data
+     * @param format
+     * @param params
      */
     void send(LogLevel level, String format, Object... params);
 

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/Prompt.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/Prompt.java
@@ -16,9 +16,9 @@ import io.smallrye.mutiny.Uni;
  * also return other types that are converted according to the following rules.
  * <p>
  * <ul>
- * <li>If it returns a {@link PromptMessage} then the reponse has no description and contains the single
+ * <li>If it returns a {@link PromptMessage} then the response has no description and contains the single
  * message object.</li>
- * <li>If it returns a {@link List} of {@link PromptMessage}s then the reponse has no description and contains the
+ * <li>If it returns a {@link List} of {@link PromptMessage}s then the response has no description and contains the
  * list of messages.</li>
  * <li>If it returns any other type {@code X} then {@code X} is encoded using the {@link PromptResponseEncoder} API.</li>
  * <li>It may also return a {@link Uni} that wraps any of the type mentioned above.</li>

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/PromptResponseEncoder.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/PromptResponseEncoder.java
@@ -5,7 +5,7 @@ import jakarta.annotation.Priority;
 /**
  * Encodes an object as {@link PromptResponse}.
  * <p>
- * If a propmpt response encoder exists and matches a specific return type then it always takes precedence over matching
+ * If a prompt response encoder exists and matches a specific return type then it always takes precedence over matching
  * {@link ContentEncoder}.
  * <p>
  * Implementation classes must be CDI beans. Qualifiers are ignored. {@link jakarta.enterprise.context.Dependent} beans are

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/Resource.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/Resource.java
@@ -16,9 +16,9 @@ import io.smallrye.mutiny.Uni;
  * can also return other types that are converted according to the following rules.
  *
  * <ul>
- * <li>If it returns an implementation of {@link ResourceContents} then the reponse contains the single contents
+ * <li>If it returns an implementation of {@link ResourceContents} then the response contains the single contents
  * object.</li>
- * <li>If it returns a {@link List} of {@link ResourceContents} implementations then the reponse contains the list of
+ * <li>If it returns a {@link List} of {@link ResourceContents} implementations then the response contains the list of
  * contents objects.</li>
  * <li>If it returns any other type {@code X} or {@code List<X>} then {@code X} is encoded using the
  * {@link ResourceContentsEncoder} API and afterwards the rules above apply.</li>

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/ResourceTemplate.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/ResourceTemplate.java
@@ -16,9 +16,9 @@ import io.smallrye.mutiny.Uni;
  * can also return other types that are converted according to the following rules.
  *
  * <ul>
- * <li>If it returns an implementation of {@link ResourceContents} then the reponse contains the single contents
+ * <li>If it returns an implementation of {@link ResourceContents} then the response contains the single contents
  * object.</li>
- * <li>If it returns a {@link List} of {@link ResourceContents} implementations then the reponse contains the list of
+ * <li>If it returns a {@link List} of {@link ResourceContents} implementations then the response contains the list of
  * contents objects.</li>
  * <li>If it returns any other type {@code X} or {@code List<X>} then {@code X} is encoded using the
  * {@link ResourceContentsEncoder} API and afterwards the rules above apply.</li>

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/Tool.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/Tool.java
@@ -16,10 +16,10 @@ import io.smallrye.mutiny.Uni;
  * return other types that are converted according to the following rules.
  * <p>
  * <ul>
- * <li>If it returns {@link String} then the reponse is {@code success} and contains a single {@link TextContent}.</li>
- * <li>If it returns an implementation of {@link Content} then the reponse is {@code success} and contains a single
+ * <li>If it returns {@link String} then the response is {@code success} and contains a single {@link TextContent}.</li>
+ * <li>If it returns an implementation of {@link Content} then the response is {@code success} and contains a single
  * content object.</li>
- * <li>If it returns a {@link List} of {@link Content} implementations or strings then the reponse is
+ * <li>If it returns a {@link List} of {@link Content} implementations or strings then the response is
  * {@code success} and contains a list of relevant content objects.</li>
  * <li>If it returns any other type {@code X} or {@code List<X>} then {@code X} is encoded using the {@link ToolResponseEncoder}
  * and {@link ContentEncoder} API and afterwards the rules above apply.</li>

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpMessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpMessageHandler.java
@@ -188,7 +188,7 @@ public class McpMessageHandler {
     }
 
     private void ping(JsonObject message, Responder responder) {
-        // https://spec.modelcontextprotocol.io/specification/basic/utilities/ping/
+        // https://spec.modelcontextprotocol.io/specification/2024-11-05/basic/utilities/ping/
         Object id = message.getValue("id");
         LOG.debugf("Ping [id: %s]", id);
         responder.sendResult(id, new JsonObject());

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpMessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpMessageHandler.java
@@ -49,7 +49,7 @@ public class McpMessageHandler {
 
     public void handle(JsonObject message, McpConnection connection, Responder responder) {
         if (Messages.isResponse(message)) {
-            // Reponse from a client
+            // Response from a client
             // Currently we discard all responses, including pong responses
             LOG.debugf("Discard client response: %s", message);
         } else {

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResultMappers.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResultMappers.java
@@ -55,7 +55,7 @@ public class ResultMappers {
 
         @Override
         public Uni<PromptResponse> apply(Uni<List<PromptMessage>> uni) {
-            return uni.map(messages -> PromptResponse.withMessages(messages));
+            return uni.map(PromptResponse::withMessages);
         }
 
     }
@@ -133,7 +133,7 @@ public class ResultMappers {
 
         @Override
         public Uni<ToolResponse> apply(Uni<Content> uni) {
-            return uni.map(c -> ToolResponse.success(c));
+            return uni.map(ToolResponse::success);
         }
 
     }
@@ -155,7 +155,7 @@ public class ResultMappers {
 
         @Override
         public Uni<ToolResponse> apply(Uni<List<Content>> uni) {
-            return uni.map(l -> ToolResponse.success(l));
+            return uni.map(ToolResponse::success);
         }
 
     }
@@ -210,7 +210,7 @@ public class ResultMappers {
 
         @Override
         public Uni<ResourceResponse> apply(Uni<List<ResourceContents>> uni) {
-            return uni.map(l -> new ResourceResponse(l));
+            return uni.map(ResourceResponse::new);
         }
 
     }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/TrafficLogger.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/TrafficLogger.java
@@ -29,7 +29,7 @@ public class TrafficLogger {
         } else if (textPayloadLimit < 0 || encoded.length() <= textPayloadLimit) {
             return encoded;
         } else {
-            return encoded.substring(0, encoded.length()) + "...";
+            return encoded.substring(0, textPayloadLimit) + "...";
         }
     }
 

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/config/McpRuntimeConfig.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/config/McpRuntimeConfig.java
@@ -15,7 +15,7 @@ public interface McpRuntimeConfig {
 
     /**
      * The server info is included in the response to an `initialize` request as defined by the
-     * https://spec.modelcontextprotocol.io/specification/basic/lifecycle/#initialization[spec].
+     * https://spec.modelcontextprotocol.io/specification/2024-11-05/basic/lifecycle/#initialization[spec].
      *
      * @asciidoclet
      */
@@ -57,7 +57,7 @@ public interface McpRuntimeConfig {
 
         /**
          * The name of the server is included in the response to an `initialize` request as defined by the
-         * https://spec.modelcontextprotocol.io/specification/basic/lifecycle/#initialization[spec].
+         * https://spec.modelcontextprotocol.io/specification/2024-11-05/basic/lifecycle/#initialization[spec].
          * By default, the value of the `quarkus.application.name` config property is used.
          *
          * @asciidoclet
@@ -66,7 +66,7 @@ public interface McpRuntimeConfig {
 
         /**
          * The version of the server is included in the response to an `initialize` request as defined by the
-         * https://spec.modelcontextprotocol.io/specification/basic/lifecycle/#initialization[spec].
+         * https://spec.modelcontextprotocol.io/specification/2024-11-05/basic/lifecycle/#initialization[spec].
          * By default, the value of the `quarkus.application.version` config property is used.
          *
          * @asciidoclet

--- a/docs/modules/ROOT/pages/includes/quarkus-mcp-server-core.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-mcp-server-core.adoc
@@ -12,7 +12,7 @@ a| [[quarkus-mcp-server-core_quarkus-mcp-server-server-info-name]] [.property-pa
 [.description]
 --
 The name of the server is included in the response to an `initialize` request as defined by the
-https://spec.modelcontextprotocol.io/specification/basic/lifecycle/#initialization[spec].
+https://spec.modelcontextprotocol.io/specification/2024-11-05/basic/lifecycle/#initialization[spec].
 By default, the value of the `quarkus.application.name` config property is used.
 
 
@@ -31,7 +31,7 @@ a| [[quarkus-mcp-server-core_quarkus-mcp-server-server-info-version]] [.property
 [.description]
 --
 The version of the server is included in the response to an `initialize` request as defined by the
-https://spec.modelcontextprotocol.io/specification/basic/lifecycle/#initialization[spec].
+https://spec.modelcontextprotocol.io/specification/2024-11-05/basic/lifecycle/#initialization[spec].
 By default, the value of the `quarkus.application.version` config property is used.
 
 

--- a/docs/modules/ROOT/pages/includes/quarkus-mcp-server-core_quarkus.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-mcp-server-core_quarkus.adoc
@@ -12,7 +12,7 @@ a|icon:lock[title=Fixed at build time] [[quarkus-mcp-server-core_quarkus-server-
 [.description]
 --
 The name of the server is included in the response to an `initialize` request as defined by the
-https://spec.modelcontextprotocol.io/specification/basic/lifecycle/#initialization[spec].
+https://spec.modelcontextprotocol.io/specification/2024-11-05/basic/lifecycle/#initialization[spec].
 By default, the value of the `quarkus.application.name` config property is used.
 
 
@@ -31,7 +31,7 @@ a|icon:lock[title=Fixed at build time] [[quarkus-mcp-server-core_quarkus-server-
 [.description]
 --
 The version of the server is included in the response to an `initialize` request as defined by the
-https://spec.modelcontextprotocol.io/specification/basic/lifecycle/#initialization[spec].
+https://spec.modelcontextprotocol.io/specification/2024-11-05/basic/lifecycle/#initialization[spec].
 By default, the value of the `quarkus.application.version` config property is used.
 
 

--- a/docs/modules/ROOT/pages/includes/quarkus-mcp-server-core_quarkus.mcp.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-mcp-server-core_quarkus.mcp.adoc
@@ -12,7 +12,7 @@ a| [[quarkus-mcp-server-core_quarkus-mcp-server-server-info-name]] [.property-pa
 [.description]
 --
 The name of the server is included in the response to an `initialize` request as defined by the
-https://spec.modelcontextprotocol.io/specification/basic/lifecycle/#initialization[spec].
+https://spec.modelcontextprotocol.io/specification/2024-11-05/basic/lifecycle/#initialization[spec].
 By default, the value of the `quarkus.application.name` config property is used.
 
 
@@ -31,7 +31,7 @@ a| [[quarkus-mcp-server-core_quarkus-mcp-server-server-info-version]] [.property
 [.description]
 --
 The version of the server is included in the response to an `initialize` request as defined by the
-https://spec.modelcontextprotocol.io/specification/basic/lifecycle/#initialization[spec].
+https://spec.modelcontextprotocol.io/specification/2024-11-05/basic/lifecycle/#initialization[spec].
 By default, the value of the `quarkus.application.version` config property is used.
 
 

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -12,7 +12,7 @@ MCP currently defines two standard transports for client-server communication.
 This extension supports both transports and defines a unified declarative API.
 In other words, the server features are defined with the same API but the selected transport determines the way the MCP server communicates with clients. 
 
-If you want to use the https://spec.modelcontextprotocol.io/specification/basic/transports/#stdio[stdio] transport you'll need to add the `io.quarkiverse.mcp:quarkus-mcp-server-stdio` extension to your build file first.
+If you want to use the https://spec.modelcontextprotocol.io/specification/2024-11-05/basic/transports/#stdio[stdio] transport you'll need to add the `io.quarkiverse.mcp:quarkus-mcp-server-stdio` extension to your build file first.
 For instance, with Maven, add the following dependency to your POM file:
 
 [source,xml,subs=attributes+]
@@ -42,7 +42,7 @@ TIP: The SSE endpoint is exposed at `/{rootPath}/sse`. The `{rootPath}` is set t
 
 == Supported server features
 
-An https://spec.modelcontextprotocol.io/specification/server/[MCP server] provides some building blocks to enrich the context of language models in AI apps.
+An https://spec.modelcontextprotocol.io/specification/2024-11-05/server/[MCP server] provides some building blocks to enrich the context of language models in AI apps.
 In this extension, a _server feature_ (prompt, resource, tool) is represented by an _annotated business method_ of a CDI bean.
 The execution model and context handling follow the idiomatic approach used in fundamental Quarkus extensions (such as `quarkus-rest` and `quarkus-scheduler`).
 For example, when a server feature is executed the CDI request context is activated and a https://quarkus.io/guides/duplicated-context[Vert.x duplicated context] is created.
@@ -69,7 +69,7 @@ The execution model is determined by the method signature and additional annotat
 
 === Prompts
 
-MCP provides a https://spec.modelcontextprotocol.io/specification/server/prompts/[standardized way] for servers to expose prompt templates to clients.
+MCP provides a https://spec.modelcontextprotocol.io/specification/2024-11-05/server/prompts/[standardized way] for servers to expose prompt templates to clients.
 
 [source,java]
 ----
@@ -169,7 +169,7 @@ However, it may also accept the following parameters:
 
 === Resources
 
-MCP provides a https://spec.modelcontextprotocol.io/specification/server/resources/[standardized way] for servers to expose resources to clients.
+MCP provides a https://spec.modelcontextprotocol.io/specification/2024-11-05/server/resources/[standardized way] for servers to expose resources to clients.
 
 [source,java]
 ----
@@ -305,7 +305,7 @@ However, it may also accept the following parameters:
 
 === Tools
 
-MCP provides a https://spec.modelcontextprotocol.io/specification/server/tools/[standardized way] for servers to expose tools that can be invoked by clients.
+MCP provides a https://spec.modelcontextprotocol.io/specification/2024-11-05/server/tools/[standardized way] for servers to expose tools that can be invoked by clients.
 
 [source,java]
 ----

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -38,7 +38,7 @@ For instance, with Maven, add the following dependency to your POM file:
 </dependency>
 ----
 
-TIP: The SSE endpoint is exposed at `/{rootPath}/sse`. The `{rootPath}` is set to `mcp` by default but it can be changed with the `quarkus.mcp.server.sse.root-path` configuration property.
+TIP: The SSE endpoint is exposed at `/{rootPath}/sse`. The `{rootPath}` is set to `mcp` by default, but it can be changed with the `quarkus.mcp.server.sse.root-path` configuration property.
 
 == Supported server features
 
@@ -99,8 +99,8 @@ public class MyPrompts {
 The result of a "prompt get" operation is always represented as a `PromptResponse`.
 However, the annotated method can also return other types that are converted according to the following rules.
 
-* If the method returns a `PromptMessage` then the reponse has no description and contains the single message object.
-* If the method returns a `List` of ``PromptMessage``s then the reponse has no description and contains the list of messages.
+* If the method returns a `PromptMessage` then the response has no description and contains the single message object.
+* If the method returns a `List` of ``PromptMessage``s then the response has no description and contains the list of messages.
 * The method may return a `Uni` that wraps any of the type mentioned above.
 
 In other words, the return type must be one of the following list:
@@ -156,8 +156,8 @@ public class MyPrompts {
 The result of a "prompt complete" operation is always represented as a `CompleteResponse`.
 However, the annotated method can also return other types that are converted according to the following rules.
 
-* If the method returns `java.lang.String` then the reponse contains a single value.
-* If the method returns a `List` of `String`s then the reponse contains the list of values.
+* If the method returns `java.lang.String` then the response contains a single value.
+* If the method returns a `List` of `String`s then the response contains the list of values.
 * The method may return a `Uni` that wraps any of the type mentioned above.
 
 A `@CompletePrompt` method must only accept a single `String` parameter that represents a completed Prompt argument.
@@ -197,8 +197,8 @@ public class MyResources {
 The result of a "resource read" operation is always represented as a `ResourceResponse`.
 However, the annotated method can also return other types that are converted according to the following rules.
 
-* If the method returns an implementation of `ResourceContents` then the reponse contains the single contents object.
-* If the method returns a `List` of `ResourceContents` implementations then the reponse contains the list of contents objects.
+* If the method returns an implementation of `ResourceContents` then the response contains the single contents object.
+* If the method returns a `List` of `ResourceContents` implementations then the response contains the list of contents objects.
 * If it returns any other type `X` or `List<X>` then `X` is encoded using the `ResourceContentsEncoder` API and afterwards the rules above apply.
 * It may also return a `Uni` that wraps any of the type mentioned above.
 
@@ -246,8 +246,8 @@ public class MyResourceTemplates {
 The result of a "resource read" operation is always represented as a `ResourceResponse`.
 However, the annotated method can also return other types that are converted according to the following rules.
 
-* If the method returns an implementation of `ResourceContents` then the reponse contains the single contents object.
-* If the method returns a `List` of `ResourceContents` implementations then the reponse contains the list of contents objects.
+* If the method returns an implementation of `ResourceContents` then the response contains the single contents object.
+* If the method returns a `List` of `ResourceContents` implementations then the response contains the list of contents objects.
 * If it returns any other type `X` or `List<X>` then `X` is encoded using the `ResourceContentsEncoder` API and afterwards the rules above apply.
 * It may also return a `Uni` that wraps any of the type mentioned above.
 
@@ -291,8 +291,8 @@ public class MyTemplates {
 The result of a "prompt complete" operation is always represented as a `CompleteResponse`.
 However, the annotated method can also return other types that are converted according to the following rules.
 
-* If the method returns `java.lang.String` then the reponse contains a single value.
-* If the method returns a `List` of `String`s then the reponse contains the list of values.
+* If the method returns `java.lang.String` then the response contains a single value.
+* If the method returns a `List` of `String`s then the response contains the list of values.
 * The method may return a `Uni` that wraps any of the type mentioned above.
 
 A `@CompleteResourceTemplate` method must only accept a single `String` parameter that represents a completed Resource template variable.
@@ -337,14 +337,14 @@ TIP: If a method annotated with `@Tool` throws a `io.quarkiverse.mcp.server.Tool
 A result of a "tool call" operation is always represented as a `ToolResponse`.
 However, the annotated method can also return other types that are converted according to the following rules.
 
-* If the method returns `java.lang.String` then the reponse is "success" and contains the single `TextContent` object.
-* If the method returns an implementation of `io.quarkiverse.mcp.server.Content` then the reponse is "success" and contains the single content object.
-* If the method returns a `List` of `Content` implementations or `String`s then the reponse is "success" and contains the list of relevant content objects.
+* If the method returns `java.lang.String` then the response is "success" and contains the single `TextContent` object.
+* If the method returns an implementation of `io.quarkiverse.mcp.server.Content` then the response is "success" and contains the single content object.
+* If the method returns a `List` of `Content` implementations or `String`s then the response is "success" and contains the list of relevant content objects.
 * The method may return a `Uni` that wraps any of the type mentioned above.
 
-* If it returns `java.lang.String` then the reponse is "success" and contains a single `TextContent`.
-* If it returns an implementation of `Content` then the reponse is "success" and contains a single content object.
-* If it returns a `List` of `Content` implementations or strings then the reponse is "success" and contains a list of relevant content objects.
+* If it returns `java.lang.String` then the response is "success" and contains a single `TextContent`.
+* If it returns an implementation of `Content` then the response is "success" and contains a single content object.
+* If it returns a `List` of `Content` implementations or strings then the response is "success" and contains a list of relevant content objects.
 * If it returns any other type `X` or `List<X>` then `X` is encoded using the `ToolResponseEncoder` and `ContentEncoder` API and afterwards the rules above apply.
 * It may also return a `Uni` that wraps any of the type mentioned above.
 

--- a/transports/stdio/integration-tests/src/test/java/io/quarkiverse/mcp/server/stdio/it/ServerFeaturesIT.java
+++ b/transports/stdio/integration-tests/src/test/java/io/quarkiverse/mcp/server/stdio/it/ServerFeaturesIT.java
@@ -61,7 +61,7 @@ public class ServerFeaturesIT {
                 try {
                     String line;
                     while ((line = stdout.readLine()) != null) {
-                        System.out.println(String.format("JSON message received:\n%s", line));
+                        System.out.printf("JSON message received:%n%s%n", line);
                         synchronizer.put(new JsonObject(line));
                     }
                 } catch (IOException | InterruptedException e) {
@@ -296,7 +296,7 @@ public class ServerFeaturesIT {
     }
 
     private void sendMessage(JsonObject message) {
-        System.out.println(String.format("JSON message sent:\n%s", message));
+        System.out.printf("JSON message sent:%n%s%n", message);
         out.println(message);
     }
 

--- a/transports/stdio/pom.xml
+++ b/transports/stdio/pom.xml
@@ -11,7 +11,7 @@
     <artifactId>quarkus-mcp-server-stdio-parent</artifactId>
     <packaging>pom</packaging>
     <name>Quarkus MCP Server Transport - stdio - Parent</name>
-    <description>This extension enables developers to implement the MCP server features easily using stanard input/output (stdio).</description>
+    <description>This extension enables developers to implement the MCP server features easily using standard input/output (stdio).</description>
 
     <modules>
         <module>deployment</module>


### PR DESCRIPTION
* Rename propmpResultMapper method to promptResultMapper
* Typos fixes
* Fix TrafficLogger to apply textPayloadLimit
* Use System.out.printf instead of String.format and System.out.println combo
* Fix links to the specification
* Update JavaDoc params
* Used method reference instead of lambda