### PR TITLE
#217:[docs] Unclear Resources Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ public class ServerFeatures {
 
     @Resource(uri = "file:///project/alpha")
     BlobResourceContents alpha(RequestUri uri) throws IOException{
-        return BlobResourceContents.create(uri.value(), Files.readAllBytes(Paths.ALPHA));
+        return BlobResourceContents.create(uri.value(), Files.readAllBytes(Path.of("alpha.txt")));
     }
 
 }

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -278,7 +278,7 @@ public class MyResources {
           .setDescription("Alpha resource file")
           .setHandler(
               args -> new ResourceResponse(
-                                    List.of(BlobResourceContents.create(args.requestUri().value(), Files.readAllBytes(Paths.ALPHA)))))
+                                    List.of(BlobResourceContents.create(args.requestUri().value(), Files.readAllBytes(Path.of("alpha.txt"))))))
           .register(); <4>
     }
 }


### PR DESCRIPTION
#217: improved the documentation a bit with the suggestion from @mkouba -> instead of using what looks like a constant (Paths.ALPHA) using a generic Path reference