### PR TITLE
Dev UI: always produce JsonRPCProvidersBuildItem

### DIFF
--- a/transports/sse/deployment/src/main/java/io/quarkiverse/mcp/server/sse/deployment/devui/SseMcpDevUIProcessor.java
+++ b/transports/sse/deployment/src/main/java/io/quarkiverse/mcp/server/sse/deployment/devui/SseMcpDevUIProcessor.java
@@ -38,7 +38,7 @@ public class SseMcpDevUIProcessor {
         cardPages.produce(pageBuildItem);
     }
 
-    @BuildStep(onlyIf = IsDevelopment.class)
+    @BuildStep
     JsonRPCProvidersBuildItem rpcProvider() {
         return new JsonRPCProvidersBuildItem(SseMcpJsonRPCService.class);
     }


### PR DESCRIPTION
This is due to an upcoming change in Execution Model Validation [1] where we need the `JsonRPCProvidersBuildItem` produced always, not only in dev mode. JSON RPC providers can use execution model affecting annotations, so we need to know about them, otherwise a non-dev build would fail with an incorrect validation error.

[1] https://github.com/quarkusio/quarkus/pull/46965