### PR TITLE
fix naming conflict for commands with same class name

### DIFF
--- a/cli-adapter/deployment/src/main/java/io/quarkiverse/mcp/server/cli/adapter/deployment/McpServerCliAdapterProcessor.java
+++ b/cli-adapter/deployment/src/main/java/io/quarkiverse/mcp/server/cli/adapter/deployment/McpServerCliAdapterProcessor.java
@@ -61,6 +61,7 @@ class McpServerCliAdapterProcessor {
 
     private static final String NON_ALPHANUMERIC = "[^a-zA-Z0-9]";
     private static final String UNDERSCORE = "_";
+    private static final String EMPTY = "";
 
     private static final String OPTION_TYPENAME = "L" + Option.class.getName().replace('.', '/') + ";";
     private static final String MCP_ADAPTER_TYPE = org.objectweb.asm.Type.getType(McpAdapter.class).getInternalName();
@@ -75,8 +76,156 @@ class McpServerCliAdapterProcessor {
         return new McpStdioExplicitInitializationBuildItem();
     }
 
-    /***
-     * Generate a bean that wraps around the actual picocli command
+    /**
+     * Creates a wrapper for each class annotated with {@link Command} reachable from the {@link TopCommand} class.
+     * If no {@link TopCommand} class is found, all classes annotated with {@link Command} are processed.
+     * Also it adds the `--mcp` option to the {@link TopCommand} class.
+     */
+    @BuildStep
+    void process(CombinedIndexBuildItem combinedIndex,
+            BuildProducer<BytecodeTransformerBuildItem> transformers,
+            BuildProducer<GeneratedBeanBuildItem> generatedBeans) {
+
+        IndexView index = combinedIndex.getIndex();
+        Map<String, ClassInfo> commandClasses = new HashMap<>();
+
+        Optional<DotName> topCommand = CommandUtil.findTopCommand(index);
+        topCommand.ifPresentOrElse(dotName -> {
+            // Top command has been found, then collect all subcommanS
+            ClassInfo classInfo = index.getClassByName(dotName);
+            if (classInfo != null) {
+                commandClasses.putAll(collectCommandClassNames(index, classInfo));
+                String className = classInfo.name().toString();
+                transformers.produce(createTopCommandTransformer(className));
+            }
+        }, () -> {
+            // No top command found, then collect all commands
+            for (DotName c : classesAnnotatedWith(index, Command.class.getName())) {
+                ClassInfo classInfo = index.getClassByName(c);
+                if (classInfo.name().toString().startsWith(DotNames.COMMANDLINE.packagePrefix())) {
+                    // .. but let`s skip the picocli internal ones
+                    continue;
+                }
+                commandClasses.putAll(collectCommandClassNames(index, classInfo));
+            }
+        });
+
+        // Get the prefix and wrap all commands
+        String commonPrefix = CommandUtil.findCommonPrefix(commandClasses.keySet());
+        commandClasses.forEach((key, value) -> {
+            ClassInfo beanClass = index.getClassByName(value.name());
+            String toolName = EMPTY.equals(commonPrefix) ? beanClass.simpleName().toLowerCase()
+                    : key.replaceFirst(commonPrefix, EMPTY);
+            wrapCommand(index, toolName, beanClass, generatedBeans);
+        });
+    }
+
+    /**
+     * Create a transformer for the {@link TopCommand} annotated class.
+     * This transformer adds the "--mcp" options and modfies the "call" method
+     * so that it returns the result of {@link McpAdapter#startMcp()} if the "--mcp" option is set.
+     *
+     * Example:
+     *
+     * <pre>
+     * @Option(names = { "--mcp" }, description = { "Start an MCP server for the current CLI." })
+     * public boolean mcp;
+     *
+     * public Integer call() {
+     *     if (this.mcp) {
+     *         return McpAdapter.startMcp();
+     *     } else {
+     *         // The original call code
+     *         return ExitCode.OK;
+     *     }
+     * }
+     *
+     * </pre>
+     */
+    public BytecodeTransformerBuildItem createTopCommandTransformer(String className) {
+        return new BytecodeTransformerBuildItem(className, new BiFunction<String, ClassVisitor, ClassVisitor>() {
+            @Override
+            public ClassVisitor apply(String originalClassName, ClassVisitor cv) {
+                return new ClassVisitor(Gizmo.ASM_API_VERSION, cv) {
+                    private String currentClassName;
+                    private boolean hasMcpField = false;
+
+                    @Override
+                    public void visit(int version, int access, String name, String signature, String superName,
+                            String[] interfaces) {
+                        currentClassName = name;
+                        super.visit(version, access, name, signature, superName, interfaces);
+                    }
+
+                    @Override
+                    public FieldVisitor visitField(int access, String name, String descriptor, String signature,
+                            Object value) {
+                        if ("mcp".equals(name) && "Z".equals(descriptor)) {
+                            hasMcpField = true;
+                        }
+                        return super.visitField(access, name, descriptor, signature, value);
+                    }
+
+                    @Override
+                    public void visitEnd() {
+                        if (!hasMcpField) {
+                            // Add: public boolean mcp;
+                            FieldVisitor fv = cv.visitField(Opcodes.ACC_PUBLIC, "mcp", "Z", null, null);
+                            // Add the @Option annotation with names and description.
+                            AnnotationVisitor av = fv.visitAnnotation(OPTION_TYPENAME, true);
+
+                            AnnotationVisitor namesAv = av.visitArray("names");
+                            namesAv.visit(null, "--mcp");
+                            namesAv.visitEnd();
+
+                            AnnotationVisitor descAv = av.visitArray("description");
+                            descAv.visit(null, "Start an MCP server for the current CLI.");
+                            descAv.visitEnd();
+
+                            av.visitEnd();
+                            fv.visitEnd();
+                        }
+                        super.visitEnd();
+                    }
+
+                    @Override
+                    public MethodVisitor visitMethod(int access, String methodName, String descriptor,
+                            String signature, String[] exceptions) {
+                        MethodVisitor mv = super.visitMethod(access, methodName, descriptor, signature,
+                                exceptions);
+                        // Target the "call" method.
+                        if ("call".equals(methodName)) {
+                            return new MethodVisitor(Gizmo.ASM_API_VERSION, mv) {
+                                @Override
+                                public void visitCode() {
+                                    mv.visitCode();
+                                    // Insert: if (this.mcp) { return McpAdapter.startMcp(); }
+                                    // Load 'this'
+                                    mv.visitVarInsn(Opcodes.ALOAD, 0);
+                                    // Get the boolean field "mcp" (descriptor "Z")
+                                    mv.visitFieldInsn(Opcodes.GETFIELD, currentClassName, "mcp", "Z");
+                                    Label continueLabel = new Label();
+                                    // If mcp == false, jump to continueLabel.
+                                    mv.visitJumpInsn(Opcodes.IFEQ, continueLabel);
+                                    // Else, call McpAdapter.startMcp(); assumed descriptor: ()I.
+                                    mv.visitMethodInsn(Opcodes.INVOKESTATIC, MCP_ADAPTER_TYPE, "startMcp",
+                                            "()Ljava/lang/Integer;", false);
+                                    // Return the int value.
+                                    mv.visitInsn(Opcodes.ARETURN);
+                                    // Mark the continue label.
+                                    mv.visitLabel(continueLabel);
+                                }
+                            };
+                        }
+                        return mv;
+                    }
+                };
+            }
+        });
+    }
+
+    /**
+     * Generate a beans that wraps around the actual picocli command
      * providing access to it as a {@link Tool}.
      *
      * The code of the generated bean will look
@@ -107,144 +256,18 @@ class McpServerCliAdapterProcessor {
      *     }
      * }
      * </pre>
+     *
+     * @param index the index
+     * @param toolName the name of the tool
+     * @param beanClass the class of the bean
+     * @param generatedBeans the generated beans
      */
-    @BuildStep
-    void createCommandWrappers(CombinedIndexBuildItem combinedIndex,
-            BuildProducer<BytecodeTransformerBuildItem> transformers,
+    void wrapCommand(IndexView index, String toolName, ClassInfo beanClass,
             BuildProducer<GeneratedBeanBuildItem> generatedBeans) {
-
-        IndexView index = combinedIndex.getIndex();
-        Optional<DotName> topCommand = findTopCommand(index);
-
-        topCommand.ifPresentOrElse(dotName -> {
-            ClassInfo classInfo = index.getClassByName(dotName);
-            if (classInfo != null) {
-                AnnotationInstance topCommandAnnotation = classInfo.annotation(DotNames.TOP_COMAMND);
-                AnnotationValue annotationValue = topCommandAnnotation.value("subcommands");
-                if (annotationValue != null) {
-                    Type[] subcommands = annotationValue.asClassArray();
-                    for (Type subcommand : subcommands) {
-                        ClassInfo subcommandClass = index.getClassByName(subcommand.name());
-                        if (subcommandClass != null) {
-                            wrapCommand(index, subcommandClass, generatedBeans);
-                        }
-                    }
-                } else {
-                    wrapCommand(index, classInfo, generatedBeans);
-                }
-
-                String className = classInfo.name().toString();
-                transformers.produce(
-                        new BytecodeTransformerBuildItem(className, new BiFunction<String, ClassVisitor, ClassVisitor>() {
-                            @Override
-                            public ClassVisitor apply(String originalClassName, ClassVisitor cv) {
-                                return new ClassVisitor(Gizmo.ASM_API_VERSION, cv) {
-                                    private String currentClassName;
-                                    private boolean hasMcpField = false;
-
-                                    @Override
-                                    public void visit(int version, int access, String name, String signature, String superName,
-                                            String[] interfaces) {
-                                        currentClassName = name;
-                                        super.visit(version, access, name, signature, superName, interfaces);
-                                    }
-
-                                    @Override
-                                    public FieldVisitor visitField(int access, String name, String descriptor, String signature,
-                                            Object value) {
-                                        if ("mcp".equals(name) && "Z".equals(descriptor)) {
-                                            hasMcpField = true;
-                                        }
-                                        return super.visitField(access, name, descriptor, signature, value);
-                                    }
-
-                                    @Override
-                                    public void visitEnd() {
-                                        if (!hasMcpField) {
-                                            // Add: public boolean mcp;
-                                            FieldVisitor fv = cv.visitField(Opcodes.ACC_PUBLIC, "mcp", "Z", null, null);
-                                            // Add the @Option annotation with names and description.
-                                            AnnotationVisitor av = fv.visitAnnotation(OPTION_TYPENAME, true);
-
-                                            AnnotationVisitor namesAv = av.visitArray("names");
-                                            namesAv.visit(null, "--mcp");
-                                            namesAv.visitEnd();
-
-                                            AnnotationVisitor descAv = av.visitArray("description");
-                                            descAv.visit(null, "Start an MCP server for the current CLI.");
-                                            descAv.visitEnd();
-
-                                            av.visitEnd();
-                                            fv.visitEnd();
-                                        }
-                                        super.visitEnd();
-                                    }
-
-                                    @Override
-                                    public MethodVisitor visitMethod(int access, String methodName, String descriptor,
-                                            String signature, String[] exceptions) {
-                                        MethodVisitor mv = super.visitMethod(access, methodName, descriptor, signature,
-                                                exceptions);
-                                        // Target the "call" method.
-                                        if ("call".equals(methodName)) {
-                                            return new MethodVisitor(Gizmo.ASM_API_VERSION, mv) {
-                                                @Override
-                                                public void visitCode() {
-                                                    mv.visitCode();
-                                                    // Insert: if (this.mcp) { return McpAdapter.startMcp(); }
-                                                    // Load 'this'
-                                                    mv.visitVarInsn(Opcodes.ALOAD, 0);
-                                                    // Get the boolean field "mcp" (descriptor "Z")
-                                                    mv.visitFieldInsn(Opcodes.GETFIELD, currentClassName, "mcp", "Z");
-                                                    Label continueLabel = new Label();
-                                                    // If mcp == false, jump to continueLabel.
-                                                    mv.visitJumpInsn(Opcodes.IFEQ, continueLabel);
-                                                    // Else, call McpAdapter.startMcp(); assumed descriptor: ()I.
-                                                    mv.visitMethodInsn(Opcodes.INVOKESTATIC, MCP_ADAPTER_TYPE, "startMcp",
-                                                            "()Ljava/lang/Integer;", false);
-                                                    // Return the int value.
-                                                    mv.visitInsn(Opcodes.ARETURN);
-                                                    // Mark the continue label.
-                                                    mv.visitLabel(continueLabel);
-                                                }
-                                            };
-                                        }
-                                        return mv;
-                                    }
-                                };
-                            }
-                        }));
-            }
-        }, () -> {
-            for (DotName c : classesAnnotatedWith(index, Command.class.getName())) {
-                ClassInfo beanClass = index.getClassByName(c);
-
-                if (beanClass.name().toString().startsWith(DotNames.COMMANDLINE.packagePrefix())) {
-                    continue;
-                }
-                wrapCommand(index, beanClass, generatedBeans);
-            }
-        });
-    }
-
-    void wrapCommand(IndexView index, ClassInfo beanClass, BuildProducer<GeneratedBeanBuildItem> generatedBeans) {
         AnnotationInstance commandAnnotation = beanClass.annotation(DotNames.COMMAND);
-        String name = beanClass.simpleName().replaceAll(NON_ALPHANUMERIC, UNDERSCORE).toLowerCase();
         String description = getCommandDescriptionOrHeader(commandAnnotation);
 
         String beanClassName = beanClass.name().toString();
-        // If the command has itself subcommands we need to wrap them too.
-        AnnotationValue annotationValue = commandAnnotation.value("subcommands");
-        if (annotationValue != null) {
-            Type[] subcommands = annotationValue.asClassArray();
-            for (Type subcommand : subcommands) {
-                ClassInfo subcommandClass = index.getClassByName(subcommand.name());
-                if (subcommandClass != null) {
-                    wrapCommand(index, subcommandClass, generatedBeans);
-                }
-            }
-        }
-
         String generatedWrapperClassName = beanClassName + "McpWrapper";
 
         // Use Gizmo to generate the new class.
@@ -285,7 +308,7 @@ class McpServerCliAdapterProcessor {
                     .mapToObj(i -> String.class.getName())
                     .toArray(String[]::new);
 
-            MethodCreator executeMethod = cc.getMethodCreator(name, String.class.getName(), parameterTypes);
+            MethodCreator executeMethod = cc.getMethodCreator(toolName, String.class.getName(), parameterTypes);
             int optionIndex = 0;
 
             for (Entry<String, FieldInfo> entry : options.entrySet()) {
@@ -374,14 +397,6 @@ class McpServerCliAdapterProcessor {
         return null;
     }
 
-    private Optional<DotName> findTopCommand(IndexView indexView) {
-        return indexView.getAnnotations(DotNames.TOP_COMAMND)
-                .stream()
-                .filter(ann -> ann.target().kind() == AnnotationTarget.Kind.CLASS)
-                .map(ann -> ann.target().asClass().name())
-                .findFirst();
-    }
-
     private List<DotName> classesAnnotatedWith(IndexView indexView, String annotationClassName) {
         return indexView.getAnnotations(DotName.createSimple(annotationClassName))
                 .stream()
@@ -411,5 +426,25 @@ class McpServerCliAdapterProcessor {
                 .map(AnnotationValue::asString);
         Optional<String[]> header = Optional.ofNullable(annotation.value("header")).map(AnnotationValue::asStringArray);
         return headerHeading.orElse("") + String.join("\n", header.orElseGet(() -> new String[0]));
+    }
+
+    private static Map<String, ClassInfo> collectCommandClassNames(IndexView index, ClassInfo classInfo) {
+        Map<String, ClassInfo> result = new HashMap<>();
+        AnnotationInstance commandAnnotation = classInfo.annotation(DotNames.COMMAND);
+        String name = classInfo.name().toString().replaceAll(NON_ALPHANUMERIC, UNDERSCORE).toLowerCase();
+        result.put(name, classInfo);
+
+        // If the command has itself subcommands we need to wrap them too.
+        AnnotationValue annotationValue = commandAnnotation.value("subcommands");
+        if (annotationValue != null) {
+            Type[] subcommands = annotationValue.asClassArray();
+            for (Type subcommand : subcommands) {
+                ClassInfo subcommandClass = index.getClassByName(subcommand.name());
+                if (subcommandClass != null) {
+                    result.putAll(collectCommandClassNames(index, subcommandClass));
+                }
+            }
+        }
+        return result;
     }
 }

--- a/cli-adapter/deployment/src/test/java/io/quarkiverse/mcp/server/cli/adapter/deployment/CommandUtilTest.java
+++ b/cli-adapter/deployment/src/test/java/io/quarkiverse/mcp/server/cli/adapter/deployment/CommandUtilTest.java
@@ -2,6 +2,8 @@ package io.quarkiverse.mcp.server.cli.adapter.deployment;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.Set;
+
 import jakarta.inject.Inject;
 
 import org.jboss.jandex.ClassInfo;
@@ -56,6 +58,19 @@ public class CommandUtilTest {
         Index index = Index.of(Simple.class, SimpleBeanWithFieldInjection.class);
         ClassInfo classInfo = index.getClassByName(DotName.createSimple(SimpleBeanWithFieldInjection.class.getName()));
         assertFalse(CommandUtil.canBeInstantiated(classInfo, index));
+    }
+
+    @Test
+    public void shouldFindMaxCommonPrefix() {
+        assertEquals("io.quarkiverse.mcp.server.cli.adapter.deployment.",
+                CommandUtil.findCommonPrefix(Set.of(
+                        "io.quarkiverse.mcp.server.cli.adapter.deployment.CommandUtilTest",
+                        "io.quarkiverse.mcp.server.cli.adapter.deployment.MyCommand")));
+
+        assertEquals("", CommandUtil.findCommonPrefix(Set.of(
+                "io.quarkiverse.mcp.server.cli.adapter.deployment.CommandUtilTest",
+                "io.quarkiverse.mcp.server.cli.adapter.deployment.CommandUtil",
+                "org.acme.MyCommand")));
     }
 
 }


### PR DESCRIPTION
Resolves: #197

The pull request uses the fully qualified class name for each command adapted to a tool. To avoid having really long names, it eliminates the maximum common package prefix. 