### PR TITLE
streamable: discard "subsidiary" messages

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/PromptManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/PromptManagerImpl.java
@@ -8,6 +8,7 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -80,13 +81,16 @@ public class PromptManagerImpl extends FeatureManagerBase<PromptResponse, Prompt
 
     @Override
     public PromptInfo removePrompt(String name) {
-        return prompts.computeIfPresent(name, (key, value) -> {
+        AtomicReference<PromptInfo> removed = new AtomicReference<>();
+        prompts.computeIfPresent(name, (key, value) -> {
             if (!value.isMethod()) {
+                removed.set(value);
                 notifyConnections("notifications/prompts/list_changed");
                 return null;
             }
             return value;
         });
+        return removed.get();
     }
 
     IllegalArgumentException promptWithNameAlreadyExists(String name) {

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceManagerImpl.java
@@ -5,6 +5,7 @@ import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -129,13 +130,16 @@ public class ResourceManagerImpl extends FeatureManagerBase<ResourceResponse, Re
 
     @Override
     public ResourceInfo removeResource(String uri) {
-        return resources.computeIfPresent(uri, (key, value) -> {
+        AtomicReference<ResourceInfo> removed = new AtomicReference<>();
+        resources.computeIfPresent(uri, (key, value) -> {
             if (!value.isMethod()) {
+                removed.set(value);
                 notifyConnections("notifications/resources/list_changed");
                 return null;
             }
             return value;
         });
+        return removed.get();
     }
 
     @SuppressWarnings("unchecked")

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceTemplateManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceTemplateManagerImpl.java
@@ -8,6 +8,7 @@ import java.util.Map.Entry;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -87,13 +88,15 @@ public class ResourceTemplateManagerImpl extends FeatureManagerBase<ResourceResp
 
     @Override
     public ResourceTemplateInfo removeResourceTemplate(String name) {
-        ResourceTemplateMetadata metadata = templates.computeIfPresent(name, (key, value) -> {
+        AtomicReference<ResourceTemplateInfo> removed = new AtomicReference<>();
+        templates.computeIfPresent(name, (key, value) -> {
             if (!value.info().isMethod()) {
+                removed.set(value.info);
                 return null;
             }
             return value;
         });
-        return metadata != null ? metadata.info : null;
+        return removed.get();
     }
 
     private VariableMatcher getVariableMatcher(String name) {

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ToolManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ToolManagerImpl.java
@@ -8,6 +8,7 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -99,13 +100,16 @@ public class ToolManagerImpl extends FeatureManagerBase<ToolResponse, ToolInfo> 
 
     @Override
     public ToolInfo removeTool(String name) {
-        return tools.computeIfPresent(name, (key, value) -> {
+        AtomicReference<ToolInfo> removed = new AtomicReference<>();
+        tools.computeIfPresent(name, (key, value) -> {
             if (!value.isMethod()) {
+                removed.set(value);
                 notifyConnections("notifications/tools/list_changed");
                 return null;
             }
             return value;
         });
+        return removed.get();
     }
 
     @SuppressWarnings("unchecked")

--- a/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/streamablehttp/SimpleStreamableTest.java
+++ b/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/streamablehttp/SimpleStreamableTest.java
@@ -9,9 +9,12 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.time.DayOfWeek;
 import java.util.Map;
 
+import jakarta.inject.Inject;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkiverse.mcp.server.ToolManager;
 import io.quarkiverse.mcp.server.test.Checks;
 import io.quarkiverse.mcp.server.test.FooService;
 import io.quarkiverse.mcp.server.test.Options;
@@ -29,9 +32,20 @@ public class SimpleStreamableTest extends StreamableHttpTest {
             .withApplicationRoot(
                     root -> root.addClasses(FooService.class, Options.class, Checks.class, MyTools.class));
 
+    @Inject
+    ToolManager toolManager;
+
     @Test
     public void testTools() {
         String mcpSessionId = initSession();
+
+        // Just test that registration does not fail even if notification is not sent
+        toolManager.newTool("foofoo")
+                .setDescription("foofoo")
+                .setHandler(atgs -> null)
+                .register();
+        assertNotNull(toolManager.getTool("foofoo"));
+        assertNotNull(toolManager.removeTool("foofoo"));
 
         JsonObject toolListMessage = newMessage("tools/list");
         ValidatableResponse response = send(toolListMessage, Map.of(MCP_SESSION_ID_HEADER, mcpSessionId));

--- a/transports/sse/runtime/src/main/java/io/quarkiverse/mcp/server/sse/runtime/StreamableHttpMcpConnection.java
+++ b/transports/sse/runtime/src/main/java/io/quarkiverse/mcp/server/sse/runtime/StreamableHttpMcpConnection.java
@@ -1,5 +1,7 @@
 package io.quarkiverse.mcp.server.sse.runtime;
 
+import org.jboss.logging.Logger;
+
 import io.quarkiverse.mcp.server.runtime.McpConnectionBase;
 import io.quarkiverse.mcp.server.runtime.config.McpServerRuntimeConfig;
 import io.vertx.core.Future;
@@ -7,13 +9,17 @@ import io.vertx.core.json.JsonObject;
 
 class StreamableHttpMcpConnection extends McpConnectionBase {
 
+    private static final Logger LOG = Logger.getLogger(StreamableHttpMcpConnection.class);
+
     StreamableHttpMcpConnection(String id, McpServerRuntimeConfig serverConfig) {
         super(id, serverConfig);
     }
 
     @Override
     public Future<Void> send(JsonObject message) {
-        throw new UnsupportedOperationException();
+        String method = message.getString("method");
+        LOG.warnf("Discarding message [%s]- 'subsidiary' SSE streams are not supported yet", method);
+        return Future.succeededFuture();
     }
 
 }


### PR DESCRIPTION
- i.e. messages unrelated to an existing request
- instead of throwing UnsupportedOperationException
- also fix the return values for some of the removeX() methods declared on managers