### PR TITLE
Upgrade Maven compiler plugin and adjust Java release version

### DIFF
--- a/samples/secure-mcp-sse-server/pom.xml
+++ b/samples/secure-mcp-sse-server/pom.xml
@@ -6,8 +6,8 @@
     <version>1.0.0-SNAPSHOT</version>
 
     <properties>
-        <compiler-plugin.version>3.13.0</compiler-plugin.version>
-        <maven.compiler.release>21</maven.compiler.release>
+        <compiler-plugin.version>3.14.0</compiler-plugin.version>
+        <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.platform.artifact-id>quarkus-bom</quarkus.platform.artifact-id>

--- a/samples/weather/pom.xml
+++ b/samples/weather/pom.xml
@@ -6,7 +6,7 @@
     <version>1.0.0-SNAPSHOT</version>
 
     <properties>
-        <compiler-plugin.version>3.13.0</compiler-plugin.version>
+        <compiler-plugin.version>3.14.0</compiler-plugin.version>
         <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>


### PR DESCRIPTION
Updated the compiler plugin to version 3.14.0 across projects for improved compatibility and features. Adjusted the Java release version in the secure-mcp-sse-server module from 21 to 17 to align with supported configurations.