### PR TITLE
Set MCP SSE dependency to 1.1.1 in the secure-mcp-sse-server demo

### DIFF
--- a/samples/secure-mcp-sse-server/pom.xml
+++ b/samples/secure-mcp-sse-server/pom.xml
@@ -41,7 +41,7 @@
         <dependency>
             <groupId>io.quarkiverse.mcp</groupId>
             <artifactId>quarkus-mcp-server-sse</artifactId>
-            <version>1.1.0</version>
+            <version>1.1.1</version>
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/samples/secure-mcp-sse-server/src/main/resources/application.properties
+++ b/samples/secure-mcp-sse-server/src/main/resources/application.properties
@@ -1,2 +1,5 @@
 quarkus.http.auth.permission.authenticated.paths=/mcp/sse
 quarkus.http.auth.permission.authenticated.policy=authenticated
+
+quarkus.keycloak.devservices.container-memory-limit=1250M
+


### PR DESCRIPTION
@mkouba Hi Martin, please update the `main` tomorrow with this update.

FYI, the Keycloak devservice related updated is needed until this project picks up one of the latest Quarkus releases