### PR TITLE
sse: introduce dummy init in the dev mode

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/TrafficLogger.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/TrafficLogger.java
@@ -2,6 +2,7 @@ package io.quarkiverse.mcp.server.runtime;
 
 import org.jboss.logging.Logger;
 
+import io.quarkiverse.mcp.server.McpConnection;
 import io.vertx.core.json.JsonObject;
 
 public class TrafficLogger {
@@ -14,12 +15,12 @@ public class TrafficLogger {
         this.textPayloadLimit = textPayloadLimit;
     }
 
-    public void messageReceived(JsonObject message) {
-        LOG.infof("JSON message received:\n\n%s", messageToString(message));
+    public void messageReceived(JsonObject message, McpConnection connection) {
+        LOG.infof("MCP message received [%s]:\n\n%s", connection.id(), messageToString(message));
     }
 
-    public void messageSent(JsonObject message) {
-        LOG.infof("JSON message sent:\n\n%s", messageToString(message));
+    public void messageSent(JsonObject message, McpConnection connection) {
+        LOG.infof("MCP message sent [%s]:\n\n%s", connection.id(), messageToString(message));
     }
 
     private String messageToString(JsonObject message) {

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/config/McpRuntimeConfig.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/config/McpRuntimeConfig.java
@@ -38,16 +38,25 @@ public interface McpRuntimeConfig {
      */
     Optional<Duration> autoPingInterval();
 
+    /**
+     * Dev mode config.
+     */
+    DevMode devMode();
+
     public interface TrafficLogging {
 
         /**
-         * If set to true then JSON messages received/sent are logged.
+         * If set to `true` then JSON messages received/sent are logged.
+         *
+         * @asciidoclet
          */
         @WithDefault("false")
         public boolean enabled();
 
         /**
          * The number of characters of a text message which will be logged if traffic logging is enabled.
+         *
+         * @asciidoclet
          */
         @WithDefault("200")
         public int textLimit();
@@ -79,9 +88,24 @@ public interface McpRuntimeConfig {
 
         /**
          * The default log level.
+         *
+         * @asciidoclet
          */
         @WithDefault("INFO")
         public LogLevel defaultLevel();
+
+    }
+
+    public interface DevMode {
+
+        /**
+         * If set to `true` then if an MCP client attempts to reconnect an SSE connection but does not reinitialize properly,
+         * the server will perform a "dummy" initialization; capability negotiation and protocol version agreement is skipped.
+         *
+         * @asciidoclet
+         */
+        @WithDefault("true")
+        public boolean dummyInit();
 
     }
 

--- a/docs/modules/ROOT/pages/includes/quarkus-mcp-server-core.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-mcp-server-core.adoc
@@ -49,7 +49,7 @@ a| [[quarkus-mcp-server-core_quarkus-mcp-server-traffic-logging-enabled]] [.prop
 
 [.description]
 --
-If set to true then JSON messages received/sent are logged.
+If set to `true` then JSON messages received/sent are logged.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -114,6 +114,24 @@ endif::add-copy-button-to-env-var[]
 --
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-mcp-server-core_quarkus-mcp[icon:question-circle[title=More information about the Duration format]]
 |
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-dev-mode-dummy-init]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-dev-mode-dummy-init[`quarkus.mcp.server.dev-mode.dummy-init`]##
+
+[.description]
+--
+If set to `true` then if an MCP client attempts to reconnect an SSE connection but does not reinitialize propertly,
+the server will perform a "dummy" initialization; capability negotiation and protocol version agreement is skipped.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_DEV_MODE_DUMMY_INIT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_DEV_MODE_DUMMY_INIT+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
 
 |===
 

--- a/docs/modules/ROOT/pages/includes/quarkus-mcp-server-core_quarkus.mcp.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-mcp-server-core_quarkus.mcp.adoc
@@ -49,7 +49,7 @@ a| [[quarkus-mcp-server-core_quarkus-mcp-server-traffic-logging-enabled]] [.prop
 
 [.description]
 --
-If set to true then JSON messages received/sent are logged.
+If set to `true` then JSON messages received/sent are logged.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -114,6 +114,24 @@ endif::add-copy-button-to-env-var[]
 --
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-mcp-server-core_quarkus-mcp[icon:question-circle[title=More information about the Duration format]]
 |
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-dev-mode-dummy-init]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-dev-mode-dummy-init[`quarkus.mcp.server.dev-mode.dummy-init`]##
+
+[.description]
+--
+If set to `true` then if an MCP client attempts to reconnect an SSE connection but does not reinitialize propertly,
+the server will perform a "dummy" initialization; capability negotiation and protocol version agreement is skipped.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_DEV_MODE_DUMMY_INIT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_DEV_MODE_DUMMY_INIT+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
 
 |===
 

--- a/docs/modules/ROOT/pages/includes/quarkus-mcp-server-sse_quarkus.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-mcp-server-sse_quarkus.adoc
@@ -11,7 +11,7 @@ a|icon:lock[title=Fixed at build time] [[quarkus-mcp-server-sse_quarkus-root-pat
 
 [.description]
 --
-The SSE endpoint is exposed at `{rootPath}/sse`. By default, it's `/mcp/sse`.
+The SSE endpoint is exposed at `\{rootPath}/sse`. By default, it's `/mcp/sse`.
 
 
 ifdef::add-copy-button-to-env-var[]

--- a/transports/sse/runtime/src/main/java/io/quarkiverse/mcp/server/sse/runtime/SseMcpConnection.java
+++ b/transports/sse/runtime/src/main/java/io/quarkiverse/mcp/server/sse/runtime/SseMcpConnection.java
@@ -30,7 +30,7 @@ public class SseMcpConnection extends McpConnectionBase {
             return;
         }
         if (trafficLogger != null) {
-            trafficLogger.messageSent(message);
+            trafficLogger.messageSent(message, this);
         }
         sendEvent("message", message.encode());
     }

--- a/transports/sse/runtime/src/main/java/io/quarkiverse/mcp/server/sse/runtime/SseMcpMessageHandler.java
+++ b/transports/sse/runtime/src/main/java/io/quarkiverse/mcp/server/sse/runtime/SseMcpMessageHandler.java
@@ -70,7 +70,7 @@ public class SseMcpMessageHandler extends McpMessageHandler implements Handler<R
             return;
         }
         if (connection.trafficLogger() != null) {
-            connection.trafficLogger().messageReceived(message);
+            connection.trafficLogger().messageReceived(message, connection);
         }
         if (JsonRPC.validate(message, connection)) {
             handle(message, connection, connection);

--- a/transports/sse/runtime/src/main/java/io/quarkiverse/mcp/server/sse/runtime/SseMcpServerRecorder.java
+++ b/transports/sse/runtime/src/main/java/io/quarkiverse/mcp/server/sse/runtime/SseMcpServerRecorder.java
@@ -51,17 +51,18 @@ public class SseMcpServerRecorder {
 
                 String id = Base64.getUrlEncoder().encodeToString(UUID.randomUUID().toString().getBytes());
 
-                LOG.debugf("Client connection initialized [%s]", id);
+                LOG.debugf("Connection initialized [%s]", id);
 
                 SseMcpConnection connection = new SseMcpConnection(id, config.clientLogging().defaultLevel(), trafficLogger,
                         config.autoPingInterval(), response);
                 connectionManager.add(connection);
+
                 // TODO we cannot override the close handler set/used by Quarkus HTTP
                 setCloseHandler(ctx.request(), id, connectionManager);
 
                 // By default /mcp/messages/{generatedId}
                 String endpointPath = mcpPath.endsWith("/") ? (mcpPath + "messages/" + id) : (mcpPath + "/messages/" + id);
-                LOG.debugf("POST endpoint path: %s [%s]", endpointPath, id);
+                LOG.debugf("POST endpoint path: %s", endpointPath);
 
                 // https://spec.modelcontextprotocol.io/specification/2024-11-05/basic/transports/#http-with-sse
                 connection.sendEvent("endpoint", endpointPath);

--- a/transports/stdio/runtime/src/main/java/io/quarkiverse/mcp/server/stdio/runtime/StdioMcpConnection.java
+++ b/transports/stdio/runtime/src/main/java/io/quarkiverse/mcp/server/stdio/runtime/StdioMcpConnection.java
@@ -31,7 +31,7 @@ public class StdioMcpConnection extends McpConnectionBase {
             return;
         }
         if (trafficLogger != null) {
-            trafficLogger.messageSent(message);
+            trafficLogger.messageSent(message, this);
         }
         if (BlockingOperationControl.isBlockingAllowed()) {
             out.println(message.encode());

--- a/transports/stdio/runtime/src/main/java/io/quarkiverse/mcp/server/stdio/runtime/StdioMcpMessageHandler.java
+++ b/transports/stdio/runtime/src/main/java/io/quarkiverse/mcp/server/stdio/runtime/StdioMcpMessageHandler.java
@@ -86,7 +86,7 @@ public class StdioMcpMessageHandler extends McpMessageHandler {
                                 return;
                             }
                             if (trafficLogger != null) {
-                                trafficLogger.messageReceived(message);
+                                trafficLogger.messageReceived(message, connection);
                             }
                             if (JsonRPC.validate(message, connection)) {
                                 handle(message, connection, connection);


### PR DESCRIPTION
- if an MCP client attempts to reconnect an SSE connection but does not reinitialize propertly, we could perform a "dummy" initialization

This PR does not fix #102 because when the app is restarted, the HTTP SSE connection is closed and there's not much we can do about it. However, some MCP clients (such as [MCP Inspector](https://modelcontextprotocol.io/docs/tools/inspector)) do attempt to reconnect but do not reinitialize MCP properly. With this change, we perform a "dummy" initialization when needed and so the subsequent requests can be processed as normally.

CC @maxandersen @sebastienblanc