### PR TITLE
sse: make it possible to include query params in the message endpoint

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-mcp-server-sse.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-mcp-server-sse.adoc
@@ -36,5 +36,31 @@ endif::add-copy-button-to-env-var[]
 |string
 |`/mcp`
 
+a|icon:lock[title=Fixed at build time] [[quarkus-mcp-server-sse_quarkus-mcp-server-sse-message-endpoint-include-query-params]] [.property-path]##link:#quarkus-mcp-server-sse_quarkus-mcp-server-sse-message-endpoint-include-query-params[`quarkus.mcp.server.sse.message-endpoint.include-query-params`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.sse.message-endpoint.include-query-params+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.mcp.server."server-name".sse.message-endpoint.include-query-params`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server."server-name".sse.message-endpoint.include-query-params+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+If set to true then the query params from the initial HTTP request should be included in the message endpoint.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_SSE_MESSAGE_ENDPOINT_INCLUDE_QUERY_PARAMS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_SSE_MESSAGE_ENDPOINT_INCLUDE_QUERY_PARAMS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`false`
+
 |===
 

--- a/docs/modules/ROOT/pages/includes/quarkus-mcp-server-sse_quarkus.mcp.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-mcp-server-sse_quarkus.mcp.adoc
@@ -36,5 +36,31 @@ endif::add-copy-button-to-env-var[]
 |string
 |`/mcp`
 
+a|icon:lock[title=Fixed at build time] [[quarkus-mcp-server-sse_quarkus-mcp-server-sse-message-endpoint-include-query-params]] [.property-path]##link:#quarkus-mcp-server-sse_quarkus-mcp-server-sse-message-endpoint-include-query-params[`quarkus.mcp.server.sse.message-endpoint.include-query-params`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.sse.message-endpoint.include-query-params+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.mcp.server."server-name".sse.message-endpoint.include-query-params`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server."server-name".sse.message-endpoint.include-query-params+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+If set to true then the query params from the initial HTTP request should be included in the message endpoint.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_SSE_MESSAGE_ENDPOINT_INCLUDE_QUERY_PARAMS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_SSE_MESSAGE_ENDPOINT_INCLUDE_QUERY_PARAMS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`false`
+
 |===
 

--- a/transports/sse/deployment/src/main/java/io/quarkiverse/mcp/server/sse/deployment/SseMcpServerProcessor.java
+++ b/transports/sse/deployment/src/main/java/io/quarkiverse/mcp/server/sse/deployment/SseMcpServerProcessor.java
@@ -55,7 +55,7 @@ public class SseMcpServerProcessor {
         Set<String> rootPaths = new HashSet<>();
         for (Map.Entry<String, McpSseServerBuildTimeConfig> e : config.servers().entrySet()) {
             String serverName = e.getKey();
-            String rootPath = e.getValue().rootPath();
+            String rootPath = e.getValue().sse().rootPath();
             if (!rootPaths.add(rootPath)) {
                 throw new IllegalStateException("Multiple server configurations define the same root path: " + rootPath);
             }

--- a/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/McpServerTest.java
+++ b/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/McpServerTest.java
@@ -68,6 +68,11 @@ public abstract class McpServerTest {
         return "/mcp";
     }
 
+    protected String ssePath() {
+        // should never start with a slash
+        return "sse";
+    }
+
     protected Map<String, Object> defaultHeaders() {
         return Map.of();
     }
@@ -99,9 +104,11 @@ public abstract class McpServerTest {
         Map<String, Object> headers = new HashMap<>(defaultHeaders());
         headers.putAll(additionalHeaders);
         return RestAssured.given()
+                .urlEncodingEnabled(false)
                 .when()
                 .headers(headers)
                 .body(data)
+                //.log().all()
                 .post(messageEndpoint)
                 .then();
     }
@@ -127,8 +134,9 @@ public abstract class McpServerTest {
             testUriStr = testUriStr.substring(0, testUriStr.length() - 1);
         }
         String sseRootPath = sseRootPath();
+        String ssePath = ssePath();
         return new McpSseClient(
-                URI.create(testUriStr + (sseRootPath.endsWith("/") ? sseRootPath + "sse" : sseRootPath + "/sse")));
+                URI.create(testUriStr + (sseRootPath.endsWith("/") ? sseRootPath + ssePath : sseRootPath + "/" + ssePath)));
     }
 
     protected Entry<String, String> initBaseAuth() {

--- a/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/messageendpoint/IncludeQueryParamsTest.java
+++ b/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/messageendpoint/IncludeQueryParamsTest.java
@@ -1,0 +1,83 @@
+package io.quarkiverse.mcp.server.test.messageendpoint;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.stream.Collectors;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+public class IncludeQueryParamsTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .withApplicationRoot(root -> root.addClass(MyTools.class))
+            .overrideConfigKey("quarkus.mcp.server.sse.message-endpoint.include-query-params", "true");
+
+    @Override
+    protected String ssePath() {
+        return new StringBuilder().append("sse?")
+                .append("foo=1")
+                .append("&bar=2")
+                .append("&bar=3")
+                .append("&name=")
+                .append(URLEncoder.encode("Čenda", StandardCharsets.UTF_8))
+                .toString();
+    }
+
+    @Test
+    public void testQueryParams() {
+        initClient();
+        assertQuery(messageEndpoint.getQuery());
+        JsonObject msg = newToolCallMessage("queryParams");
+        send(msg);
+        assertToolTextContent(msg);
+    }
+
+    private void assertQuery(String query) {
+        assertTrue(query.contains("foo=1"));
+        assertTrue(query.contains("bar=2"));
+        assertTrue(query.contains("bar=3"));
+        assertTrue(query.contains("name=Čenda"));
+    }
+
+    private void assertToolTextContent(JsonObject msg) {
+        JsonObject response = client().waitForResponse(msg);
+        JsonObject result = assertResultResponse(msg, response);
+        assertNotNull(result);
+        assertFalse(result.getBoolean("isError"));
+        JsonArray content = result.getJsonArray("content");
+        assertEquals(1, content.size());
+        JsonObject textContent = content.getJsonObject(0);
+        assertEquals("text", textContent.getString("type"));
+        String text4 = textContent.getString("text");
+        assertQuery(text4);
+    }
+
+    public static class MyTools {
+
+        @Inject
+        HttpServerRequest request;
+
+        @Tool
+        String queryParams() {
+            return request.params().entries().stream().map(e -> e.getKey() + "=" + e.getValue())
+                    .collect(Collectors.joining(","));
+        }
+
+    }
+}

--- a/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/messageendpoint/QueryParamsNotIncludedByDefaultTest.java
+++ b/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/messageendpoint/QueryParamsNotIncludedByDefaultTest.java
@@ -1,0 +1,74 @@
+package io.quarkiverse.mcp.server.test.messageendpoint;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.stream.Collectors;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.http.HttpServerRequest;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+public class QueryParamsNotIncludedByDefaultTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .withApplicationRoot(root -> root.addClass(MyTools.class));
+
+    @Override
+    protected String ssePath() {
+        return new StringBuilder().append("sse?")
+                .append("foo=1")
+                .append("&bar=2")
+                .toString();
+    }
+
+    @Test
+    public void testQueryParams() {
+        initClient();
+        assertNull(messageEndpoint.getQuery());
+        JsonObject msg = newToolCallMessage("queryParams");
+        send(msg);
+        assertToolTextContent(msg);
+    }
+
+    private void assertToolTextContent(JsonObject msg) {
+        JsonObject response = client().waitForResponse(msg);
+        JsonObject result = assertResultResponse(msg, response);
+        assertNotNull(result);
+        assertFalse(result.getBoolean("isError"));
+        JsonArray content = result.getJsonArray("content");
+        assertEquals(1, content.size());
+        JsonObject textContent = content.getJsonObject(0);
+        assertEquals("text", textContent.getString("type"));
+        String text4 = textContent.getString("text");
+        assertFalse(text4.contains("foo=1"));
+        assertFalse(text4.contains("bar=2"));
+        // HttpServerRequest#params() also contains path params
+        assertTrue(text4.contains("id="));
+    }
+
+    public static class MyTools {
+
+        @Inject
+        HttpServerRequest request;
+
+        @Tool
+        String queryParams() {
+            return request.params().entries().stream().map(e -> e.getKey() + "=" + e.getValue())
+                    .collect(Collectors.joining(","));
+        }
+
+    }
+}

--- a/transports/sse/runtime/src/main/java/io/quarkiverse/mcp/server/sse/runtime/StreamableHttpMcpMessageHandler.java
+++ b/transports/sse/runtime/src/main/java/io/quarkiverse/mcp/server/sse/runtime/StreamableHttpMcpMessageHandler.java
@@ -103,9 +103,6 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
         if (serverName == null) {
             throw new IllegalStateException("Server name not defined");
         }
-        McpServerRuntimeConfig serverConfig = config.servers().get(serverName);
-        // TODO fail if not found
-
         HttpServerRequest request = ctx.request();
 
         // The client MUST include an "Accept" header,
@@ -123,6 +120,7 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
         if (mcpSessionId == null) {
             String id = ConnectionManager.connectionId();
             LOG.debugf("Streamable connection initialized [%s]", id);
+            McpServerRuntimeConfig serverConfig = config.servers().get(serverName);
             connection = new StreamableHttpMcpConnection(id, serverConfig.clientLogging().defaultLevel(),
                     serverConfig.trafficLogging().enabled() ? new TrafficLogger(serverConfig.trafficLogging().textLimit())
                             : null,

--- a/transports/sse/runtime/src/main/java/io/quarkiverse/mcp/server/sse/runtime/config/McpSseServerBuildTimeConfig.java
+++ b/transports/sse/runtime/src/main/java/io/quarkiverse/mcp/server/sse/runtime/config/McpSseServerBuildTimeConfig.java
@@ -1,20 +1,43 @@
 package io.quarkiverse.mcp.server.sse.runtime.config;
 
 import io.smallrye.config.WithDefault;
-import io.smallrye.config.WithName;
 
 public interface McpSseServerBuildTimeConfig {
 
     /**
-     * The MCP endpoint (as defined in the specification `2025-03-26`) is exposed at `\{rootPath}`. By default, it's `/mcp`.
-     *
-     * The SSE endpoint (as defined in the specification `2024-11-05`) is exposed at `\{rootPath}/sse`. By default, it's
-     * `/mcp/sse`.
-     *
-     * @asciidoclet
+     * HTTP/SSE configuration.
      */
-    @WithName("sse.root-path")
-    @WithDefault("/mcp")
-    String rootPath();
+    Sse sse();
+
+    public interface Sse {
+
+        /**
+         * The MCP endpoint (as defined in the specification `2025-03-26`) is exposed at `\{rootPath}`. By default, it's `/mcp`.
+         *
+         * The SSE endpoint (as defined in the specification `2024-11-05`) is exposed at `\{rootPath}/sse`. By default, it's
+         * `/mcp/sse`.
+         *
+         * @asciidoclet
+         */
+        @WithDefault("/mcp")
+        String rootPath();
+
+        /**
+         * The SSE endpoint (as defined in the specification `2024-11-05`) sends a message endpoint as the first event to
+         * the client. And the client should use this endpoint for all subsequent requests.
+         */
+        MessageEndpoint messageEndpoint();
+
+        public interface MessageEndpoint {
+
+            /**
+             * If set to true then the query params from the initial HTTP request should be included in the message endpoint.
+             */
+            @WithDefault("false")
+            boolean includeQueryParams();
+
+        }
+
+    }
 
 }

--- a/transports/sse/runtime/src/main/java/io/quarkiverse/mcp/server/sse/runtime/devui/SseMcpJsonRPCService.java
+++ b/transports/sse/runtime/src/main/java/io/quarkiverse/mcp/server/sse/runtime/devui/SseMcpJsonRPCService.java
@@ -85,8 +85,8 @@ public class SseMcpJsonRPCService {
                     .append(":")
                     .append(port)
                     .append(rootPath)
-                    .append(pathToAppend(rootPath, e.getValue().rootPath()))
-                    .append(pathToAppend(e.getValue().rootPath(), "sse")).toString()),
+                    .append(pathToAppend(rootPath, e.getValue().sse().rootPath()))
+                    .append(pathToAppend(e.getValue().sse().rootPath(), "sse")).toString()),
                     HttpClient.newBuilder()
                             .connectTimeout(Duration.ofSeconds(10))
                             .build()));


### PR DESCRIPTION
- with `quarkus.mcp.server.sse.message-endpoint.include-query-params=true`
- resolves #287