### PR TITLE
feat: have proxy default use quarkus-dev coordinates and otherwise have first argument be uri

### DIFF
--- a/devtools/stdio-sse-proxy/README.md
+++ b/devtools/stdio-sse-proxy/README.md
@@ -40,7 +40,13 @@ Usage: stdio-sse-proxy [-hV] [--[no-]reconnect] -e=<sseEndpoint> [-s=<sleep>]
 In order to run a proxy server for a `quarkus-mcp-server` application running in the dev mode:
 
 ```shell script
-java -jar target/quarkus-mcp-stdio-sse-proxy-1.0.0-SNAPSHOT-runner.jar -e http://localhost:8080/mcp/sse
+java -jar target/quarkus-mcp-stdio-sse-proxy-1.0.0-SNAPSHOT-runner.jar
+```
+
+or if you need a custom endpoint:
+
+```shell script
+java -jar target/quarkus-mcp-stdio-sse-proxy-1.0.0-SNAPSHOT-runner.jar http://my.app/mcp
 ```
 
 > [!IMPORTANT]  

--- a/devtools/stdio-sse-proxy/src/main/java/io/quarkiverse/mcp/server/proxy/StdioSseProxy.java
+++ b/devtools/stdio-sse-proxy/src/main/java/io/quarkiverse/mcp/server/proxy/StdioSseProxy.java
@@ -39,6 +39,7 @@ import org.jboss.logging.Logger;
 import io.quarkus.runtime.Quarkus;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.Option;
+import picocli.CommandLine.Parameters;
 
 /**
  * Starts a proxy server between an MCP client using the {@code stdio} transport and an MCP server using the {@code HTTP/SSE}
@@ -49,7 +50,7 @@ public class StdioSseProxy implements Runnable {
 
     private static final Logger LOG = Logger.getLogger(StdioSseProxy.class);
 
-    @Option(names = { "-e", "--endpoint" }, required = true, description = "The URI of the target SSE endpoint")
+    @Parameters(description = "The URI of the target SSE endpoint", defaultValue = "http://localhost:8080/mcp/sse")
     URI sseEndpoint;
 
     @Option(names = { "-t",


### PR DESCRIPTION

makes it easier to run the proxy as it will default to quarkus devmode coordinates and otherwise have as first argument.

all other flags stay as is.