### PR TITLE
NPE when annotating with Tool @Annotations without title. 

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/McpServerProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/McpServerProcessor.java
@@ -971,7 +971,7 @@ class McpServerProcessor {
             toolAnnotations = metaMethod.newInstance(
                     MethodDescriptor.ofConstructor(ToolManager.ToolAnnotations.class, String.class, boolean.class,
                             boolean.class, boolean.class, boolean.class),
-                    metaMethod.load(annotations.title()),
+                    annotations.title() == null ? metaMethod.loadNull() : metaMethod.load(annotations.title()),
                     metaMethod.load(annotations.readOnlyHint()),
                     metaMethod.load(annotations.destructiveHint()),
                     metaMethod.load(annotations.idempotentHint()),

--- a/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/annotations/ToolAnnotationsTest.java
+++ b/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/annotations/ToolAnnotationsTest.java
@@ -99,6 +99,11 @@ public class ToolAnnotationsTest extends McpServerTest {
             return "ok";
         }
 
+        @Tool(annotations = @Annotations(readOnlyHint = true, destructiveHint = false))
+        String withoutTitle() {
+            return "ok";
+        }
+
         @Tool
         String charlie() {
             return "nok";


### PR DESCRIPTION
When creating a tool like shown below: 

```java
        @Tool(annotations = @Annotations(readOnlyHint = true, destructiveHint = false))
        String withoutTitle() {
            return "ok";
        }
```

it results in an NPE: 

```
java.lang.RuntimeException: io.quarkus.builder.BuildException: Build failure: Build failed due to errors
	[error]: Build step io.quarkiverse.mcp.server.deployment.McpServerProcessor#generateMetadata threw an exception: java.lang.NullPointerException
	at java.base/java.util.Objects.requireNonNull(Objects.java:233)
	at io.quarkus.gizmo.BytecodeCreatorImpl.load(BytecodeCreatorImpl.java:319)
	at io.quarkiverse.mcp.server.deployment.McpServerProcessor.processFeatureMethod(McpServerProcessor.java:974)
	at io.quarkiverse.mcp.server.deployment.McpServerProcessor.generateMetadata(McpServerProcessor.java:524)
	at java.base/java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:733)
	at io.quarkus.deployment.ExtensionLoader$3.execute(ExtensionLoader.java:856)
	at io.quarkus.builder.BuildContext.run(BuildContext.java:255)
	at org.jboss.threads.ContextHandler$1.runWith(ContextHandler.java:18)
	at org.jboss.threads.EnhancedQueueExecutor$Task.doRunWith(EnhancedQueueExecutor.java:2675)
	at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2654)
	at org.jboss.threads.EnhancedQueueExecutor.runThreadBody(EnhancedQueueExecutor.java:1627)
	at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1594)
	at java.base/java.lang.Thread.run(Thread.java:1583)
	at org.jboss.threads.JBossThread.run(JBossThread.java:499)


	at io.quarkus.runner.bootstrap.AugmentActionImpl.runAugment(AugmentActionImpl.java:372)
	at io.quarkus.runner.bootstrap.AugmentActionImpl.createInitialRuntimeApplication(AugmentActionImpl.java:289)
	at io.quarkus.test.QuarkusUnitTest.beforeAll(QuarkusUnitTest.java:690)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1596)
Caused by: io.quarkus.builder.BuildException: Build failure: Build failed due to errors
	[error]: Build step io.quarkiverse.mcp.server.deployment.McpServerProcessor#generateMetadata threw an exception: java.lang.NullPointerException
	at java.base/java.util.Objects.requireNonNull(Objects.java:233)
	at io.quarkus.gizmo.BytecodeCreatorImpl.load(BytecodeCreatorImpl.java:319)
	at io.quarkiverse.mcp.server.deployment.McpServerProcessor.processFeatureMethod(McpServerProcessor.java:974)
	at io.quarkiverse.mcp.server.deployment.McpServerProcessor.generateMetadata(McpServerProcessor.java:524)
	at java.base/java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:733)
	at io.quarkus.deployment.ExtensionLoader$3.execute(ExtensionLoader.java:856)
	at io.quarkus.builder.BuildContext.run(BuildContext.java:255)
	at org.jboss.threads.ContextHandler$1.runWith(ContextHandler.java:18)
	at org.jboss.threads.EnhancedQueueExecutor$Task.doRunWith(EnhancedQueueExecutor.java:2675)
	at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2654)
	at org.jboss.threads.EnhancedQueueExecutor.runThreadBody(EnhancedQueueExecutor.java:1627)
	at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1594)
	at java.base/java.lang.Thread.run(Thread.java:1583)
	at org.jboss.threads.JBossThread.run(JBossThread.java:499)

	at io.quarkus.builder.Execution.run(Execution.java:122)
	at io.quarkus.builder.BuildExecutionBuilder.execute(BuildExecutionBuilder.java:78)
	at io.quarkus.deployment.QuarkusAugmentor.run(QuarkusAugmentor.java:161)
	at io.quarkus.runner.bootstrap.AugmentActionImpl.runAugment(AugmentActionImpl.java:368)
	... 3 more
Caused by: java.lang.NullPointerException
	at java.base/java.util.Objects.requireNonNull(Objects.java:233)
	at io.quarkus.gizmo.BytecodeCreatorImpl.load(BytecodeCreatorImpl.java:319)
	at io.quarkiverse.mcp.server.deployment.McpServerProcessor.processFeatureMethod(McpServerProcessor.java:974)
	at io.quarkiverse.mcp.server.deployment.McpServerProcessor.generateMetadata(McpServerProcessor.java:524)
	at java.base/java.lang.invoke.MethodHandle.invokeWithArguments(MethodHandle.java:733)
	at io.quarkus.deployment.ExtensionLoader$3.execute(ExtensionLoader.java:856)
	at io.quarkus.builder.BuildContext.run(BuildContext.java:255)
	at org.jboss.threads.ContextHandler$1.runWith(ContextHandler.java:18)
	at org.jboss.threads.EnhancedQueueExecutor$Task.doRunWith(EnhancedQueueExecutor.java:2675)
	at org.jboss.threads.EnhancedQueueExecutor$Task.run(EnhancedQueueExecutor.java:2654)
	at org.jboss.threads.EnhancedQueueExecutor.runThreadBody(EnhancedQueueExecutor.java:1627)
	at org.jboss.threads.EnhancedQueueExecutor$ThreadBody.run(EnhancedQueueExecutor.java:1594)
	at java.base/java.lang.Thread.run(Thread.java:1583)
	at org.jboss.threads.JBossThread.run(JBossThread.java:499)

```

I created a test case for this, not sure though, how to fix it. 