### PR TITLE
sse: return HTTP 405 if POST is sent to the legacy SSE endpoint

### DIFF
--- a/test/src/main/java/io/quarkiverse/mcp/server/test/McpAssured.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/McpAssured.java
@@ -11,6 +11,8 @@ import io.quarkiverse.mcp.server.ClientCapability;
 import io.quarkiverse.mcp.server.PromptResponse;
 import io.quarkiverse.mcp.server.ResourceResponse;
 import io.quarkiverse.mcp.server.ToolResponse;
+import io.quarkiverse.mcp.server.test.McpAssured.McpSseTestClient;
+import io.quarkiverse.mcp.server.test.McpAssured.McpStreamableTestClient;
 import io.smallrye.common.annotation.CheckReturnValue;
 import io.vertx.core.MultiMap;
 import io.vertx.core.json.JsonObject;
@@ -231,6 +233,12 @@ public class McpAssured {
      */
     public interface McpSseTestClient
             extends McpTestClient<McpSseAssert, McpSseTestClient> {
+
+        /**
+         *
+         * @return the SSE endpoint
+         */
+        URI sseEndpoint();
 
         /**
          *

--- a/test/src/main/java/io/quarkiverse/mcp/server/test/McpSseTestClientImpl.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/McpSseTestClientImpl.java
@@ -59,6 +59,11 @@ class McpSseTestClientImpl extends McpTestClientBase<McpSseAssert, McpSseTestCli
     }
 
     @Override
+    public URI sseEndpoint() {
+        return sseEndpoint;
+    }
+
+    @Override
     public URI messageEndpoint() {
         return messageEndpoint;
     }

--- a/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/streamablehttp/InitPostAttemptTest.java
+++ b/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/streamablehttp/InitPostAttemptTest.java
@@ -1,0 +1,51 @@
+package io.quarkiverse.mcp.server.test.streamablehttp;
+
+import java.net.URI;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkiverse.mcp.server.test.McpAssured.McpSseTestClient;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.vertx.core.json.JsonObject;
+
+public class InitPostAttemptTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .withApplicationRoot(
+                    root -> root.addClasses(MyTools.class));
+
+    @Test
+    public void testFailures() {
+        McpSseTestClient client = McpAssured.newConnectedSseClient();
+        URI sseEndpoint = client.sseEndpoint();
+        JsonObject initMessage = client.newMessage("initialize");
+        JsonObject params = new JsonObject()
+                .put("clientInfo", new JsonObject()
+                        .put("name", "test")
+                        .put("version", "1.0"))
+                .put("protocolVersion", "2024-11-05");
+        initMessage.put("params", params);
+        client.disconnect();
+        RestAssured.given()
+                .when()
+                .body(initMessage.encode())
+                .post(sseEndpoint)
+                .then()
+                .statusCode(405);
+    }
+
+    public static class MyTools {
+
+        @Tool
+        String bravo(int price) {
+            return "" + price * 42;
+        }
+    }
+
+}

--- a/transports/sse/runtime/src/main/java/io/quarkiverse/mcp/server/sse/runtime/SseMcpServerRecorder.java
+++ b/transports/sse/runtime/src/main/java/io/quarkiverse/mcp/server/sse/runtime/SseMcpServerRecorder.java
@@ -83,6 +83,15 @@ public class SseMcpServerRecorder {
 
             @Override
             public void handle(RoutingContext ctx) {
+                // The client may attempt to POST an initialize request to the SSE endpoint
+                // to test whether the Streamable transport is supported
+                // (for the case when the server combines the legacy SSE endpoint and the new MCP streamable endpoint)
+                // This is not our case but we should still return 405
+                if (HttpMethod.POST.equals(ctx.request().method())) {
+                    ctx.fail(405);
+                    return;
+                }
+
                 ctx.put(CONTEXT_KEY, serverName);
                 HttpServerResponse response = ctx.response();
                 response.setChunked(true);


### PR DESCRIPTION
- fixes #317