### PR TITLE
Fix the build order

### DIFF
--- a/transports/sse/integration-tests/pom.xml
+++ b/transports/sse/integration-tests/pom.xml
@@ -33,6 +33,18 @@
             <artifactId>quarkus-mcp-server-sse</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!-- For consistent build order -->
+        <dependency>
+            <groupId>io.quarkiverse.mcp</groupId>
+            <artifactId>quarkus-mcp-server-sse-deployment</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>

--- a/transports/sse/integration-tests/pom.xml
+++ b/transports/sse/integration-tests/pom.xml
@@ -38,6 +38,8 @@
             <groupId>io.quarkiverse.mcp</groupId>
             <artifactId>quarkus-mcp-server-sse-deployment</artifactId>
             <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>

--- a/transports/stdio/integration-tests/pom.xml
+++ b/transports/stdio/integration-tests/pom.xml
@@ -21,6 +21,18 @@
             <artifactId>quarkus-mcp-server-stdio</artifactId>
             <version>${project.version}</version>
         </dependency>
+        <!-- For consistent build order -->
+        <dependency>
+            <groupId>io.quarkiverse.mcp</groupId>
+            <artifactId>quarkus-mcp-server-stdio-deployment</artifactId>
+            <version>${project.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>

--- a/transports/stdio/integration-tests/pom.xml
+++ b/transports/stdio/integration-tests/pom.xml
@@ -26,6 +26,8 @@
             <groupId>io.quarkiverse.mcp</groupId>
             <artifactId>quarkus-mcp-server-stdio-deployment</artifactId>
             <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
             <exclusions>
                 <exclusion>
                     <groupId>*</groupId>


### PR DESCRIPTION
Without this, the tests might either use an outdated artifact or, when building the project tree for the first time, fail the build with

```
[ERROR] Failed to execute goal io.quarkus:quarkus-maven-plugin:3.19.2:build (default) on project quarkus-mcp-server-stdio-integration-tests: Failed to build quarkus application: The following errors were encountered while processing Quarkus application dependencies:
[ERROR] 1) io.quarkus.bootstrap.resolver.maven.BootstrapMavenException: Failed to resolve artifact io.quarkiverse.mcp:quarkus-mcp-server-core-deployment:jar:999-SNAPSHOT
[ERROR]   at io.quarkus.bootstrap.resolver.maven.ApplicationDependencyResolver$AppDep.initResolvedDependency(ApplicationDependencyResolver.java:531)
[ERROR]   ...
[ERROR] 2) io.quarkus.bootstrap.resolver.maven.BootstrapMavenException: Failed to resolve artifact io.quarkiverse.mcp:quarkus-mcp-server-stdio-deployment:jar:999-SNAPSHOT
[ERROR]   at io.quarkus.bootstrap.resolver.maven.ApplicationDependencyResolver$AppDep.initResolvedDependency(ApplicationDependencyResolver.java:531)
```