### PR TITLE
Fix docs - escape the "{rootPath}"

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 _"[Model Context Protocol](https://modelcontextprotocol.io/) (MCP) is an open protocol that enables seamless integration between LLM applications and external data sources and tools."_
 
-This extension provides a declarative API that enables developers to implement the MCP server features easily.
+This extension provides declarative and programmatic APIs that enable developers to implement the MCP server features easily.
 
 ## Get Started
 
@@ -45,9 +45,9 @@ public class ServerFeatures {
     @Inject
     CodeService codeService;
 
-    @Tool
-    TextContent toLowerCase(String value) {
-        return new TextContent(value.toLowerCase());
+    @Tool(description = "Converts the string value to lower case")
+    String toLowerCase(String value) {
+        return value.toLowerCase();
     }
 
     @Prompt(name = "code_assist")
@@ -56,8 +56,8 @@ public class ServerFeatures {
     }
 
     @Resource(uri = "file:///project/alpha")
-    BlobResourceContents alpha(String uri) throws IOException{
-        return BlobResourceContents.create(uri, Files.readAllBytes(Paths.ALPHA));
+    BlobResourceContents alpha(RequestUri uri) throws IOException{
+        return BlobResourceContents.create(uri.value(), Files.readAllBytes(Paths.ALPHA));
     }
 
 }

--- a/docs/modules/ROOT/pages/includes/quarkus-mcp-server-sse.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-mcp-server-sse.adoc
@@ -11,7 +11,7 @@ a|icon:lock[title=Fixed at build time] [[quarkus-mcp-server-sse_quarkus-mcp-serv
 
 [.description]
 --
-The SSE endpoint is exposed at `{rootPath}/sse`. By default, it's `/mcp/sse`.
+The SSE endpoint is exposed at `\{rootPath}/sse`. By default, it's `/mcp/sse`.
 
 
 ifdef::add-copy-button-to-env-var[]

--- a/docs/modules/ROOT/pages/includes/quarkus-mcp-server-sse_quarkus.mcp.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-mcp-server-sse_quarkus.mcp.adoc
@@ -11,7 +11,7 @@ a|icon:lock[title=Fixed at build time] [[quarkus-mcp-server-sse_quarkus-mcp-serv
 
 [.description]
 --
-The SSE endpoint is exposed at `{rootPath}/sse`. By default, it's `/mcp/sse`.
+The SSE endpoint is exposed at `\{rootPath}/sse`. By default, it's `/mcp/sse`.
 
 
 ifdef::add-copy-button-to-env-var[]

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -4,12 +4,12 @@ include::./includes/attributes.adoc[]
 
 _"https://modelcontextprotocol.io/[Model Context Protocol]  (MCP) is an open protocol that enables seamless integration between LLM applications and external data sources and tools."_
 
-This extension provides a declarative API that enables developers to implement the MCP server features easily.
+This extension provides declarative and programmatic APIs that enable developers to implement the MCP server features easily.
 
 == Supported transports
 
 MCP currently defines two standard transports for client-server communication.
-This extension supports both transports and defines a unified declarative API.
+This extension supports both transports and defines a unified API to define server features.
 In other words, the server features are defined with the same API but the selected transport determines the way the MCP server communicates with clients. 
 
 If you want to use the https://spec.modelcontextprotocol.io/specification/2024-11-05/basic/transports/#stdio[stdio] transport you'll need to add the `io.quarkiverse.mcp:quarkus-mcp-server-stdio` extension to your build file first.
@@ -38,7 +38,9 @@ For instance, with Maven, add the following dependency to your POM file:
 </dependency>
 ----
 
-TIP: The SSE endpoint is exposed at `{rootPath}/sse`. The `{rootPath}` is set to `mcp` by default, but it can be changed with the `quarkus.mcp.server.sse.root-path` configuration property.
+// We need to escape the {rootPath}
+// https://github.com/quarkiverse/quarkus-mcp-server/issues/105
+TIP: The SSE endpoint is exposed at `\{rootPath}/sse`. The `\{rootPath}` is set to `mcp` by default, but it can be changed with the `quarkus.mcp.server.sse.root-path` configuration property.
 
 == Supported server features
 

--- a/transports/sse/runtime/src/main/java/io/quarkiverse/mcp/server/sse/runtime/config/McpSseBuildTimeConfig.java
+++ b/transports/sse/runtime/src/main/java/io/quarkiverse/mcp/server/sse/runtime/config/McpSseBuildTimeConfig.java
@@ -10,7 +10,7 @@ import io.smallrye.config.WithDefault;
 public interface McpSseBuildTimeConfig {
 
     /**
-     * The SSE endpoint is exposed at `{rootPath}/sse`. By default, it's `/mcp/sse`.
+     * The SSE endpoint is exposed at `\{rootPath}/sse`. By default, it's `/mcp/sse`.
      *
      * @asciidoclet
      */


### PR DESCRIPTION
- fixes #105