### PR TITLE
core: fix McpLog for stremable transport

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/FeatureManagerBase.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/FeatureManagerBase.java
@@ -17,6 +17,8 @@ import java.util.stream.Stream;
 import jakarta.enterprise.inject.Instance;
 import jakarta.enterprise.invoke.Invoker;
 
+import org.jboss.logging.Logger;
+
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -44,7 +46,7 @@ public abstract class FeatureManagerBase<RESULT, INFO extends FeatureManager.Fea
 
     protected final ConnectionManager connectionManager;
 
-    protected final ConcurrentMap<String, McpLogImpl> logs;
+    protected final ConcurrentMap<String, Logger> loggers;
 
     protected final CurrentIdentityAssociation currentIdentityAssociation;
 
@@ -55,7 +57,7 @@ public abstract class FeatureManagerBase<RESULT, INFO extends FeatureManager.Fea
         this.vertx = vertx;
         this.mapper = mapper;
         this.connectionManager = connectionManager;
-        this.logs = new ConcurrentHashMap<>();
+        this.loggers = new ConcurrentHashMap<>();
         this.currentIdentityAssociation = currentIdentityAssociation.isResolvable() ? currentIdentityAssociation.get() : null;
         this.responseHandlers = responseHandlers;
     }
@@ -248,8 +250,8 @@ public abstract class FeatureManagerBase<RESULT, INFO extends FeatureManager.Fea
     }
 
     protected McpLog log(String key, String loggerName, ArgumentProviders argProviders) {
-        return logs.computeIfAbsent(key, k -> new McpLogImpl(argProviders.connection()::logLevel, loggerName, key,
-                argProviders.sender()));
+        Logger logger = loggers.computeIfAbsent(key, k -> Logger.getLogger(loggerName));
+        return new McpLogImpl(argProviders.connection()::logLevel, logger, key, argProviders.sender());
     }
 
     private String logKey(FeatureMetadata<?> metadata) {

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpLogImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpLogImpl.java
@@ -16,14 +16,14 @@ class McpLogImpl implements McpLog {
 
     private final Supplier<LogLevel> level;
 
-    private final Logger log;
+    private final Logger logger;
 
     private final Sender sender;
 
-    McpLogImpl(Supplier<LogLevel> level, String loggerName, String mcpLoggerName, Sender sender) {
+    McpLogImpl(Supplier<LogLevel> level, Logger logger, String mcpLoggerName, Sender sender) {
         this.mcpLoggerName = mcpLoggerName;
         this.level = level;
-        this.log = Logger.getLogger(loggerName);
+        this.logger = logger;
         this.sender = sender;
     }
 
@@ -50,25 +50,25 @@ class McpLogImpl implements McpLog {
 
     @Override
     public void info(String format, Object... params) {
-        log.infof(format, params);
+        logger.infof(format, params);
         send(LogLevel.INFO, format, params);
     }
 
     @Override
     public void debug(String format, Object... params) {
-        log.debugf(format, params);
+        logger.debugf(format, params);
         send(LogLevel.DEBUG, format, params);
     }
 
     @Override
     public void error(String format, Object... params) {
-        log.errorf(format, params);
+        logger.errorf(format, params);
         send(LogLevel.ERROR, format, params);
     }
 
     @Override
     public void error(Throwable t, String format, Object... params) {
-        log.infof(t, format, params);
+        logger.infof(t, format, params);
         send(LogLevel.ERROR, format, params);
     }
 

--- a/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/logging/LoggingStreamableTest.java
+++ b/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/logging/LoggingStreamableTest.java
@@ -1,0 +1,84 @@
+package io.quarkiverse.mcp.server.test.logging;
+
+import static io.quarkiverse.mcp.server.sse.runtime.StreamableHttpMcpMessageHandler.MCP_SESSION_ID_HEADER;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.net.http.HttpRequest.BodyPublishers;
+import java.time.DayOfWeek;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.McpLog.LogLevel;
+import io.quarkiverse.mcp.server.test.StreamableHttpTest;
+import io.quarkiverse.mcp.server.test.StreamableMcpSseClient;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+public class LoggingStreamableTest extends StreamableHttpTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .withApplicationRoot(root -> root.addClass(MyTools.class));
+
+    @Test
+    public void testLog() {
+        String mcpSessionId = initSession();
+
+        Map<String, String> headers = new HashMap<>();
+        headers.put(MCP_SESSION_ID_HEADER, mcpSessionId);
+        defaultHeaders().entrySet().stream().forEach(e -> headers.put(e.getKey(), e.getValue().toString()));
+
+        JsonObject charlie1 = newMessage("tools/call")
+                .put("params", new JsonObject()
+                        .put("name", "charlie")
+                        .put("arguments", new JsonObject().put("day", DayOfWeek.MONDAY)));
+
+        StreamableMcpSseClient client = new StreamableMcpSseClient(messageEndpoint, BodyPublishers.ofString(charlie1.encode()),
+                headers);
+        client.connect();
+        List<JsonObject> notifications1 = client.waitForNotifications(1);
+        assertEquals(1, notifications1.size());
+        assertLog(notifications1.get(0), LogLevel.INFO, "tool:charlie", "Charlie does not work on MONDAY");
+
+        JsonObject response1 = client.waitForResponse(charlie1);
+        assertResponse(charlie1, response1, "monday:INFO");
+
+        JsonObject charlie2 = newMessage("tools/call")
+                .put("params", new JsonObject()
+                        .put("name", "charlie")
+                        .put("arguments", new JsonObject().put("day", DayOfWeek.WEDNESDAY)));
+
+        StreamableMcpSseClient client2 = new StreamableMcpSseClient(messageEndpoint, BodyPublishers.ofString(charlie2.encode()),
+                headers);
+        client2.connect();
+        List<JsonObject> notifications2 = client2.waitForNotifications(1);
+        assertEquals(1, notifications2.size());
+        assertLog(notifications2.get(0), LogLevel.CRITICAL, "tool:charlie", "Wednesday is critical!");
+
+        JsonObject response2 = client2.waitForResponse(charlie2);
+        assertResponse(charlie2, response2, "wednesday:INFO");
+    }
+
+    private void assertLog(JsonObject log, LogLevel level, String logger, String message) {
+        JsonObject params = log.getJsonObject("params");
+        assertEquals(level.toString().toLowerCase(), params.getString("level"));
+        assertEquals(logger, params.getString("logger"));
+        assertEquals(message, params.getString("data"));
+    }
+
+    private void assertResponse(JsonObject request, JsonObject response, String expectedText) {
+        JsonObject result = assertResultResponse(request, response);
+        assertNotNull(result);
+        JsonArray content = result.getJsonArray("content");
+        assertEquals(1, content.size());
+        JsonObject textContent = content.getJsonObject(0);
+        assertEquals("text", textContent.getString("type"));
+        assertEquals(expectedText, textContent.getString("text"));
+    }
+}


### PR DESCRIPTION
- do not cache McpLog but merely the Logger instances
- fixes #308