### PR TITLE
Issue 289 - Add support for annotation-based schema generation for nested tool argument classes

### DIFF
--- a/core/deployment/pom.xml
+++ b/core/deployment/pom.xml
@@ -25,7 +25,7 @@
             <artifactId>quarkus-mcp-server-core</artifactId>
             <version>${project.version}</version>
         </dependency>
-        
+
         <!-- Test dependencies -->
         <dependency>
             <groupId>io.quarkus</groupId>

--- a/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/JsonSchemaGeneratorProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/JsonSchemaGeneratorProcessor.java
@@ -1,0 +1,44 @@
+package io.quarkiverse.mcp.server.deployment;
+
+import io.quarkiverse.mcp.server.runtime.SchemaGeneratorConfigCustomizerJackson;
+import io.quarkiverse.mcp.server.runtime.SchemaGeneratorConfigCustomizerJakartaValidation;
+import io.quarkiverse.mcp.server.runtime.SchemaGeneratorConfigCustomizerSwagger2;
+import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
+import io.quarkus.bootstrap.model.ApplicationModel;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.pkg.builditem.CurateOutcomeBuildItem;
+
+public class JsonSchemaGeneratorProcessor {
+
+    public static final String MODULE_JACKSON = "jsonschema-module-jackson";
+    public static final String MODULE_JAKARTA_VALIDATION = "jsonschema-module-jakarta-validation";
+    public static final String MODULE_SWAGGER_2 = "jsonschema-module-swagger-2";
+    public static final String VICTOOLS_GROUP_ID = "com.github.victools";
+
+    @BuildStep
+    void provideSchemaGeneratorAndOptionalModules(CurateOutcomeBuildItem curateOutcomeBuildItem,
+            BuildProducer<AdditionalBeanBuildItem> additionalBeanProducer) {
+        var appModel = curateOutcomeBuildItem.getApplicationModel();
+
+        if (isDependencyPresent(appModel, MODULE_JACKSON)) {
+            additionalBeanProducer.produce(new AdditionalBeanBuildItem(SchemaGeneratorConfigCustomizerJackson.class));
+        }
+
+        if (isDependencyPresent(appModel, MODULE_JAKARTA_VALIDATION)) {
+            additionalBeanProducer
+                    .produce(new AdditionalBeanBuildItem(SchemaGeneratorConfigCustomizerJakartaValidation.class));
+        }
+
+        if (isDependencyPresent(appModel, MODULE_SWAGGER_2)) {
+            additionalBeanProducer.produce(new AdditionalBeanBuildItem(SchemaGeneratorConfigCustomizerSwagger2.class));
+        }
+    }
+
+    private boolean isDependencyPresent(ApplicationModel applicationModel, String artifactId) {
+        return applicationModel.getRuntimeDependencies()
+                .stream()
+                .anyMatch(dependency -> VICTOOLS_GROUP_ID.equals(dependency.getGroupId()) &&
+                        artifactId.equals(dependency.getArtifactId()));
+    }
+}

--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -29,10 +29,39 @@
             <artifactId>jsonschema-generator</artifactId>
             <version>${jsonschema-generator.version}</version>
         </dependency>
+        <dependency>
+            <groupId>com.github.victools</groupId>
+            <artifactId>jsonschema-module-jackson</artifactId>
+            <version>${jsonschema-generator.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.github.victools</groupId>
+            <artifactId>jsonschema-module-jakarta-validation</artifactId>
+            <version>${jsonschema-generator.version}</version>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.github.victools</groupId>
+            <artifactId>jsonschema-module-swagger-2</artifactId>
+            <version>${jsonschema-generator.version}</version>
+            <optional>true</optional>
+        </dependency>
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-annotations</artifactId>
+            <version>${swagger-annotations.version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/SchemaGeneratorConfigCustomizer.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/SchemaGeneratorConfigCustomizer.java
@@ -1,0 +1,20 @@
+package io.quarkiverse.mcp.server.runtime;
+
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
+
+/**
+ * An interface that allows customization of the {@link SchemaGeneratorConfigBuilder}
+ * before the {@link com.github.victools.jsonschema.generator.SchemaGenerator} is built.
+ * <p>
+ * Implementations of this interface will be discovered and applied automatically.
+ */
+
+public interface SchemaGeneratorConfigCustomizer {
+
+    /**
+     * Customizes the given {@link SchemaGeneratorConfigBuilder}.
+     *
+     * @param builder the builder to customize
+     */
+    void customize(SchemaGeneratorConfigBuilder builder);
+}

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/SchemaGeneratorConfigCustomizerJackson.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/SchemaGeneratorConfigCustomizerJackson.java
@@ -1,0 +1,75 @@
+package io.quarkiverse.mcp.server.runtime;
+
+import java.util.ArrayList;
+
+import jakarta.enterprise.context.Dependent;
+
+import com.github.victools.jsonschema.generator.Module;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
+import com.github.victools.jsonschema.module.jackson.JacksonModule;
+import com.github.victools.jsonschema.module.jackson.JacksonOption;
+
+import io.quarkiverse.mcp.server.runtime.config.McpServerSchemaGeneratorJacksonRuntimeConfig;
+
+@Dependent
+public class SchemaGeneratorConfigCustomizerJackson implements SchemaGeneratorConfigCustomizer {
+
+    private final McpServerSchemaGeneratorJacksonRuntimeConfig config;
+
+    public SchemaGeneratorConfigCustomizerJackson(McpServerSchemaGeneratorJacksonRuntimeConfig config) {
+        this.config = config;
+    }
+
+    @Override
+    public void customize(SchemaGeneratorConfigBuilder builder) {
+        if (config.enabled()) {
+            var configuredOptions = getConfiguredOptions();
+            var jacksonModule = createJacksonModule(configuredOptions);
+            builder.with(jacksonModule);
+        }
+    }
+
+    Module createJacksonModule(JacksonOption[] options) {
+        return new JacksonModule(options);
+    }
+
+    private JacksonOption[] getConfiguredOptions() {
+        var options = new ArrayList<JacksonOption>();
+
+        if (config.respectJsonPropertyOrder()) {
+            options.add(JacksonOption.RESPECT_JSONPROPERTY_ORDER);
+        }
+        if (config.respectJsonPropertyRequired()) {
+            options.add(JacksonOption.RESPECT_JSONPROPERTY_REQUIRED);
+        }
+        if (config.flattenedEnumsFromJsonValue()) {
+            options.add(JacksonOption.FLATTENED_ENUMS_FROM_JSONVALUE);
+        }
+        if (config.flattenedEnumsFromJsonProperty()) {
+            options.add(JacksonOption.FLATTENED_ENUMS_FROM_JSONPROPERTY);
+        }
+        if (config.includeOnlyJsonPropertyAnnotatedMethods()) {
+            options.add(JacksonOption.INCLUDE_ONLY_JSONPROPERTY_ANNOTATED_METHODS);
+        }
+        if (config.ignorePropertyNamingStrategy()) {
+            options.add(JacksonOption.IGNORE_PROPERTY_NAMING_STRATEGY);
+        }
+        if (config.alwaysRefSubtypes()) {
+            options.add(JacksonOption.ALWAYS_REF_SUBTYPES);
+        }
+        if (config.inlineTransformedSubtypes()) {
+            options.add(JacksonOption.INLINE_TRANSFORMED_SUBTYPES);
+        }
+        if (config.skipSubtypeLookup()) {
+            options.add(JacksonOption.SKIP_SUBTYPE_LOOKUP);
+        }
+        if (config.ignoreTypeInfoTransform()) {
+            options.add(JacksonOption.IGNORE_TYPE_INFO_TRANSFORM);
+        }
+        if (config.jsonIdentityReferenceAlwaysAsId()) {
+            options.add(JacksonOption.JSONIDENTITY_REFERENCE_ALWAYS_AS_ID);
+        }
+
+        return options.toArray(JacksonOption[]::new);
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/SchemaGeneratorConfigCustomizerJakartaValidation.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/SchemaGeneratorConfigCustomizerJakartaValidation.java
@@ -1,0 +1,54 @@
+package io.quarkiverse.mcp.server.runtime;
+
+import java.util.ArrayList;
+
+import jakarta.enterprise.context.Dependent;
+
+import com.github.victools.jsonschema.generator.Module;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
+import com.github.victools.jsonschema.module.jakarta.validation.JakartaValidationModule;
+import com.github.victools.jsonschema.module.jakarta.validation.JakartaValidationOption;
+
+import io.quarkiverse.mcp.server.runtime.config.McpServerSchemaGeneratorJakartaValidationRuntimeConfig;
+
+@Dependent
+public class SchemaGeneratorConfigCustomizerJakartaValidation implements SchemaGeneratorConfigCustomizer {
+
+    private final McpServerSchemaGeneratorJakartaValidationRuntimeConfig config;
+
+    public SchemaGeneratorConfigCustomizerJakartaValidation(McpServerSchemaGeneratorJakartaValidationRuntimeConfig config) {
+        this.config = config;
+    }
+
+    @Override
+    public void customize(SchemaGeneratorConfigBuilder builder) {
+        if (config.enabled()) {
+            var configuredOptions = getConfiguredOptions();
+            var jakartaValidationModule = createJakartaValidationModule(configuredOptions);
+            builder.with(jakartaValidationModule);
+        }
+    }
+
+    Module createJakartaValidationModule(JakartaValidationOption[] options) {
+        return new JakartaValidationModule(options);
+    }
+
+    private JakartaValidationOption[] getConfiguredOptions() {
+        var options = new ArrayList<JakartaValidationOption>();
+
+        if (config.notNullableFieldIsRequired()) {
+            options.add(JakartaValidationOption.NOT_NULLABLE_FIELD_IS_REQUIRED);
+        }
+        if (config.notNullableMethodIsRequired()) {
+            options.add(JakartaValidationOption.NOT_NULLABLE_METHOD_IS_REQUIRED);
+        }
+        if (config.preferIdnEmailFormat()) {
+            options.add(JakartaValidationOption.PREFER_IDN_EMAIL_FORMAT);
+        }
+        if (config.includePatternExpressions()) {
+            options.add(JakartaValidationOption.INCLUDE_PATTERN_EXPRESSIONS);
+        }
+
+        return options.toArray(JakartaValidationOption[]::new);
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/SchemaGeneratorConfigCustomizerSwagger2.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/SchemaGeneratorConfigCustomizerSwagger2.java
@@ -1,0 +1,31 @@
+package io.quarkiverse.mcp.server.runtime;
+
+import jakarta.enterprise.context.Dependent;
+
+import com.github.victools.jsonschema.generator.Module;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
+import com.github.victools.jsonschema.module.swagger2.Swagger2Module;
+
+import io.quarkiverse.mcp.server.runtime.config.McpServerSchemaGeneratorSwagger2RuntimeConfig;
+
+@Dependent
+public class SchemaGeneratorConfigCustomizerSwagger2 implements SchemaGeneratorConfigCustomizer {
+
+    private final McpServerSchemaGeneratorSwagger2RuntimeConfig config;
+
+    public SchemaGeneratorConfigCustomizerSwagger2(McpServerSchemaGeneratorSwagger2RuntimeConfig config) {
+        this.config = config;
+    }
+
+    @Override
+    public void customize(SchemaGeneratorConfigBuilder builder) {
+        if (config.enabled()) {
+            var swagger2Module = createSwagger2Module();
+            builder.with(swagger2Module);
+        }
+    }
+
+    Module createSwagger2Module() {
+        return new Swagger2Module();
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/config/McpServerSchemaGeneratorJacksonRuntimeConfig.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/config/McpServerSchemaGeneratorJacksonRuntimeConfig.java
@@ -1,0 +1,127 @@
+package io.quarkiverse.mcp.server.runtime.config;
+
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+@ConfigMapping(prefix = "quarkus.mcp.server.schema-generator.jackson")
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+public interface McpServerSchemaGeneratorJacksonRuntimeConfig {
+
+    /**
+     * Whether to use the SchemaGenerator's Jackson Module.
+     * If this module is not present as a dependency, this module won't be enabled.
+     */
+    @WithDefault("true")
+    boolean enabled();
+
+    /**
+     * Corresponds to {@code JacksonOption.RESPECT_JSONPROPERTY_ORDER}.
+     * <p>
+     * If enabled, the order of properties in the generated schema will respect
+     * the order defined in a {@code @JsonPropertyOrder} annotation on a given type.
+     * </p>
+     */
+    @WithDefault("true")
+    boolean respectJsonPropertyOrder();
+
+    /**
+     * Corresponds to {@code JacksonOption.RESPECT_JSONPROPERTY_REQUIRED}.
+     * <p>
+     * If enabled, a property will be marked as "required" in the schema if its
+     * corresponding field or method is annotated with {@code @JsonProperty(required = true)}.
+     * </p>
+     */
+    @WithDefault("true")
+    boolean respectJsonPropertyRequired();
+
+    /**
+     * Corresponds to {@code JacksonOption.FLATTENED_ENUMS_FROM_JSONVALUE}.
+     * <p>
+     * If enabled, the schema for an enum will be a simple array of values (e.g., strings)
+     * derived from the method annotated with {@code @JsonValue}.
+     * </p>
+     */
+    @WithDefault("true")
+    boolean flattenedEnumsFromJsonValue();
+
+    /**
+     * Corresponds to {@code JacksonOption.FLATTENED_ENUMS_FROM_JSONPROPERTY}.
+     * <p>
+     * If enabled, the schema for an enum will be derived from {@code @JsonProperty}
+     * annotations on the enum's constants.
+     * </p>
+     */
+    @WithDefault("false")
+    boolean flattenedEnumsFromJsonProperty();
+
+    /**
+     * Corresponds to {@code JacksonOption.INCLUDE_ONLY_JSONPROPERTY_ANNOTATED_METHODS}.
+     * <p>
+     * If enabled, only methods explicitly annotated with {@code @JsonProperty} will be
+     * included in the schema.
+     * </p>
+     */
+    @WithDefault("false")
+    boolean includeOnlyJsonPropertyAnnotatedMethods();
+
+    /**
+     * Corresponds to {@code JacksonOption.IGNORE_PROPERTY_NAMING_STRATEGY}.
+     * <p>
+     * If enabled, any configured {@code PropertyNamingStrategy} (e.g., snake_case)
+     * will be ignored, and field names from the Java class will be used directly.
+     * </p>
+     */
+    @WithDefault("false")
+    boolean ignorePropertyNamingStrategy();
+
+    /**
+     * Corresponds to {@code JacksonOption.ALWAYS_REF_SUBTYPES}.
+     * <p>
+     * If enabled, subtypes in a polymorphic hierarchy will always be represented
+     * by a {@code $ref} to a definition, rather than being inlined.
+     * </p>
+     */
+    @WithDefault("false")
+    boolean alwaysRefSubtypes();
+
+    /**
+     * Corresponds to {@code JacksonOption.INLINE_TRANSFORMED_SUBTYPES}.
+     * <p>
+     * A specialized option for handling subtypes that have been transformed.
+     * </p>
+     */
+    @WithDefault("false")
+    boolean inlineTransformedSubtypes();
+
+    /**
+     * Corresponds to {@code JacksonOption.SKIP_SUBTYPE_LOOKUP}.
+     * <p>
+     * If enabled, subtype resolution via {@code @JsonSubTypes} will be disabled entirely.
+     * </p>
+     */
+    @WithDefault("false")
+    boolean skipSubtypeLookup();
+
+    /**
+     * Corresponds to {@code JacksonOption.IGNORE_TYPE_INFO_TRANSFORM}.
+     * <p>
+     * If enabled, the transformation of the schema based on a {@code @JsonTypeInfo}
+     * annotation will be skipped.
+     * </p>
+     */
+    @WithDefault("false")
+    boolean ignoreTypeInfoTransform();
+
+    /**
+     * Corresponds to {@code JacksonOption.JSONIDENTITY_REFERENCE_ALWAYS_AS_ID}.
+     * <p>
+     * If enabled, properties referencing an object that has an ID (via
+     * {@code @JsonIdentityInfo}) will be represented as a simple ID field,
+     * rather than a {@code $ref}.
+     * </p>
+     */
+    @WithDefault("false")
+    boolean jsonIdentityReferenceAlwaysAsId();
+}

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/config/McpServerSchemaGeneratorJakartaValidationRuntimeConfig.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/config/McpServerSchemaGeneratorJakartaValidationRuntimeConfig.java
@@ -1,0 +1,59 @@
+package io.quarkiverse.mcp.server.runtime.config;
+
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+@ConfigMapping(prefix = "quarkus.mcp.server.schema-generator.jakarta-validation")
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+public interface McpServerSchemaGeneratorJakartaValidationRuntimeConfig {
+
+    /**
+     * Whether to use the SchemaGenerator's Jakarta Validation Module.
+     * If this module is not present as a dependency, this module won't be enabled.
+     */
+    @WithDefault("true")
+    boolean enabled();
+
+    /**
+     * Corresponds to {@code JakartaValidationOption.NOT_NULLABLE_FIELD_IS_REQUIRED}.
+     * <p>
+     * If enabled, a field annotated with a "not-nullable" constraint (e.g., {@code @NotNull},
+     * {@code @NotEmpty}, {@code @NotBlank}) will be marked as "required" in the generated schema.
+     * </p>
+     */
+    @WithDefault("true")
+    boolean notNullableFieldIsRequired();
+
+    /**
+     * Corresponds to {@code JakartaValidationOption.NOT_NULLABLE_METHOD_IS_REQUIRED}.
+     * <p>
+     * If enabled, a method (typically a getter) annotated with a "not-nullable" constraint
+     * (e.g., {@code @NotNull}, {@code @NotEmpty}, {@code @NotBlank}) will be marked as
+     * "required" in the generated schema.
+     * </p>
+     */
+    @WithDefault("true")
+    boolean notNullableMethodIsRequired();
+
+    /**
+     * Corresponds to {@code JakartaValidationOption.PREFER_IDN_EMAIL_FORMAT}.
+     * <p>
+     * If enabled, for properties annotated with {@code @Email}, the schema will use
+     * the "idn-email" format instead of the standard "email" format.
+     * </p>
+     */
+    @WithDefault("false")
+    boolean preferIdnEmailFormat();
+
+    /**
+     * Corresponds to {@code JakartaValidationOption.INCLUDE_PATTERN_EXPRESSIONS}.
+     * <p>
+     * If enabled, for properties annotated with {@code @Pattern}, the regular
+     * expression will be included in the schema as a "pattern" attribute.
+     * </p>
+     */
+    @WithDefault("true")
+    boolean includePatternExpressions();
+}

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/config/McpServerSchemaGeneratorSwagger2RuntimeConfig.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/config/McpServerSchemaGeneratorSwagger2RuntimeConfig.java
@@ -1,0 +1,18 @@
+package io.quarkiverse.mcp.server.runtime.config;
+
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefault;
+
+@ConfigMapping(prefix = "quarkus.mcp.server.schema-generator.swagger2")
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
+public interface McpServerSchemaGeneratorSwagger2RuntimeConfig {
+
+    /**
+     * Whether to use the SchemaGenerator's Swagger 2 Module.
+     * If this module is not present as a dependency, this module won't be enabled.
+     */
+    @WithDefault("true")
+    boolean enabled();
+}

--- a/core/runtime/src/test/java/io/quarkiverse/mcp/server/runtime/SchemaGeneratorConfigCustomizerJacksonTest.java
+++ b/core/runtime/src/test/java/io/quarkiverse/mcp/server/runtime/SchemaGeneratorConfigCustomizerJacksonTest.java
@@ -1,0 +1,203 @@
+package io.quarkiverse.mcp.server.runtime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.github.victools.jsonschema.generator.Module;
+import com.github.victools.jsonschema.generator.Option;
+import com.github.victools.jsonschema.generator.OptionPreset;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
+import com.github.victools.jsonschema.generator.SchemaVersion;
+import com.github.victools.jsonschema.module.jackson.JacksonOption;
+
+import io.quarkiverse.mcp.server.runtime.config.McpServerSchemaGeneratorJacksonRuntimeConfig;
+
+class SchemaGeneratorConfigCustomizerJacksonTest {
+
+    @Test
+    void customize_disabled() {
+        // Given
+        var config = Config.createDisableConfig();
+        var customizer = new ConfigCustomizerSpy(config);
+
+        // When
+        customizer.customize(new SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_2020_12, OptionPreset.PLAIN_JSON)
+                .without(Option.SCHEMA_VERSION_INDICATOR));
+
+        // Then
+        assertFalse(customizer.isModuleCreated);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideConfigOptions")
+    void customize_enabled_with_options(Consumer<Config> configModifier, JacksonOption expectedJacksonOption) {
+        // Given
+        var config = Config.createEnabledConfig(configModifier);
+        var customizer = new ConfigCustomizerSpy(config);
+
+        // When
+        customizer.customize(new SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_2020_12, OptionPreset.PLAIN_JSON)
+                .without(Option.SCHEMA_VERSION_INDICATOR));
+
+        // Then
+        assertTrue(customizer.isModuleCreated);
+        assertArrayEquals(new JacksonOption[] { expectedJacksonOption }, customizer.configuredOptions);
+        assertTrue(customizer.module.applyCalled);
+    }
+
+    private static Stream<Arguments> provideConfigOptions() {
+        return Stream.of(
+                Arguments.of((Consumer<Config>) c -> c.respectJsonPropertyOrder = true,
+                        JacksonOption.RESPECT_JSONPROPERTY_ORDER),
+                Arguments.of((Consumer<Config>) c -> c.respectJsonPropertyRequired = true,
+                        JacksonOption.RESPECT_JSONPROPERTY_REQUIRED),
+                Arguments.of((Consumer<Config>) c -> c.flattenedEnumsFromJsonValue = true,
+                        JacksonOption.FLATTENED_ENUMS_FROM_JSONVALUE),
+                Arguments.of((Consumer<Config>) c -> c.flattenedEnumsFromJsonProperty = true,
+                        JacksonOption.FLATTENED_ENUMS_FROM_JSONPROPERTY),
+                Arguments.of((Consumer<Config>) c -> c.includeOnlyJsonPropertyAnnotatedMethods = true,
+                        JacksonOption.INCLUDE_ONLY_JSONPROPERTY_ANNOTATED_METHODS),
+                Arguments.of((Consumer<Config>) c -> c.ignorePropertyNamingStrategy = true,
+                        JacksonOption.IGNORE_PROPERTY_NAMING_STRATEGY),
+                Arguments.of((Consumer<Config>) c -> c.alwaysRefSubtypes = true,
+                        JacksonOption.ALWAYS_REF_SUBTYPES),
+                Arguments.of((Consumer<Config>) c -> c.inlineTransformedSubtypes = true,
+                        JacksonOption.INLINE_TRANSFORMED_SUBTYPES),
+                Arguments.of((Consumer<Config>) c -> c.skipSubtypeLookup = true,
+                        JacksonOption.SKIP_SUBTYPE_LOOKUP),
+                Arguments.of((Consumer<Config>) c -> c.ignoreTypeInfoTransform = true,
+                        JacksonOption.IGNORE_TYPE_INFO_TRANSFORM),
+                Arguments.of((Consumer<Config>) c -> c.jsonIdentityReferenceAlwaysAsId = true,
+                        JacksonOption.JSONIDENTITY_REFERENCE_ALWAYS_AS_ID));
+    }
+
+    private static class ConfigCustomizerSpy extends SchemaGeneratorConfigCustomizerJackson {
+
+        private boolean isModuleCreated;
+        private JacksonOption[] configuredOptions;
+        private ModuleSpy module;
+
+        public ConfigCustomizerSpy(McpServerSchemaGeneratorJacksonRuntimeConfig config) {
+            super(config);
+        }
+
+        @Override
+        Module createJacksonModule(JacksonOption[] options) {
+            this.isModuleCreated = true;
+            this.configuredOptions = options;
+            this.module = new ModuleSpy(super.createJacksonModule(options));
+            return this.module;
+        }
+    }
+
+    private static class ModuleSpy implements Module {
+        private final Module delegate;
+        boolean applyCalled;
+
+        public ModuleSpy(Module delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void applyToConfigBuilder(SchemaGeneratorConfigBuilder builder) {
+            applyCalled = true;
+            delegate.applyToConfigBuilder(builder);
+        }
+    }
+
+    private static class Config implements McpServerSchemaGeneratorJacksonRuntimeConfig {
+
+        boolean enabled;
+        boolean respectJsonPropertyOrder;
+        boolean respectJsonPropertyRequired;
+        boolean flattenedEnumsFromJsonValue;
+        boolean flattenedEnumsFromJsonProperty;
+        boolean includeOnlyJsonPropertyAnnotatedMethods;
+        boolean ignorePropertyNamingStrategy;
+        boolean alwaysRefSubtypes;
+        boolean inlineTransformedSubtypes;
+        boolean skipSubtypeLookup;
+        boolean ignoreTypeInfoTransform;
+        boolean jsonIdentityReferenceAlwaysAsId;
+
+        static Config createDisableConfig() {
+            var config = new Config();
+            config.enabled = false;
+            return config;
+        }
+
+        static Config createEnabledConfig(Consumer<Config> configModifier) {
+            var config = new Config();
+            config.enabled = true;
+            configModifier.accept(config);
+            return config;
+        }
+
+        @Override
+        public boolean enabled() {
+            return enabled;
+        }
+
+        @Override
+        public boolean respectJsonPropertyOrder() {
+            return respectJsonPropertyOrder;
+        }
+
+        @Override
+        public boolean respectJsonPropertyRequired() {
+            return respectJsonPropertyRequired;
+        }
+
+        @Override
+        public boolean flattenedEnumsFromJsonValue() {
+            return flattenedEnumsFromJsonValue;
+        }
+
+        @Override
+        public boolean flattenedEnumsFromJsonProperty() {
+            return flattenedEnumsFromJsonProperty;
+        }
+
+        @Override
+        public boolean includeOnlyJsonPropertyAnnotatedMethods() {
+            return includeOnlyJsonPropertyAnnotatedMethods;
+        }
+
+        @Override
+        public boolean ignorePropertyNamingStrategy() {
+            return ignorePropertyNamingStrategy;
+        }
+
+        @Override
+        public boolean alwaysRefSubtypes() {
+            return alwaysRefSubtypes;
+        }
+
+        @Override
+        public boolean inlineTransformedSubtypes() {
+            return inlineTransformedSubtypes;
+        }
+
+        @Override
+        public boolean skipSubtypeLookup() {
+            return skipSubtypeLookup;
+        }
+
+        @Override
+        public boolean ignoreTypeInfoTransform() {
+            return ignoreTypeInfoTransform;
+        }
+
+        @Override
+        public boolean jsonIdentityReferenceAlwaysAsId() {
+            return jsonIdentityReferenceAlwaysAsId;
+        }
+    }
+}

--- a/core/runtime/src/test/java/io/quarkiverse/mcp/server/runtime/SchemaGeneratorConfigCustomizerJakartaValidationTest.java
+++ b/core/runtime/src/test/java/io/quarkiverse/mcp/server/runtime/SchemaGeneratorConfigCustomizerJakartaValidationTest.java
@@ -1,0 +1,148 @@
+package io.quarkiverse.mcp.server.runtime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.function.Consumer;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.github.victools.jsonschema.generator.Module;
+import com.github.victools.jsonschema.generator.Option;
+import com.github.victools.jsonschema.generator.OptionPreset;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
+import com.github.victools.jsonschema.generator.SchemaVersion;
+import com.github.victools.jsonschema.module.jakarta.validation.JakartaValidationOption;
+
+import io.quarkiverse.mcp.server.runtime.config.McpServerSchemaGeneratorJakartaValidationRuntimeConfig;
+
+class SchemaGeneratorConfigCustomizerJakartaValidationTest {
+
+    @Test
+    void customize_disabled() {
+        // Given
+        var config = Config.createDisableConfig();
+        var customizer = new ConfigCustomizerSpy(config);
+
+        // When
+        customizer.customize(new SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_2020_12, OptionPreset.PLAIN_JSON)
+                .without(Option.SCHEMA_VERSION_INDICATOR));
+
+        // Then
+        assertFalse(customizer.isModuleCreated);
+    }
+
+    @ParameterizedTest
+    @MethodSource("provideConfigOptions")
+    void customize_enabled_with_options(Consumer<Config> configModifier,
+            JakartaValidationOption expectedJakartaValidationOption) {
+        // Given
+        var config = Config.createEnabledConfig(configModifier);
+        var customizer = new ConfigCustomizerSpy(config);
+
+        // When
+        customizer.customize(new SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_2020_12, OptionPreset.PLAIN_JSON)
+                .without(Option.SCHEMA_VERSION_INDICATOR));
+
+        // Then
+        assertTrue(customizer.isModuleCreated);
+        assertArrayEquals(new JakartaValidationOption[] { expectedJakartaValidationOption }, customizer.configuredOptions);
+        assertTrue(customizer.module.applyCalled);
+    }
+
+    private static Stream<Arguments> provideConfigOptions() {
+        return Stream.of(
+                Arguments.of((Consumer<Config>) c -> c.notNullableFieldIsRequired = true,
+                        JakartaValidationOption.NOT_NULLABLE_FIELD_IS_REQUIRED),
+                Arguments.of((Consumer<Config>) c -> c.notNullableMethodIsRequired = true,
+                        JakartaValidationOption.NOT_NULLABLE_METHOD_IS_REQUIRED),
+                Arguments.of((Consumer<Config>) c -> c.preferIdnEmailFormat = true,
+                        JakartaValidationOption.PREFER_IDN_EMAIL_FORMAT),
+                Arguments.of((Consumer<Config>) c -> c.includePatternExpressions = true,
+                        JakartaValidationOption.INCLUDE_PATTERN_EXPRESSIONS));
+    }
+
+    private static class ConfigCustomizerSpy extends SchemaGeneratorConfigCustomizerJakartaValidation {
+
+        private boolean isModuleCreated;
+        private JakartaValidationOption[] configuredOptions;
+        private ModuleSpy module;
+
+        public ConfigCustomizerSpy(McpServerSchemaGeneratorJakartaValidationRuntimeConfig config) {
+            super(config);
+        }
+
+        @Override
+        Module createJakartaValidationModule(JakartaValidationOption[] options) {
+            this.isModuleCreated = true;
+            this.configuredOptions = options;
+            this.module = new ModuleSpy(super.createJakartaValidationModule(options));
+            return this.module;
+        }
+    }
+
+    private static class ModuleSpy implements Module {
+        private final Module delegate;
+        boolean applyCalled;
+
+        public ModuleSpy(Module delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void applyToConfigBuilder(SchemaGeneratorConfigBuilder builder) {
+            applyCalled = true;
+            delegate.applyToConfigBuilder(builder);
+        }
+    }
+
+    private static class Config implements McpServerSchemaGeneratorJakartaValidationRuntimeConfig {
+
+        boolean enabled;
+        boolean notNullableFieldIsRequired;
+        boolean notNullableMethodIsRequired;
+        boolean preferIdnEmailFormat;
+        boolean includePatternExpressions;
+
+        static Config createDisableConfig() {
+            var config = new Config();
+            config.enabled = false;
+            return config;
+        }
+
+        static Config createEnabledConfig(Consumer<Config> configModifier) {
+            var config = new Config();
+            config.enabled = true;
+            configModifier.accept(config);
+            return config;
+        }
+
+        @Override
+        public boolean enabled() {
+            return enabled;
+        }
+
+        @Override
+        public boolean notNullableFieldIsRequired() {
+            return notNullableFieldIsRequired;
+        }
+
+        @Override
+        public boolean notNullableMethodIsRequired() {
+            return notNullableMethodIsRequired;
+        }
+
+        @Override
+        public boolean preferIdnEmailFormat() {
+            return preferIdnEmailFormat;
+        }
+
+        @Override
+        public boolean includePatternExpressions() {
+            return includePatternExpressions;
+        }
+    }
+}

--- a/core/runtime/src/test/java/io/quarkiverse/mcp/server/runtime/SchemaGeneratorConfigCustomizerSwagger2Test.java
+++ b/core/runtime/src/test/java/io/quarkiverse/mcp/server/runtime/SchemaGeneratorConfigCustomizerSwagger2Test.java
@@ -1,0 +1,99 @@
+package io.quarkiverse.mcp.server.runtime;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+import com.github.victools.jsonschema.generator.Module;
+import com.github.victools.jsonschema.generator.Option;
+import com.github.victools.jsonschema.generator.OptionPreset;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
+import com.github.victools.jsonschema.generator.SchemaVersion;
+
+import io.quarkiverse.mcp.server.runtime.config.McpServerSchemaGeneratorSwagger2RuntimeConfig;
+
+class SchemaGeneratorConfigCustomizerSwagger2Test {
+
+    @Test
+    void customize_disabled() {
+        // Given
+        var config = Config.createDisableConfig();
+        var customizer = new ConfigCustomizerSpy(config);
+
+        // When
+        customizer.customize(new SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_2020_12, OptionPreset.PLAIN_JSON)
+                .without(Option.SCHEMA_VERSION_INDICATOR));
+
+        // Then
+        assertFalse(customizer.isModuleCreated);
+    }
+
+    @Test
+    void customize_enabled() {
+        // Given
+        var config = Config.createEnabledConfig();
+        var customizer = new ConfigCustomizerSpy(config);
+
+        // When
+        customizer.customize(new SchemaGeneratorConfigBuilder(SchemaVersion.DRAFT_2020_12, OptionPreset.PLAIN_JSON)
+                .without(Option.SCHEMA_VERSION_INDICATOR));
+
+        // Then
+        assertTrue(customizer.isModuleCreated);
+        assertTrue(customizer.module.applyCalled);
+    }
+
+    private static class ConfigCustomizerSpy extends SchemaGeneratorConfigCustomizerSwagger2 {
+
+        private boolean isModuleCreated;
+        private ModuleSpy module;
+
+        public ConfigCustomizerSpy(McpServerSchemaGeneratorSwagger2RuntimeConfig config) {
+            super(config);
+        }
+
+        @Override
+        Module createSwagger2Module() {
+            this.isModuleCreated = true;
+            this.module = new ModuleSpy(super.createSwagger2Module());
+            return this.module;
+        }
+    }
+
+    private static class ModuleSpy implements Module {
+        private final Module delegate;
+        boolean applyCalled;
+
+        public ModuleSpy(Module delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public void applyToConfigBuilder(SchemaGeneratorConfigBuilder builder) {
+            applyCalled = true;
+            delegate.applyToConfigBuilder(builder);
+        }
+    }
+
+    private static class Config implements McpServerSchemaGeneratorSwagger2RuntimeConfig {
+
+        boolean enabled;
+
+        static Config createDisableConfig() {
+            var config = new Config();
+            config.enabled = false;
+            return config;
+        }
+
+        static Config createEnabledConfig() {
+            var config = new Config();
+            config.enabled = true;
+            return config;
+        }
+
+        @Override
+        public boolean enabled() {
+            return enabled;
+        }
+    }
+}

--- a/docs/modules/ROOT/pages/includes/quarkus-mcp-server-core.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-mcp-server-core.adoc
@@ -7,6 +7,435 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-invalid-server-name-strategy]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-invalid-server-name-strategy[`quarkus.mcp.server.invalid-server-name-strategy`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.invalid-server-name-strategy+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The strategy used when server features, such as tools, prompts, and resources, reference an non-existent server name.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_INVALID_SERVER_NAME_STRATEGY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_INVALID_SERVER_NAME_STRATEGY+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`fail`, `ignore`
+|`fail`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-enabled]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-enabled[`quarkus.mcp.server.schema-generator.jackson.enabled`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.schema-generator.jackson.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to use the SchemaGenerator's Jackson Module. If this module is not present as a dependency, this module won't be enabled.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-respect-json-property-order]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-respect-json-property-order[`quarkus.mcp.server.schema-generator.jackson.respect-json-property-order`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.schema-generator.jackson.respect-json-property-order+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Corresponds to `JacksonOption.RESPECT_JSONPROPERTY_ORDER`.
+
+If enabled, the order of properties in the generated schema will respect the order defined in a `@JsonPropertyOrder` annotation on a given type.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_RESPECT_JSON_PROPERTY_ORDER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_RESPECT_JSON_PROPERTY_ORDER+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-respect-json-property-required]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-respect-json-property-required[`quarkus.mcp.server.schema-generator.jackson.respect-json-property-required`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.schema-generator.jackson.respect-json-property-required+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Corresponds to `JacksonOption.RESPECT_JSONPROPERTY_REQUIRED`.
+
+If enabled, a property will be marked as "required" in the schema if its corresponding field or method is annotated with `@JsonProperty(required = true)`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_RESPECT_JSON_PROPERTY_REQUIRED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_RESPECT_JSON_PROPERTY_REQUIRED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-flattened-enums-from-json-value]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-flattened-enums-from-json-value[`quarkus.mcp.server.schema-generator.jackson.flattened-enums-from-json-value`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.schema-generator.jackson.flattened-enums-from-json-value+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Corresponds to `JacksonOption.FLATTENED_ENUMS_FROM_JSONVALUE`.
+
+If enabled, the schema for an enum will be a simple array of values (e.g., strings) derived from the method annotated with `@JsonValue`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_FLATTENED_ENUMS_FROM_JSON_VALUE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_FLATTENED_ENUMS_FROM_JSON_VALUE+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-flattened-enums-from-json-property]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-flattened-enums-from-json-property[`quarkus.mcp.server.schema-generator.jackson.flattened-enums-from-json-property`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.schema-generator.jackson.flattened-enums-from-json-property+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Corresponds to `JacksonOption.FLATTENED_ENUMS_FROM_JSONPROPERTY`.
+
+If enabled, the schema for an enum will be derived from `@JsonProperty` annotations on the enum's constants.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_FLATTENED_ENUMS_FROM_JSON_PROPERTY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_FLATTENED_ENUMS_FROM_JSON_PROPERTY+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`false`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-include-only-json-property-annotated-methods]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-include-only-json-property-annotated-methods[`quarkus.mcp.server.schema-generator.jackson.include-only-json-property-annotated-methods`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.schema-generator.jackson.include-only-json-property-annotated-methods+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Corresponds to `JacksonOption.INCLUDE_ONLY_JSONPROPERTY_ANNOTATED_METHODS`.
+
+If enabled, only methods explicitly annotated with `@JsonProperty` will be included in the schema.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_INCLUDE_ONLY_JSON_PROPERTY_ANNOTATED_METHODS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_INCLUDE_ONLY_JSON_PROPERTY_ANNOTATED_METHODS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`false`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-ignore-property-naming-strategy]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-ignore-property-naming-strategy[`quarkus.mcp.server.schema-generator.jackson.ignore-property-naming-strategy`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.schema-generator.jackson.ignore-property-naming-strategy+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Corresponds to `JacksonOption.IGNORE_PROPERTY_NAMING_STRATEGY`.
+
+If enabled, any configured `PropertyNamingStrategy` (e.g., snake_case) will be ignored, and field names from the Java class will be used directly.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_IGNORE_PROPERTY_NAMING_STRATEGY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_IGNORE_PROPERTY_NAMING_STRATEGY+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`false`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-always-ref-subtypes]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-always-ref-subtypes[`quarkus.mcp.server.schema-generator.jackson.always-ref-subtypes`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.schema-generator.jackson.always-ref-subtypes+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Corresponds to `JacksonOption.ALWAYS_REF_SUBTYPES`.
+
+If enabled, subtypes in a polymorphic hierarchy will always be represented by a `$ref` to a definition, rather than being inlined.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_ALWAYS_REF_SUBTYPES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_ALWAYS_REF_SUBTYPES+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`false`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-inline-transformed-subtypes]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-inline-transformed-subtypes[`quarkus.mcp.server.schema-generator.jackson.inline-transformed-subtypes`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.schema-generator.jackson.inline-transformed-subtypes+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Corresponds to `JacksonOption.INLINE_TRANSFORMED_SUBTYPES`.
+
+A specialized option for handling subtypes that have been transformed.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_INLINE_TRANSFORMED_SUBTYPES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_INLINE_TRANSFORMED_SUBTYPES+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`false`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-skip-subtype-lookup]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-skip-subtype-lookup[`quarkus.mcp.server.schema-generator.jackson.skip-subtype-lookup`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.schema-generator.jackson.skip-subtype-lookup+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Corresponds to `JacksonOption.SKIP_SUBTYPE_LOOKUP`.
+
+If enabled, subtype resolution via `@JsonSubTypes` will be disabled entirely.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_SKIP_SUBTYPE_LOOKUP+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_SKIP_SUBTYPE_LOOKUP+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`false`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-ignore-type-info-transform]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-ignore-type-info-transform[`quarkus.mcp.server.schema-generator.jackson.ignore-type-info-transform`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.schema-generator.jackson.ignore-type-info-transform+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Corresponds to `JacksonOption.IGNORE_TYPE_INFO_TRANSFORM`.
+
+If enabled, the transformation of the schema based on a `@JsonTypeInfo` annotation will be skipped.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_IGNORE_TYPE_INFO_TRANSFORM+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_IGNORE_TYPE_INFO_TRANSFORM+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`false`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-json-identity-reference-always-as-id]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-json-identity-reference-always-as-id[`quarkus.mcp.server.schema-generator.jackson.json-identity-reference-always-as-id`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.schema-generator.jackson.json-identity-reference-always-as-id+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Corresponds to `JacksonOption.JSONIDENTITY_REFERENCE_ALWAYS_AS_ID`.
+
+If enabled, properties referencing an object that has an ID (via `@JsonIdentityInfo`) will be represented as a simple ID field, rather than a `$ref`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_JSON_IDENTITY_REFERENCE_ALWAYS_AS_ID+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_JSON_IDENTITY_REFERENCE_ALWAYS_AS_ID+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`false`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-swagger2-enabled]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-swagger2-enabled[`quarkus.mcp.server.schema-generator.swagger2.enabled`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.schema-generator.swagger2.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to use the SchemaGenerator's Swagger 2 Module. If this module is not present as a dependency, this module won't be enabled.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_SWAGGER2_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_SWAGGER2_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jakarta-validation-enabled]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jakarta-validation-enabled[`quarkus.mcp.server.schema-generator.jakarta-validation.enabled`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.schema-generator.jakarta-validation.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to use the SchemaGenerator's Jakarta Validation Module. If this module is not present as a dependency, this module won't be enabled.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JAKARTA_VALIDATION_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JAKARTA_VALIDATION_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jakarta-validation-not-nullable-field-is-required]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jakarta-validation-not-nullable-field-is-required[`quarkus.mcp.server.schema-generator.jakarta-validation.not-nullable-field-is-required`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.schema-generator.jakarta-validation.not-nullable-field-is-required+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Corresponds to `JakartaValidationOption.NOT_NULLABLE_FIELD_IS_REQUIRED`.
+
+If enabled, a field annotated with a "not-nullable" constraint (e.g., `@NotNull`, `@NotEmpty`, `@NotBlank`) will be marked as "required" in the generated schema.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JAKARTA_VALIDATION_NOT_NULLABLE_FIELD_IS_REQUIRED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JAKARTA_VALIDATION_NOT_NULLABLE_FIELD_IS_REQUIRED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jakarta-validation-not-nullable-method-is-required]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jakarta-validation-not-nullable-method-is-required[`quarkus.mcp.server.schema-generator.jakarta-validation.not-nullable-method-is-required`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.schema-generator.jakarta-validation.not-nullable-method-is-required+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Corresponds to `JakartaValidationOption.NOT_NULLABLE_METHOD_IS_REQUIRED`.
+
+If enabled, a method (typically a getter) annotated with a "not-nullable" constraint (e.g., `@NotNull`, `@NotEmpty`, `@NotBlank`) will be marked as "required" in the generated schema.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JAKARTA_VALIDATION_NOT_NULLABLE_METHOD_IS_REQUIRED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JAKARTA_VALIDATION_NOT_NULLABLE_METHOD_IS_REQUIRED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jakarta-validation-prefer-idn-email-format]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jakarta-validation-prefer-idn-email-format[`quarkus.mcp.server.schema-generator.jakarta-validation.prefer-idn-email-format`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.schema-generator.jakarta-validation.prefer-idn-email-format+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Corresponds to `JakartaValidationOption.PREFER_IDN_EMAIL_FORMAT`.
+
+If enabled, for properties annotated with `@Email`, the schema will use the "idn-email" format instead of the standard "email" format.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JAKARTA_VALIDATION_PREFER_IDN_EMAIL_FORMAT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JAKARTA_VALIDATION_PREFER_IDN_EMAIL_FORMAT+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`false`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jakarta-validation-include-pattern-expressions]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jakarta-validation-include-pattern-expressions[`quarkus.mcp.server.schema-generator.jakarta-validation.include-pattern-expressions`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.schema-generator.jakarta-validation.include-pattern-expressions+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Corresponds to `JakartaValidationOption.INCLUDE_PATTERN_EXPRESSIONS`.
+
+If enabled, for properties annotated with `@Pattern`, the regular expression will be included in the schema as a "pattern" attribute.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JAKARTA_VALIDATION_INCLUDE_PATTERN_EXPRESSIONS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JAKARTA_VALIDATION_INCLUDE_PATTERN_EXPRESSIONS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
 a| [[quarkus-mcp-server-core_quarkus-mcp-server-server-info-name]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-server-info-name[`quarkus.mcp.server.server-info.name`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.mcp.server.server-info.name+++[]
@@ -377,27 +806,6 @@ endif::add-copy-button-to-env-var[]
 --
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-mcp-server-core_quarkus-mcp[icon:question-circle[title=More information about the Duration format]]
 |`30M`
-
-a| [[quarkus-mcp-server-core_quarkus-mcp-server-invalid-server-name-strategy]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-invalid-server-name-strategy[`quarkus.mcp.server.invalid-server-name-strategy`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.mcp.server.invalid-server-name-strategy+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-The strategy used when server features, such as tools, prompts, and resources, reference an non-existent server name.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_INVALID_SERVER_NAME_STRATEGY+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_MCP_SERVER_INVALID_SERVER_NAME_STRATEGY+++`
-endif::add-copy-button-to-env-var[]
---
-a|`fail`, `ignore`
-|`fail`
 
 |===
 

--- a/docs/modules/ROOT/pages/includes/quarkus-mcp-server-core_quarkus.mcp.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-mcp-server-core_quarkus.mcp.adoc
@@ -7,6 +7,435 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-invalid-server-name-strategy]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-invalid-server-name-strategy[`quarkus.mcp.server.invalid-server-name-strategy`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.invalid-server-name-strategy+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The strategy used when server features, such as tools, prompts, and resources, reference an non-existent server name.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_INVALID_SERVER_NAME_STRATEGY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_INVALID_SERVER_NAME_STRATEGY+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`fail`, `ignore`
+|`fail`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-enabled]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-enabled[`quarkus.mcp.server.schema-generator.jackson.enabled`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.schema-generator.jackson.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to use the SchemaGenerator's Jackson Module. If this module is not present as a dependency, this module won't be enabled.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-respect-json-property-order]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-respect-json-property-order[`quarkus.mcp.server.schema-generator.jackson.respect-json-property-order`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.schema-generator.jackson.respect-json-property-order+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Corresponds to `JacksonOption.RESPECT_JSONPROPERTY_ORDER`.
+
+If enabled, the order of properties in the generated schema will respect the order defined in a `@JsonPropertyOrder` annotation on a given type.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_RESPECT_JSON_PROPERTY_ORDER+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_RESPECT_JSON_PROPERTY_ORDER+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-respect-json-property-required]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-respect-json-property-required[`quarkus.mcp.server.schema-generator.jackson.respect-json-property-required`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.schema-generator.jackson.respect-json-property-required+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Corresponds to `JacksonOption.RESPECT_JSONPROPERTY_REQUIRED`.
+
+If enabled, a property will be marked as "required" in the schema if its corresponding field or method is annotated with `@JsonProperty(required = true)`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_RESPECT_JSON_PROPERTY_REQUIRED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_RESPECT_JSON_PROPERTY_REQUIRED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-flattened-enums-from-json-value]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-flattened-enums-from-json-value[`quarkus.mcp.server.schema-generator.jackson.flattened-enums-from-json-value`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.schema-generator.jackson.flattened-enums-from-json-value+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Corresponds to `JacksonOption.FLATTENED_ENUMS_FROM_JSONVALUE`.
+
+If enabled, the schema for an enum will be a simple array of values (e.g., strings) derived from the method annotated with `@JsonValue`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_FLATTENED_ENUMS_FROM_JSON_VALUE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_FLATTENED_ENUMS_FROM_JSON_VALUE+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-flattened-enums-from-json-property]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-flattened-enums-from-json-property[`quarkus.mcp.server.schema-generator.jackson.flattened-enums-from-json-property`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.schema-generator.jackson.flattened-enums-from-json-property+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Corresponds to `JacksonOption.FLATTENED_ENUMS_FROM_JSONPROPERTY`.
+
+If enabled, the schema for an enum will be derived from `@JsonProperty` annotations on the enum's constants.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_FLATTENED_ENUMS_FROM_JSON_PROPERTY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_FLATTENED_ENUMS_FROM_JSON_PROPERTY+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`false`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-include-only-json-property-annotated-methods]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-include-only-json-property-annotated-methods[`quarkus.mcp.server.schema-generator.jackson.include-only-json-property-annotated-methods`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.schema-generator.jackson.include-only-json-property-annotated-methods+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Corresponds to `JacksonOption.INCLUDE_ONLY_JSONPROPERTY_ANNOTATED_METHODS`.
+
+If enabled, only methods explicitly annotated with `@JsonProperty` will be included in the schema.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_INCLUDE_ONLY_JSON_PROPERTY_ANNOTATED_METHODS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_INCLUDE_ONLY_JSON_PROPERTY_ANNOTATED_METHODS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`false`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-ignore-property-naming-strategy]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-ignore-property-naming-strategy[`quarkus.mcp.server.schema-generator.jackson.ignore-property-naming-strategy`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.schema-generator.jackson.ignore-property-naming-strategy+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Corresponds to `JacksonOption.IGNORE_PROPERTY_NAMING_STRATEGY`.
+
+If enabled, any configured `PropertyNamingStrategy` (e.g., snake_case) will be ignored, and field names from the Java class will be used directly.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_IGNORE_PROPERTY_NAMING_STRATEGY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_IGNORE_PROPERTY_NAMING_STRATEGY+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`false`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-always-ref-subtypes]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-always-ref-subtypes[`quarkus.mcp.server.schema-generator.jackson.always-ref-subtypes`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.schema-generator.jackson.always-ref-subtypes+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Corresponds to `JacksonOption.ALWAYS_REF_SUBTYPES`.
+
+If enabled, subtypes in a polymorphic hierarchy will always be represented by a `$ref` to a definition, rather than being inlined.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_ALWAYS_REF_SUBTYPES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_ALWAYS_REF_SUBTYPES+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`false`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-inline-transformed-subtypes]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-inline-transformed-subtypes[`quarkus.mcp.server.schema-generator.jackson.inline-transformed-subtypes`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.schema-generator.jackson.inline-transformed-subtypes+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Corresponds to `JacksonOption.INLINE_TRANSFORMED_SUBTYPES`.
+
+A specialized option for handling subtypes that have been transformed.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_INLINE_TRANSFORMED_SUBTYPES+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_INLINE_TRANSFORMED_SUBTYPES+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`false`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-skip-subtype-lookup]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-skip-subtype-lookup[`quarkus.mcp.server.schema-generator.jackson.skip-subtype-lookup`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.schema-generator.jackson.skip-subtype-lookup+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Corresponds to `JacksonOption.SKIP_SUBTYPE_LOOKUP`.
+
+If enabled, subtype resolution via `@JsonSubTypes` will be disabled entirely.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_SKIP_SUBTYPE_LOOKUP+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_SKIP_SUBTYPE_LOOKUP+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`false`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-ignore-type-info-transform]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-ignore-type-info-transform[`quarkus.mcp.server.schema-generator.jackson.ignore-type-info-transform`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.schema-generator.jackson.ignore-type-info-transform+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Corresponds to `JacksonOption.IGNORE_TYPE_INFO_TRANSFORM`.
+
+If enabled, the transformation of the schema based on a `@JsonTypeInfo` annotation will be skipped.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_IGNORE_TYPE_INFO_TRANSFORM+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_IGNORE_TYPE_INFO_TRANSFORM+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`false`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-json-identity-reference-always-as-id]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-json-identity-reference-always-as-id[`quarkus.mcp.server.schema-generator.jackson.json-identity-reference-always-as-id`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.schema-generator.jackson.json-identity-reference-always-as-id+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Corresponds to `JacksonOption.JSONIDENTITY_REFERENCE_ALWAYS_AS_ID`.
+
+If enabled, properties referencing an object that has an ID (via `@JsonIdentityInfo`) will be represented as a simple ID field, rather than a `$ref`.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_JSON_IDENTITY_REFERENCE_ALWAYS_AS_ID+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JACKSON_JSON_IDENTITY_REFERENCE_ALWAYS_AS_ID+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`false`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-swagger2-enabled]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-swagger2-enabled[`quarkus.mcp.server.schema-generator.swagger2.enabled`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.schema-generator.swagger2.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to use the SchemaGenerator's Swagger 2 Module. If this module is not present as a dependency, this module won't be enabled.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_SWAGGER2_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_SWAGGER2_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jakarta-validation-enabled]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jakarta-validation-enabled[`quarkus.mcp.server.schema-generator.jakarta-validation.enabled`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.schema-generator.jakarta-validation.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Whether to use the SchemaGenerator's Jakarta Validation Module. If this module is not present as a dependency, this module won't be enabled.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JAKARTA_VALIDATION_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JAKARTA_VALIDATION_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jakarta-validation-not-nullable-field-is-required]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jakarta-validation-not-nullable-field-is-required[`quarkus.mcp.server.schema-generator.jakarta-validation.not-nullable-field-is-required`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.schema-generator.jakarta-validation.not-nullable-field-is-required+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Corresponds to `JakartaValidationOption.NOT_NULLABLE_FIELD_IS_REQUIRED`.
+
+If enabled, a field annotated with a "not-nullable" constraint (e.g., `@NotNull`, `@NotEmpty`, `@NotBlank`) will be marked as "required" in the generated schema.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JAKARTA_VALIDATION_NOT_NULLABLE_FIELD_IS_REQUIRED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JAKARTA_VALIDATION_NOT_NULLABLE_FIELD_IS_REQUIRED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jakarta-validation-not-nullable-method-is-required]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jakarta-validation-not-nullable-method-is-required[`quarkus.mcp.server.schema-generator.jakarta-validation.not-nullable-method-is-required`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.schema-generator.jakarta-validation.not-nullable-method-is-required+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Corresponds to `JakartaValidationOption.NOT_NULLABLE_METHOD_IS_REQUIRED`.
+
+If enabled, a method (typically a getter) annotated with a "not-nullable" constraint (e.g., `@NotNull`, `@NotEmpty`, `@NotBlank`) will be marked as "required" in the generated schema.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JAKARTA_VALIDATION_NOT_NULLABLE_METHOD_IS_REQUIRED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JAKARTA_VALIDATION_NOT_NULLABLE_METHOD_IS_REQUIRED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jakarta-validation-prefer-idn-email-format]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jakarta-validation-prefer-idn-email-format[`quarkus.mcp.server.schema-generator.jakarta-validation.prefer-idn-email-format`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.schema-generator.jakarta-validation.prefer-idn-email-format+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Corresponds to `JakartaValidationOption.PREFER_IDN_EMAIL_FORMAT`.
+
+If enabled, for properties annotated with `@Email`, the schema will use the "idn-email" format instead of the standard "email" format.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JAKARTA_VALIDATION_PREFER_IDN_EMAIL_FORMAT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JAKARTA_VALIDATION_PREFER_IDN_EMAIL_FORMAT+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`false`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jakarta-validation-include-pattern-expressions]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jakarta-validation-include-pattern-expressions[`quarkus.mcp.server.schema-generator.jakarta-validation.include-pattern-expressions`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.schema-generator.jakarta-validation.include-pattern-expressions+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+Corresponds to `JakartaValidationOption.INCLUDE_PATTERN_EXPRESSIONS`.
+
+If enabled, for properties annotated with `@Pattern`, the regular expression will be included in the schema as a "pattern" attribute.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JAKARTA_VALIDATION_INCLUDE_PATTERN_EXPRESSIONS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_SCHEMA_GENERATOR_JAKARTA_VALIDATION_INCLUDE_PATTERN_EXPRESSIONS+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`true`
+
 a| [[quarkus-mcp-server-core_quarkus-mcp-server-server-info-name]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-server-info-name[`quarkus.mcp.server.server-info.name`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.mcp.server.server-info.name+++[]
@@ -377,27 +806,6 @@ endif::add-copy-button-to-env-var[]
 --
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-mcp-server-core_quarkus-mcp[icon:question-circle[title=More information about the Duration format]]
 |`30M`
-
-a| [[quarkus-mcp-server-core_quarkus-mcp-server-invalid-server-name-strategy]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-invalid-server-name-strategy[`quarkus.mcp.server.invalid-server-name-strategy`]##
-ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.mcp.server.invalid-server-name-strategy+++[]
-endif::add-copy-button-to-config-props[]
-
-
-[.description]
---
-The strategy used when server features, such as tools, prompts, and resources, reference an non-existent server name.
-
-
-ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_INVALID_SERVER_NAME_STRATEGY+++[]
-endif::add-copy-button-to-env-var[]
-ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_MCP_SERVER_INVALID_SERVER_NAME_STRATEGY+++`
-endif::add-copy-button-to-env-var[]
---
-a|`fail`, `ignore`
-|`fail`
 
 |===
 

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -562,6 +562,15 @@ The `@dev.langchain4j.agent.tool.Tool` and `@dev.langchain4j.agent.tool.P` annot
 However, keep in mind that semantics may vary and follows the rules defined in this documentation.
 For example, `void` methods are not supported.
 
+=== Customizing JSON Schema Generation
+
+The MCP server uses the `com.github.victools:jsonschema-generator` library to generate JSON schemas for tool inputs.
+This library is configurable through modules that process various annotations (e.g., Jackson, Bean Validation) to enrich the generated schemas.
+
+By defining a dependency on `com.github.victools:jsonschema-module-jackson`, the schema generator server will be automatically configured to use the Jackson module.
+The same goes for `com.github.victools:jsonschema-module-jakarta-validation and `com.github.victools:jsonschema-module-swagger-2`.
+See the <<extension-configuration-reference>> for relevant config properties.
+
 == Notifications
 
 You can annotate a business method of a CDI bean with `@io.quarkiverse.mcp.server.Notification`.

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,7 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.version>3.20.1</quarkus.version>
         <jsonschema-generator.version>4.38.0</jsonschema-generator.version>
+        <swagger-annotations.version>2.2.25</swagger-annotations.version>
     </properties>
 
     <dependencyManagement>

--- a/transports/sse/deployment/pom.xml
+++ b/transports/sse/deployment/pom.xml
@@ -71,6 +71,35 @@
             <version>${version.assertj}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.github.victools</groupId>
+            <artifactId>jsonschema-module-jackson</artifactId>
+            <version>${jsonschema-generator.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.victools</groupId>
+            <artifactId>jsonschema-module-jakarta-validation</artifactId>
+            <version>${jsonschema-generator.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.github.victools</groupId>
+            <artifactId>jsonschema-module-swagger-2</artifactId>
+            <version>${jsonschema-generator.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.validation</groupId>
+            <artifactId>jakarta.validation-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-annotations</artifactId>
+            <version>${swagger-annotations.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/McpServerTest.java
+++ b/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/McpServerTest.java
@@ -43,6 +43,9 @@ public abstract class McpServerTest {
             config.overrideConfigKey("quarkus.mcp.server.traffic-logging.enabled", "true");
             config.overrideConfigKey("quarkus.mcp.server.traffic-logging.text-limit", "" + textLimit);
         }
+        config.overrideRuntimeConfigKey("quarkus.mcp.server.schema-generator.jackson.enabled", "false");
+        config.overrideRuntimeConfigKey("quarkus.mcp.server.schema-generator.jakarta-validation.enabled", "false");
+        config.overrideRuntimeConfigKey("quarkus.mcp.server.schema-generator.swagger2.enabled", "false");
         return config;
     }
 

--- a/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/schemageneration/ToolsSchemaCustomizerCustomTest.java
+++ b/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/schemageneration/ToolsSchemaCustomizerCustomTest.java
@@ -1,0 +1,109 @@
+package io.quarkiverse.mcp.server.test.tools.schemageneration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.math.BigDecimal;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.github.victools.jsonschema.generator.CustomDefinition;
+import com.github.victools.jsonschema.generator.CustomDefinitionProviderV2;
+import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
+
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolArg;
+import io.quarkiverse.mcp.server.runtime.SchemaGeneratorConfigCustomizer;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+public class ToolsSchemaCustomizerCustomTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .withApplicationRoot(
+                    root -> root.addClasses(
+                            MyToolWithJacksonAnnotatedType.class,
+                            BigDecimalAsStringCustomizer.class));
+
+    @Test
+    public void testSchemaGenerationWithProvidedCustomizer() {
+        initClient();
+        JsonObject toolListMessage = newMessage("tools/list");
+        send(toolListMessage);
+
+        JsonObject toolListResponse = waitForLastResponse();
+
+        JsonObject toolListResult = assertResultResponse(toolListMessage, toolListResponse);
+        assertNotNull(toolListResult);
+        JsonArray tools = toolListResult.getJsonArray("tools");
+        assertEquals(1, tools.size());
+
+        assertTool(tools, "add-products", null, schema -> {
+            assertHasPropertyWithNameType(schema, "products", "array");
+            assertHasPropertyCount(schema, 1);
+            assertHasRequiredProperties(schema, Set.of("products"));
+            JsonObject properties = schema.getJsonObject("properties");
+            JsonObject productsProperty = properties.getJsonObject("products");
+            JsonObject productType = productsProperty.getJsonObject("items");
+            assertNotNull(productType);
+            assertEquals("object", productType.getString("type"));
+            assertHasPropertyWithNameType(productType, "price", "string");
+            assertHasPropertyCount(productType, 1);
+        });
+    }
+
+    @ApplicationScoped
+    public static class BigDecimalAsStringCustomizer implements SchemaGeneratorConfigCustomizer {
+
+        @Override
+        public void customize(SchemaGeneratorConfigBuilder builder) {
+            CustomDefinitionProviderV2 customDefinitionProvider = (javaType,
+                    context) -> javaType.getErasedType() == BigDecimal.class
+                            ? new CustomDefinition(context.createDefinition(context.getTypeContext().resolve(String.class)))
+                            : null;
+            builder.forTypesInGeneral()
+                    .withCustomDefinitionProvider(customDefinitionProvider);
+        }
+    }
+
+    private void assertHasPropertyWithNameType(JsonObject typeObject, String name, String expectedType) {
+        JsonObject properties = typeObject.getJsonObject("properties");
+        assertNotNull(properties);
+        JsonObject property = properties.getJsonObject(name);
+        assertNotNull(property);
+        assertEquals(expectedType, property.getString("type"));
+    }
+
+    private void assertHasPropertyCount(JsonObject typeObject, int expectedNumberOfProperties) {
+        JsonObject properties = typeObject.getJsonObject("properties");
+        assertNotNull(properties);
+        assertEquals(expectedNumberOfProperties, properties.size());
+    }
+
+    private void assertHasRequiredProperties(JsonObject typeObject, Set<String> expectedRequireProperties) {
+        var requiredProperties = new HashSet<Object>(typeObject.getJsonArray("required").getList());
+        assertEquals(expectedRequireProperties, requiredProperties);
+    }
+
+    public static class MyToolWithJacksonAnnotatedType {
+
+        @Tool(name = "add-products", description = "Add multiple products to the product catalog.")
+        public String addProducts(
+                @ToolArg(name = "products", description = "The products to add to the catalog") List<Product> products) {
+            return "ok";
+        }
+    }
+
+    public static class Product {
+        private BigDecimal price;
+    }
+}

--- a/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/schemageneration/ToolsSchemaCustomizerJacksonTest.java
+++ b/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/schemageneration/ToolsSchemaCustomizerJacksonTest.java
@@ -1,0 +1,109 @@
+package io.quarkiverse.mcp.server.test.tools.schemageneration;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.math.BigDecimal;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolArg;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+public class ToolsSchemaCustomizerJacksonTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .overrideRuntimeConfigKey("quarkus.mcp.server.schema-generator.jackson.enabled", "true")
+            .withApplicationRoot(
+                    root -> root.addClasses(MyToolWithJacksonAnnotatedType.class));
+
+    @Test
+    public void testSchemaGenerationWithJacksonAnnotation() {
+        initClient();
+        JsonObject toolListMessage = newMessage("tools/list");
+        send(toolListMessage);
+
+        JsonObject toolListResponse = waitForLastResponse();
+
+        JsonObject toolListResult = assertResultResponse(toolListMessage, toolListResponse);
+        assertNotNull(toolListResult);
+        JsonArray tools = toolListResult.getJsonArray("tools");
+        assertEquals(1, tools.size());
+
+        assertTool(tools, "add-products", null, schema -> {
+            assertHasPropertyWithNameTypeDescription(schema, "products", "array", "The products to add to the catalog");
+            assertHasPropertyCount(schema, 1);
+            assertHasRequiredProperties(schema, Set.of("products"));
+            JsonObject properties = schema.getJsonObject("properties");
+            JsonObject productsProperty = properties.getJsonObject("products");
+            JsonObject productType = productsProperty.getJsonObject("items");
+            assertNotNull(productType);
+            assertEquals("object", productType.getString("type"));
+            assertHasRequiredProperties(productType, Set.of("identifier", "name", "price"));
+            assertHasPropertyWithNameTypeDescription(productType, "identifier", "string",
+                    "The unique identifier of the product.");
+            assertHasPropertyWithNameTypeDescription(productType, "name", "string", "The name of the product.");
+            assertHasPropertyWithNameTypeDescription(productType, "description", "string", null);
+            assertHasPropertyWithNameTypeDescription(productType, "price", "number", null);
+            assertHasPropertyCount(productType, 4);
+        });
+    }
+
+    private void assertHasPropertyWithNameTypeDescription(JsonObject typeObject, String name, String expectedType,
+            String expectedDescription) {
+        JsonObject properties = typeObject.getJsonObject("properties");
+        assertNotNull(properties);
+        JsonObject property = properties.getJsonObject(name);
+        assertNotNull(property);
+        assertEquals(expectedType, property.getString("type"));
+        assertEquals(expectedDescription, property.getString("description"));
+    }
+
+    private void assertHasPropertyCount(JsonObject typeObject, int expectedNumberOfProperties) {
+        JsonObject properties = typeObject.getJsonObject("properties");
+        assertNotNull(properties);
+        assertEquals(expectedNumberOfProperties, properties.size());
+    }
+
+    private void assertHasRequiredProperties(JsonObject typeObject, Set<String> expectedRequireProperties) {
+        var requiredProperties = new HashSet<Object>(typeObject.getJsonArray("required").getList());
+        assertEquals(expectedRequireProperties, requiredProperties);
+    }
+
+    public static class MyToolWithJacksonAnnotatedType {
+
+        @Tool(name = "add-products", description = "Add multiple products to the product catalog.")
+        public String addProducts(
+                @ToolArg(name = "products", description = "The products to add to the catalog") List<Product> products) {
+            return "ok";
+        }
+    }
+
+    public static class Product {
+
+        @JsonProperty(value = "identifier", required = true)
+        @JsonPropertyDescription("The unique identifier of the product.")
+        private String id;
+
+        @JsonProperty(value = "name", required = true)
+        @JsonPropertyDescription("The name of the product.")
+        private String name;
+
+        @JsonProperty(value = "description", required = false)
+        private String description;
+
+        @JsonProperty(value = "price", required = true)
+        private BigDecimal price;
+    }
+}

--- a/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/schemageneration/ToolsSchemaCustomizerJakartaValidationTest.java
+++ b/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/schemageneration/ToolsSchemaCustomizerJakartaValidationTest.java
@@ -1,0 +1,135 @@
+package io.quarkiverse.mcp.server.test.tools.schemageneration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.math.BigDecimal;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolArg;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+public class ToolsSchemaCustomizerJakartaValidationTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .overrideRuntimeConfigKey("quarkus.mcp.server.schema-generator.jakarta-validation.enabled", "true")
+            .withApplicationRoot(
+                    root -> root.addClasses(MyToolWithJakartaValidationAnnotatedType.class));
+
+    @Test
+    public void testSchemaGenerationWithJakartaValidationAnnotations() {
+        initClient();
+        JsonObject toolListMessage = newMessage("tools/list");
+        send(toolListMessage);
+
+        JsonObject toolListResponse = waitForLastResponse();
+
+        JsonObject toolListResult = assertResultResponse(toolListMessage, toolListResponse);
+        assertNotNull(toolListResult);
+        JsonArray tools = toolListResult.getJsonArray("tools");
+        assertEquals(1, tools.size());
+
+        assertTool(tools, "add-products", null, schema -> {
+            assertHasPropertyWithNameTypeDescription(schema, "products", "array");
+            assertHasPropertyCount(schema, 1);
+            assertHasRequiredProperties(schema, Set.of("products"));
+            JsonObject properties = getProperties(schema);
+            JsonObject productsProperty = properties.getJsonObject("products");
+            JsonObject productType = productsProperty.getJsonObject("items");
+            assertNotNull(productType);
+            assertEquals("object", productType.getString("type"));
+            assertHasRequiredProperties(productType, Set.of("id", "name", "price"));
+            assertHasPropertyWithNameTypeDescription(productType, "id", "string");
+            assertPropertyHasMinimumLength(productType, "id", 1);
+            assertPropertyHasPattern(productType, "id", "P\\d+");
+            assertHasPropertyWithNameTypeDescription(productType, "name", "string");
+            assertPropertyHasMinimumLength(productType, "name", 1);
+            assertHasPropertyWithNameTypeDescription(productType, "description", "string");
+            assertHasPropertyWithNameTypeDescription(productType, "price", "number");
+            assertPropertyHasMinimum(productType, "price", 0);
+            assertHasPropertyCount(productType, 4);
+        });
+    }
+
+    private void assertHasPropertyWithNameTypeDescription(JsonObject typeObject, String name, String expectedType) {
+        JsonObject properties = getProperties(typeObject);
+        assertNotNull(properties);
+        JsonObject property = properties.getJsonObject(name);
+        assertNotNull(property);
+        assertEquals(expectedType, property.getString("type"));
+    }
+
+    private void assertPropertyHasMinimumLength(JsonObject typeObject, String name, int expectedMinimumLength) {
+        JsonObject properties = getProperties(typeObject);
+        JsonObject property = properties.getJsonObject(name);
+        assertEquals(expectedMinimumLength, property.getInteger("minLength"));
+    }
+
+    private void assertPropertyHasMinimum(JsonObject typeObject, String name, int expectedMinimum) {
+        JsonObject properties = getProperties(typeObject);
+        JsonObject property = properties.getJsonObject(name);
+        assertEquals(expectedMinimum, property.getInteger("minimum"));
+    }
+
+    private void assertPropertyHasPattern(JsonObject typeObject, String name, String expectedPattern) {
+        JsonObject properties = getProperties(typeObject);
+        JsonObject property = properties.getJsonObject(name);
+        assertEquals(expectedPattern, property.getString("pattern"));
+    }
+
+    private void assertHasPropertyCount(JsonObject typeObject, int expectedNumberOfProperties) {
+        JsonObject properties = getProperties(typeObject);
+        assertNotNull(properties);
+        assertEquals(expectedNumberOfProperties, properties.size());
+    }
+
+    private void assertHasRequiredProperties(JsonObject typeObject, Set<String> expectedRequireProperties) {
+        var requiredProperties = new HashSet<Object>(typeObject.getJsonArray("required").getList());
+        assertEquals(expectedRequireProperties, requiredProperties);
+    }
+
+    private static JsonObject getProperties(JsonObject typeObject) {
+        return typeObject.getJsonObject("properties");
+    }
+
+    public static class MyToolWithJakartaValidationAnnotatedType {
+
+        @Tool(name = "add-products", description = "Add multiple products to the product catalog.")
+        public String addProducts(
+                @ToolArg(name = "products", description = "The products to add to the catalog") List<Product> products) {
+            return "ok";
+        }
+    }
+
+    public static class Product {
+
+        @NotBlank
+        @Pattern(regexp = "P\\d+")
+        private String id;
+
+        @NotEmpty
+        private String name;
+
+        private String description;
+
+        @NotNull
+        @Min(0)
+        private BigDecimal price;
+    }
+}

--- a/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/schemageneration/ToolsSchemaCustomizerSwagger2Test.java
+++ b/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/schemageneration/ToolsSchemaCustomizerSwagger2Test.java
@@ -1,0 +1,128 @@
+package io.quarkiverse.mcp.server.test.tools.schemageneration;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.math.BigDecimal;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolArg;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+public class ToolsSchemaCustomizerSwagger2Test extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .overrideRuntimeConfigKey("quarkus.mcp.server.schema-generator.swagger2.enabled", "true")
+            .withApplicationRoot(
+                    root -> root.addClasses(MyToolWithSwagger2AnnotatedType.class));
+
+    @Test
+    public void testSchemaGenerationWithSwagger2Annotations() {
+        initClient();
+        JsonObject toolListMessage = newMessage("tools/list");
+        send(toolListMessage);
+
+        JsonObject toolListResponse = waitForLastResponse();
+
+        JsonObject toolListResult = assertResultResponse(toolListMessage, toolListResponse);
+        assertNotNull(toolListResult);
+        JsonArray tools = toolListResult.getJsonArray("tools");
+        assertEquals(1, tools.size());
+
+        assertTool(tools, "add-products", null, schema -> {
+            assertHasPropertyWithNameTypeDescription(schema, "products", "array");
+            assertHasPropertyCount(schema, 1);
+            assertHasRequiredProperties(schema, Set.of("products"));
+            JsonObject properties = getProperties(schema);
+            JsonObject productsProperty = properties.getJsonObject("products");
+            JsonObject productType = productsProperty.getJsonObject("items");
+            assertNotNull(productType);
+            assertEquals("object", productType.getString("type"));
+            assertHasRequiredProperties(productType, Set.of("identifier", "name", "price"));
+            assertHasPropertyWithNameTypeDescription(productType, "identifier", "string");
+            assertPropertyHasMinimumLength(productType, "identifier", 1);
+            assertPropertyHasPattern(productType, "identifier", "P\\d+");
+            assertHasPropertyWithNameTypeDescription(productType, "name", "string");
+            assertPropertyHasMinimumLength(productType, "name", 1);
+            assertHasPropertyWithNameTypeDescription(productType, "description", "string");
+            assertHasPropertyWithNameTypeDescription(productType, "price", "number");
+            assertPropertyHasMinimum(productType, "price", 0);
+            assertHasPropertyCount(productType, 4);
+        });
+    }
+
+    private void assertHasPropertyWithNameTypeDescription(JsonObject typeObject, String name, String expectedType) {
+        JsonObject properties = getProperties(typeObject);
+        assertNotNull(properties);
+        JsonObject property = properties.getJsonObject(name);
+        assertNotNull(property);
+        assertEquals(expectedType, property.getString("type"));
+    }
+
+    private void assertPropertyHasMinimumLength(JsonObject typeObject, String name, int expectedMinimumLength) {
+        JsonObject properties = getProperties(typeObject);
+        JsonObject property = properties.getJsonObject(name);
+        assertEquals(expectedMinimumLength, property.getInteger("minLength"));
+    }
+
+    private void assertPropertyHasMinimum(JsonObject typeObject, String name, int expectedMinimum) {
+        JsonObject properties = getProperties(typeObject);
+        JsonObject property = properties.getJsonObject(name);
+        assertEquals(expectedMinimum, property.getInteger("minimum"));
+    }
+
+    private void assertPropertyHasPattern(JsonObject typeObject, String name, String expectedPattern) {
+        JsonObject properties = getProperties(typeObject);
+        JsonObject property = properties.getJsonObject(name);
+        assertEquals(expectedPattern, property.getString("pattern"));
+    }
+
+    private void assertHasPropertyCount(JsonObject typeObject, int expectedNumberOfProperties) {
+        JsonObject properties = getProperties(typeObject);
+        assertNotNull(properties);
+        assertEquals(expectedNumberOfProperties, properties.size());
+    }
+
+    private void assertHasRequiredProperties(JsonObject typeObject, Set<String> expectedRequireProperties) {
+        var requiredProperties = new HashSet<Object>(typeObject.getJsonArray("required").getList());
+        assertEquals(expectedRequireProperties, requiredProperties);
+    }
+
+    private static JsonObject getProperties(JsonObject typeObject) {
+        return typeObject.getJsonObject("properties");
+    }
+
+    public static class MyToolWithSwagger2AnnotatedType {
+
+        @Tool(name = "add-products", description = "Add multiple products to the product catalog.")
+        public String addProducts(
+                @ToolArg(name = "products", description = "The products to add to the catalog") List<Product> products) {
+            return "ok";
+        }
+    }
+
+    public static class Product {
+
+        @Schema(name = "identifier", requiredMode = Schema.RequiredMode.REQUIRED, minLength = 1, pattern = "P\\d+")
+        private String id;
+
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED, minLength = 1)
+        private String name;
+
+        private String description;
+
+        @Schema(requiredMode = Schema.RequiredMode.REQUIRED, minimum = "0")
+        private BigDecimal price;
+    }
+}


### PR DESCRIPTION
Issue https://github.com/quarkiverse/quarkus-mcp-server/issues/289

This PR adds support to customize the Victools SchemaGenerator used by the MCP Server extension.

For the modules `com.github.victools:jsonschema-module-jackson`, `com.github.victools:jsonschema-module-jakarta-validation` and `com.github.victools:jsonschema-module-swagger-2`, automatic detection of these modules is added and customizers are added to configure these modules on the SchemaGenerator.