### PR TITLE
feat: Allow mcp-server-stdio to be explicilty started.

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-mcp-server-stdio.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-mcp-server-stdio.adoc
@@ -7,6 +7,27 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
+a|icon:lock[title=Fixed at build time] [[quarkus-mcp-server-stdio_quarkus-mcp-server-stdio-initialization-enabled]] [.property-path]##link:#quarkus-mcp-server-stdio_quarkus-mcp-server-stdio-initialization-enabled[`quarkus.mcp.server.stdio.initialization-enabled`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.stdio.initialization-enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Flag to specify whether the MCP server should be automatically initialized. This can be useful in case where the MCP server should be conditionally started. For example: from a CLI that provides multiple commands including one for starting the MCP server.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_STDIO_INITIALIZATION_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_STDIO_INITIALIZATION_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
 a| [[quarkus-mcp-server-stdio_quarkus-mcp-server-stdio-enabled]] [.property-path]##link:#quarkus-mcp-server-stdio_quarkus-mcp-server-stdio-enabled[`quarkus.mcp.server.stdio.enabled`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.mcp.server.stdio.enabled+++[]

--- a/docs/modules/ROOT/pages/includes/quarkus-mcp-server-stdio_quarkus.mcp.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-mcp-server-stdio_quarkus.mcp.adoc
@@ -7,6 +7,27 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
+a|icon:lock[title=Fixed at build time] [[quarkus-mcp-server-stdio_quarkus-mcp-server-stdio-initialization-enabled]] [.property-path]##link:#quarkus-mcp-server-stdio_quarkus-mcp-server-stdio-initialization-enabled[`quarkus.mcp.server.stdio.initialization-enabled`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.stdio.initialization-enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Flag to specify whether the MCP server should be automatically initialized. This can be useful in case where the MCP server should be conditionally started. For example: from a CLI that provides multiple commands including one for starting the MCP server.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_STDIO_INITIALIZATION_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_STDIO_INITIALIZATION_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
 a| [[quarkus-mcp-server-stdio_quarkus-mcp-server-stdio-enabled]] [.property-path]##link:#quarkus-mcp-server-stdio_quarkus-mcp-server-stdio-enabled[`quarkus.mcp.server.stdio.enabled`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.mcp.server.stdio.enabled+++[]

--- a/transports/stdio/deployment/src/main/java/io/quarkiverse/mcp/server/stdio/deployment/McpStdioBuildTimeConfig.java
+++ b/transports/stdio/deployment/src/main/java/io/quarkiverse/mcp/server/stdio/deployment/McpStdioBuildTimeConfig.java
@@ -1,0 +1,21 @@
+package io.quarkiverse.mcp.server.stdio.deployment;
+
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+@ConfigMapping(prefix = "quarkus.mcp.server.stdio")
+@ConfigRoot(phase = ConfigPhase.BUILD_TIME)
+public interface McpStdioBuildTimeConfig {
+
+    /**
+     * Flag to specify whether the MCP server should be automatically initialized.
+     * This can be useful in case where the MCP server should be conditionally
+     * started. For example: from a CLI that provides multiple commands including
+     * one for starting the MCP server.
+     */
+    @WithDefault("true")
+    boolean initializationEnabled();
+
+}

--- a/transports/stdio/deployment/src/main/java/io/quarkiverse/mcp/server/stdio/deployment/StdioMcpServerProcessor.java
+++ b/transports/stdio/deployment/src/main/java/io/quarkiverse/mcp/server/stdio/deployment/StdioMcpServerProcessor.java
@@ -27,8 +27,10 @@ public class StdioMcpServerProcessor {
     @Record(RUNTIME_INIT)
     @Consume(SyntheticBeansRuntimeInitBuildItem.class)
     @BuildStep
-    void initialize(StdioMcpServerRecorder recorder) {
-        recorder.initialize();
+    void initialize(StdioMcpServerRecorder recorder, McpStdioBuildTimeConfig config) {
+        if (config.initializationEnabled()) {
+            recorder.initialize();
+        }
     }
 
 }


### PR DESCRIPTION
Resolves: #155 

The pull request introduces a build time config parameter that controls the initialization of the `mcp-server-stdio` this allows users to have more control over when the server is started.

For my use case, this works like a charm.