### PR TITLE
core: implement cancellation of in-progress requests

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/DotNames.java
+++ b/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/DotNames.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.jboss.jandex.DotName;
 
 import io.quarkiverse.mcp.server.BlobResourceContents;
+import io.quarkiverse.mcp.server.Cancellation;
 import io.quarkiverse.mcp.server.CompleteArg;
 import io.quarkiverse.mcp.server.CompletePrompt;
 import io.quarkiverse.mcp.server.CompleteResourceTemplate;
@@ -91,6 +92,7 @@ class DotNames {
     static final DotName ROOTS = DotName.createSimple(Roots.class);
     static final DotName RUN_ON_VIRTUAL_THREAD = DotName.createSimple(RunOnVirtualThread.class);
     static final DotName SAMPLING = DotName.createSimple(Sampling.class);
+    static final DotName CANCELLATION = DotName.createSimple(Cancellation.class);
     static final DotName STRING = DotName.createSimple(String.class);
     static final DotName TEXT_CONTENT = DotName.createSimple(TextContent.class);
     static final DotName TEXT_RESOURCE_CONTENTS = DotName.createSimple(TextResourceContents.class);

--- a/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/McpServerProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/McpServerProcessor.java
@@ -616,7 +616,8 @@ class McpServerProcessor {
                         || paramType.name().equals(DotNames.REQUEST_URI)
                         || paramType.name().equals(DotNames.PROGRESS)
                         || paramType.name().equals(DotNames.ROOTS)
-                        || paramType.name().equals(DotNames.SAMPLING)) {
+                        || paramType.name().equals(DotNames.SAMPLING)
+                        || paramType.name().equals(DotNames.CANCELLATION)) {
                     continue;
                 }
                 reflectiveHierarchies.produce(ReflectiveHierarchyBuildItem.builder(paramType).build());
@@ -876,7 +877,7 @@ class McpServerProcessor {
                     && !param.type().name().equals(DotNames.ROOTS)
                     && !param.type().name().equals(DotNames.SAMPLING)) {
                 throw new IllegalStateException(
-                        "Notification methods must only consume built-in parameter types [McpConnection, McpLog, Roots, Sampling]: "
+                        "Notification methods may only consume built-in parameter types [McpConnection, McpLog, Roots, Sampling]: "
                                 + methodDesc(method));
             }
         }
@@ -1025,6 +1026,8 @@ class McpServerProcessor {
             return FeatureArgument.Provider.ROOTS;
         } else if (type.name().equals(DotNames.SAMPLING)) {
             return FeatureArgument.Provider.SAMPLING;
+        } else if (type.name().equals(DotNames.CANCELLATION)) {
+            return FeatureArgument.Provider.CANCELLATION;
         } else {
             return FeatureArgument.Provider.PARAMS;
         }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/Cancellation.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/Cancellation.java
@@ -1,0 +1,57 @@
+package io.quarkiverse.mcp.server;
+
+import java.util.Optional;
+
+/**
+ * Can be used to determine if an MCP client requested a cancellation of an in-progress request.
+ * <p>
+ * {@link Tool}, {@link Prompt}, {@link Resource}, {@link ResourceTemplate}, {@link CompletePrompt} and
+ * {@link CompleteResourceTemplate} methods can accept this class as a parameter. It will be automatically injected before the
+ * method is invoked.
+ *
+ * @see #check()
+ */
+public interface Cancellation {
+
+    /**
+     * Perform the check.
+     * <p>
+     * A feature method should throw an {@link OperationCancellationException} if cancellation was requested by the client.
+     *
+     * @return the result
+     * @see Result#isRequested()
+     * @see OperationCancellationException
+     */
+    Result check();
+
+    /**
+     * Perform the check and if cancellation is requested then skip the processing, i.e. throw
+     * {@link OperationCancellationException}.
+     *
+     * @throws OperationCancellationException
+     */
+    default void skipProcessingIfCancelled() {
+        if (check().isRequested()) {
+            throw new OperationCancellationException();
+        }
+    }
+
+    /**
+     *
+     * @param isRequested {@code true} if a client wants to cancel an in-progress request
+     * @param reason an optional reason for cancellation
+     */
+    record Result(boolean isRequested, Optional<String> reason) {
+    }
+
+    /**
+     * Exception indicating that the result of an MCP request cannot be returned because the request
+     * was cancelled by the client.
+     */
+    class OperationCancellationException extends RuntimeException {
+
+        private static final long serialVersionUID = 1L;
+
+    }
+
+}

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/RequestId.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/RequestId.java
@@ -9,7 +9,10 @@ public record RequestId(Object value) {
 
     public RequestId {
         if (value == null) {
-            throw new IllegalArgumentException("messages must not be null");
+            throw new IllegalArgumentException("value must not be null");
+        }
+        if (!(value instanceof Number) && !(value instanceof String)) {
+            throw new IllegalArgumentException("value must be string or number");
         }
     }
 

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ArgumentProviders.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ArgumentProviders.java
@@ -2,14 +2,12 @@ package io.quarkiverse.mcp.server.runtime;
 
 import java.util.Map;
 
-import io.quarkiverse.mcp.server.McpConnection;
-
 /**
  * Holds all information needed to supply arguments for a feature method.
  */
 public record ArgumentProviders(
         Map<String, Object> args,
-        McpConnection connection,
+        McpConnectionBase connection,
         Object requestId,
         String uri,
         Sender sender,

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/CancellationImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/CancellationImpl.java
@@ -1,0 +1,32 @@
+package io.quarkiverse.mcp.server.runtime;
+
+import java.util.Optional;
+
+import io.quarkiverse.mcp.server.Cancellation;
+import io.quarkiverse.mcp.server.RequestId;
+
+public class CancellationImpl implements Cancellation {
+
+    static CancellationImpl from(ArgumentProviders argProviders) {
+        return new CancellationImpl(argProviders.connection(), argProviders.requestId());
+    }
+
+    private final McpConnectionBase connection;
+    private final RequestId requestId;
+
+    private CancellationImpl(McpConnectionBase connection, Object requestId) {
+        this.connection = connection;
+        this.requestId = new RequestId(requestId);
+    }
+
+    @Override
+    public Result check() {
+        Optional<String> reason = connection.getCancellationRequest(requestId);
+        if (reason == null) {
+            return new Result(false, Optional.empty());
+        } else {
+            return new Result(true, reason);
+        }
+    }
+
+}

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/FeatureArgument.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/FeatureArgument.java
@@ -29,5 +29,6 @@ public record FeatureArgument(String name,
         PROGRESS,
         ROOTS,
         SAMPLING,
+        CANCELLATION,
     }
 }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/FeatureManagerBase.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/FeatureManagerBase.java
@@ -157,6 +157,8 @@ public abstract class FeatureManagerBase<RESULT, INFO extends FeatureManager.Fea
                 ret[idx] = RootsImpl.from(argProviders);
             } else if (arg.provider() == Provider.SAMPLING) {
                 ret[idx] = SamplingImpl.from(argProviders);
+            } else if (arg.provider() == Provider.CANCELLATION) {
+                ret[idx] = CancellationImpl.from(argProviders);
             } else {
                 Object val = argProviders.getArg(arg.name());
                 if (val == null && arg.defaultValue() != null) {

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/MessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/MessageHandler.java
@@ -2,15 +2,22 @@ package io.quarkiverse.mcp.server.runtime;
 
 import org.jboss.logging.Logger;
 
+import io.quarkiverse.mcp.server.Cancellation;
 import io.quarkiverse.mcp.server.McpConnection;
 import io.vertx.core.Future;
 
 public abstract class MessageHandler {
 
+    private static final Logger LOG = Logger.getLogger(MessageHandler.class);
+
     protected Future<Void> handleFailure(Object requestId, Sender sender, McpConnection connection, Throwable cause,
             Logger logger, String errorMessage, String featureId) {
         if (cause instanceof McpException mcp) {
             return sender.sendError(requestId, mcp.getJsonRpcError(), mcp.getMessage());
+        } else if (cause instanceof Cancellation.OperationCancellationException) {
+            LOG.debugf("Operation for request %s was cancelled", requestId);
+            // Skip processing
+            return Future.succeededFuture();
         } else if (Failures.isSecurityFailure(cause)) {
             return sender.sendError(requestId, JsonRPC.SECURITY_ERROR, cause.toString());
         } else {

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -136,6 +136,7 @@ However, it may also accept the following parameters:
 * `io.quarkiverse.mcp.server.Progress`
 * `io.quarkiverse.mcp.server.Roots`
 * `io.quarkiverse.mcp.server.Sampling`
+* `io.quarkiverse.mcp.server.Cancellation`
 
 === Completion API
 
@@ -185,6 +186,7 @@ However, it may also accept the following parameters:
 * `io.quarkiverse.mcp.server.Progress`
 * `io.quarkiverse.mcp.server.Roots`
 * `io.quarkiverse.mcp.server.Sampling`
+* `io.quarkiverse.mcp.server.Cancellation`
 
 === Programmatic API
 
@@ -271,6 +273,7 @@ A `@Resource` method may accept the following parameters:
 * `io.quarkiverse.mcp.server.RequestUri`
 * `io.quarkiverse.mcp.server.Roots`
 * `io.quarkiverse.mcp.server.Sampling`
+* `io.quarkiverse.mcp.server.Cancellation`
 
 === Programmatic API
 
@@ -376,6 +379,7 @@ However, it may also accept the following parameters:
 * `io.quarkiverse.mcp.server.RequestUri`
 * `io.quarkiverse.mcp.server.Roots`
 * `io.quarkiverse.mcp.server.Sampling`
+* `io.quarkiverse.mcp.server.Cancellation`
 
 === Completion API
 
@@ -425,6 +429,7 @@ However, it may also accept the following parameters:
 * `io.quarkiverse.mcp.server.RequestUri`
 * `io.quarkiverse.mcp.server.Roots`
 * `io.quarkiverse.mcp.server.Sampling`
+* `io.quarkiverse.mcp.server.Cancellation`
 
 === Programmatic API
 
@@ -522,6 +527,7 @@ However, it may also accept the following parameters:
 * `io.quarkiverse.mcp.server.Progress`
 * `io.quarkiverse.mcp.server.Roots`
 * `io.quarkiverse.mcp.server.Sampling`
+* `io.quarkiverse.mcp.server.Cancellation`
 
 === Programmatic API
 
@@ -866,6 +872,38 @@ public class MyTools {
 <2> If sampling is supported a convenient builder can be used to construct a `SamplingRequest`.
 <3> The server sends a sampling request and when a sampling response returns the tool method completes.
 
+
+== Cancellation
+
+MCP supports optional cancellation of in-progress requests.
+The `io.quarkiverse.mcp.server.Cancellation` interface can be used to determine if an MCP client requested a cancellation of the current request.
+Feature methods can accept this class as a parameter.
+It will be automatically injected before the method is invoked.
+
+[source,java]
+----
+import io.quarkiverse.mcp.server.Cancellation;
+import io.quarkiverse.mcp.server.Tool;
+
+public class MyTools {
+
+   @Tool(description = "A tool that may be cancelled")
+   String myTool(Cancellation cancellation) { <1>
+       while (someCondition) {
+          if (cancellation.check().isRequested()) { <2> <3>
+            throw new OperationCancellationException();
+          }
+          // do something...
+          TimeUnit.MILLISECONDS.sleep(500);
+       }
+       return "OK";
+   }
+}
+----
+<1> The `Cancellation` parameter is injected automatically.
+<2> Perform the check and if cancellation is requested then skip the processing, i.e. throw an `OperationCancellationException`.
+<3> The convenient method `Cancellation#skipProcessingIfCancelled()` can be used instead.
+ 
 == Security
 
 In case of using the HTTP/SSE transport, you can secure the MCP SSE endpoints using the https://quarkus.io/guides/security-authorize-web-endpoints-reference[Quarkus web security layer].

--- a/test/src/main/java/io/quarkiverse/mcp/server/test/McpAssured.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/McpAssured.java
@@ -141,6 +141,13 @@ public class McpAssured {
 
         /**
          *
+         * @param method
+         * @return a new request message
+         */
+        JsonObject newRequest(String method);
+
+        /**
+         *
          * @return a new {@code initialize} message
          */
         JsonObject newInitMessage();
@@ -622,7 +629,7 @@ public class McpAssured {
             GenericMessage<ASSERT> withErrorAssert(Consumer<McpError> errorAssertFunction);
 
             /**
-             * Send a {@code ping} message to the server.
+             * Send the message to the server.
              *
              * @return the assert group
              */

--- a/test/src/main/java/io/quarkiverse/mcp/server/test/McpStreamableClient.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/McpStreamableClient.java
@@ -27,6 +27,7 @@ class McpStreamableClient extends SseClient {
         this.state = new McpClientState();
     }
 
+    // impl. note: the response is not reflected in the client state object
     HttpResponse<String> sendSync(String body, MultiMap headers) {
         HttpRequest.Builder builder = HttpRequest.newBuilder()
                 .uri(mcpEndpoint)

--- a/test/src/main/java/io/quarkiverse/mcp/server/test/McpStreamableTestClientImpl.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/McpStreamableTestClientImpl.java
@@ -71,6 +71,7 @@ class McpStreamableTestClientImpl extends McpTestClientBase<McpStreamableAssert,
         LOG.infof("Mcp-Session-Id received: %s", mcpSessionId);
 
         JsonObject initResponse = new JsonObject(response.body());
+        client.state.responses.add(initResponse);
         JsonObject initResult = assertResultResponse(initMessage, initResponse);
         assertNotNull(initResult);
 
@@ -92,7 +93,8 @@ class McpStreamableTestClientImpl extends McpTestClientBase<McpStreamableAssert,
         // Send "notifications/initialized"
         JsonObject nofitication = newMessage("notifications/initialized");
         response = client.sendSync(nofitication.encode(), additionalHeaders(nofitication));
-        if (response.statusCode() != 200) {
+        // The server must respond with 202 for response or notification
+        if (response.statusCode() != 202) {
             throw new IllegalStateException(
                     "Initialization not finished successfully; HTTP response status: " + response.statusCode());
         }

--- a/test/src/main/java/io/quarkiverse/mcp/server/test/McpTestClientBase.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/McpTestClientBase.java
@@ -92,8 +92,12 @@ abstract class McpTestClientBase<ASSERT extends McpAssert<ASSERT>, CLIENT extend
     public JsonObject newMessage(String method) {
         return new JsonObject()
                 .put("jsonrpc", "2.0")
-                .put("method", method)
-                .put("id", nextRequestId());
+                .put("method", method);
+    }
+
+    @Override
+    public JsonObject newRequest(String method) {
+        return newMessage(method).put("id", nextRequestId());
     }
 
     @Override
@@ -148,15 +152,15 @@ abstract class McpTestClientBase<ASSERT extends McpAssert<ASSERT>, CLIENT extend
         return error;
     }
 
-    protected JsonObject newMessage(String method, Consumer<JsonObject> paramsConsumer) {
+    protected JsonObject newRequest(String method, Consumer<JsonObject> paramsConsumer) {
         JsonObject params = new JsonObject();
         paramsConsumer.accept(params);
-        return newMessage(method)
+        return newRequest(method)
                 .put("params", params);
     }
 
     protected JsonObject newToolsCallMessage(String toolName, Map<String, Object> arguments, Map<String, Object> meta) {
-        return newMessage(McpAssured.TOOLS_CALL, p -> {
+        return newRequest(McpAssured.TOOLS_CALL, p -> {
             p.put("name", toolName);
             addMeta(p, meta);
             if (!arguments.isEmpty()) {
@@ -166,7 +170,7 @@ abstract class McpTestClientBase<ASSERT extends McpAssert<ASSERT>, CLIENT extend
     }
 
     protected JsonObject newListMessage(String method, Map<String, Object> meta, String cursor) {
-        return newMessage(method, p -> {
+        return newRequest(method, p -> {
             addMeta(p, meta);
             if (cursor != null) {
                 p.put("cursor", cursor);
@@ -181,7 +185,7 @@ abstract class McpTestClientBase<ASSERT extends McpAssert<ASSERT>, CLIENT extend
     }
 
     protected JsonObject newPromptsGetMessage(String promptName, Map<String, String> args, Map<String, Object> meta) {
-        return newMessage(McpAssured.PROMPTS_GET, p -> {
+        return newRequest(McpAssured.PROMPTS_GET, p -> {
             p.put("name", promptName);
             addMeta(p, meta);
             if (!args.isEmpty()) {
@@ -191,7 +195,7 @@ abstract class McpTestClientBase<ASSERT extends McpAssert<ASSERT>, CLIENT extend
     }
 
     protected JsonObject newResourcesReadMessage(String uri, Map<String, Object> meta) {
-        return newMessage(McpAssured.RESOURCES_READ, p -> {
+        return newRequest(McpAssured.RESOURCES_READ, p -> {
             p.put("uri", uri);
             addMeta(p, meta);
         });
@@ -199,7 +203,7 @@ abstract class McpTestClientBase<ASSERT extends McpAssert<ASSERT>, CLIENT extend
 
     @Override
     public JsonObject newInitMessage() {
-        JsonObject initMessage = newMessage("initialize");
+        JsonObject initMessage = newRequest("initialize");
         JsonObject params = new JsonObject()
                 .put("clientInfo", new JsonObject()
                         .put("name", name)
@@ -380,7 +384,7 @@ abstract class McpTestClientBase<ASSERT extends McpAssert<ASSERT>, CLIENT extend
 
             @Override
             public ASSERT send() {
-                JsonObject message = newMessage(McpAssured.PING);
+                JsonObject message = newRequest(McpAssured.PING);
                 doSend(message);
                 if (pongAssert) {
                     asserts.add(new PongAssert(message));

--- a/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/cancel/CancellationTest.java
+++ b/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/cancel/CancellationTest.java
@@ -1,0 +1,75 @@
+package io.quarkiverse.mcp.server.test.cancel;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.Cancellation;
+import io.quarkiverse.mcp.server.Cancellation.OperationCancellationException;
+import io.quarkiverse.mcp.server.Cancellation.Result;
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolArg;
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkiverse.mcp.server.test.McpAssured.McpStreamableTestClient;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.json.JsonObject;
+
+public class CancellationTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .withApplicationRoot(
+                    root -> root.addClasses(MyTools.class));
+
+    @Test
+    public void testCancellation() {
+        McpStreamableTestClient client = McpAssured.newConnectedStreamableClient();
+
+        JsonObject request = client.newRequest("tools/call")
+                .put("params", new JsonObject()
+                        .put("name", "bravo"));
+        client.sendAndForget(request);
+
+        JsonObject notification = client.newMessage("notifications/cancelled").put("params",
+                new JsonObject()
+                        .put("requestId", request.getValue("id"))
+                        .put("reason", "No reason at all"));
+
+        client.sendAndForget(notification);
+        // This notification should be ignored
+        client.sendAndForget(notification);
+
+        Awaitility.await().until(() -> MyTools.CANCELLED.get());
+        // Only the response to the "initialize" request
+        assertEquals(1, client.snapshot().responses().size());
+    }
+
+    public static class MyTools {
+
+        static final AtomicBoolean CANCELLED = new AtomicBoolean();
+
+        @Tool
+        String bravo(Cancellation cancellation, @ToolArg(defaultValue = "1") int price) throws InterruptedException {
+            int c = 0;
+            while (c++ < 20) {
+                Result r = cancellation.check();
+                if (r.isRequested()
+                        && r.reason().isPresent()
+                        && r.reason().get().equals("No reason at all")) {
+                    CANCELLED.set(true);
+                    throw new OperationCancellationException();
+                }
+                TimeUnit.MILLISECONDS.sleep(200);
+            }
+            return "OK";
+        }
+
+    }
+
+}

--- a/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/close/CloseTest.java
+++ b/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/close/CloseTest.java
@@ -35,7 +35,7 @@ public class CloseTest extends McpServerTest {
 
         // Send "q/close"
         client.when()
-                .message(client.newMessage("q/close"))
+                .message(client.newRequest("q/close"))
                 .send()
                 .thenAssertResults();
 

--- a/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/complete/InvalidPromptCompleteTest.java
+++ b/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/complete/InvalidPromptCompleteTest.java
@@ -22,7 +22,8 @@ public class InvalidPromptCompleteTest extends McpServerTest {
     @Test
     public void testError() {
         McpSseTestClient client = McpAssured.newConnectedSseClient();
-        JsonObject completeMessage = client.newMessage("completion/complete")
+        JsonObject completeMessage = client
+                .newRequest("completion/complete")
                 .put("params", new JsonObject()
                         .put("ref", new JsonObject()
                                 .put("type", "ref/prompt")

--- a/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/complete/InvalidResourceTemplateCompleteTest.java
+++ b/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/complete/InvalidResourceTemplateCompleteTest.java
@@ -22,7 +22,7 @@ public class InvalidResourceTemplateCompleteTest extends McpServerTest {
     @Test
     public void testError() {
         McpSseTestClient client = McpAssured.newConnectedSseClient();
-        JsonObject completeMessage = client.newMessage("completion/complete")
+        JsonObject completeMessage = client.newRequest("completion/complete")
                 .put("params", new JsonObject()
                         .put("ref", new JsonObject()
                                 .put("type", "ref/prompt")

--- a/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/complete/PromptCompleteTest.java
+++ b/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/complete/PromptCompleteTest.java
@@ -30,7 +30,7 @@ public class PromptCompleteTest extends McpServerTest {
     @Test
     public void testCompletion() {
         McpSseTestClient client = McpAssured.newConnectedSseClient();
-        JsonObject completeMessage = client.newMessage("completion/complete")
+        JsonObject completeMessage = client.newRequest("completion/complete")
                 .put("params", new JsonObject()
                         .put("ref", new JsonObject()
                                 .put("type", "ref/prompt")
@@ -47,7 +47,7 @@ public class PromptCompleteTest extends McpServerTest {
         assertEquals(1, values.size());
         assertEquals("Vojtik", values.getString(0));
 
-        completeMessage = client.newMessage("completion/complete")
+        completeMessage = client.newRequest("completion/complete")
                 .put("params", new JsonObject()
                         .put("ref", new JsonObject()
                                 .put("type", "ref/prompt")

--- a/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/complete/PromptProgrammaticCompleteTest.java
+++ b/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/complete/PromptProgrammaticCompleteTest.java
@@ -58,7 +58,7 @@ public class PromptProgrammaticCompleteTest extends McpServerTest {
                         List.of(), 0, false))
                 .register());
 
-        JsonObject completeMessage = client.newMessage("completion/complete")
+        JsonObject completeMessage = client.newRequest("completion/complete")
                 .put("params", new JsonObject()
                         .put("ref", new JsonObject()
                                 .put("type", "ref/prompt")
@@ -76,7 +76,7 @@ public class PromptProgrammaticCompleteTest extends McpServerTest {
         assertEquals(1, values.size());
         assertEquals("Vojtik", values.getString(0));
 
-        completeMessage = client.newMessage("completion/complete")
+        completeMessage = client.newRequest("completion/complete")
                 .put("params", new JsonObject()
                         .put("ref", new JsonObject()
                                 .put("type", "ref/prompt")

--- a/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/complete/ResourceTemplateCompleteTest.java
+++ b/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/complete/ResourceTemplateCompleteTest.java
@@ -23,7 +23,7 @@ public class ResourceTemplateCompleteTest extends McpServerTest {
     @Test
     public void testCompletion() {
         McpSseTestClient client = McpAssured.newConnectedSseClient();
-        JsonObject completeMessage = client.newMessage("completion/complete")
+        JsonObject completeMessage = client.newRequest("completion/complete")
                 .put("params", new JsonObject()
                         .put("ref", new JsonObject()
                                 .put("type", "ref/resource")
@@ -41,7 +41,7 @@ public class ResourceTemplateCompleteTest extends McpServerTest {
         assertEquals(1, values.size());
         assertEquals("Jachym", values.getString(0));
 
-        completeMessage = client.newMessage("completion/complete")
+        completeMessage = client.newRequest("completion/complete")
                 .put("params", new JsonObject()
                         .put("ref", new JsonObject()
                                 .put("type", "ref/resource")

--- a/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/complete/ResourceTemplateProgrammaticCompleteTest.java
+++ b/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/complete/ResourceTemplateProgrammaticCompleteTest.java
@@ -55,7 +55,7 @@ public class ResourceTemplateProgrammaticCompleteTest extends McpServerTest {
                 .setHandler(args -> CompletionResponse.create(List.of()))
                 .register());
 
-        JsonObject completeMessage = client.newMessage("completion/complete")
+        JsonObject completeMessage = client.newRequest("completion/complete")
                 .put("params", new JsonObject()
                         .put("ref", new JsonObject()
                                 .put("type", "ref/resource")
@@ -73,7 +73,7 @@ public class ResourceTemplateProgrammaticCompleteTest extends McpServerTest {
         assertEquals(1, values.size());
         assertEquals("Jachym", values.getString(0));
 
-        completeMessage = client.newMessage("completion/complete")
+        completeMessage = client.newRequest("completion/complete")
                 .put("params", new JsonObject()
                         .put("ref", new JsonObject()
                                 .put("type", "ref/resource")

--- a/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/logging/LoggingSetLevelTest.java
+++ b/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/logging/LoggingSetLevelTest.java
@@ -36,7 +36,7 @@ public class LoggingSetLevelTest extends McpServerTest {
 
         assertLog(notifications.get(0), LogLevel.INFO, "tool:charlie", "Charlie does not work on MONDAY");
 
-        JsonObject setLogLevelMessage = client.newMessage("logging/setLevel")
+        JsonObject setLogLevelMessage = client.newRequest("logging/setLevel")
                 .put("params", new JsonObject()
                         .put("level", LogLevel.CRITICAL.toString().toLowerCase()));
         client.when()

--- a/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/resources/ResourcesSubscribeTest.java
+++ b/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/resources/ResourcesSubscribeTest.java
@@ -45,11 +45,11 @@ public class ResourcesSubscribeTest extends McpServerTest {
 
         McpSseTestClient client = McpAssured.newConnectedSseClient();
 
-        JsonObject sub1 = client.newMessage("resources/subscribe")
+        JsonObject sub1 = client.newRequest("resources/subscribe")
                 .put("params", new JsonObject().put("uri", uri1));
         client.sendAndForget(sub1);
         client.waitForResponse(sub1);
-        JsonObject sub2 = client.newMessage("resources/subscribe")
+        JsonObject sub2 = client.newRequest("resources/subscribe")
                 .put("params", new JsonObject().put("uri", uri2));
         client.sendAndForget(sub2);
         client.waitForResponse(sub2);
@@ -63,7 +63,7 @@ public class ResourcesSubscribeTest extends McpServerTest {
             assertThat(n.getJsonObject("params").getString("uri")).isIn(List.of(uri1, uri2));
         }
 
-        JsonObject un1 = client.newMessage("resources/unsubscribe")
+        JsonObject un1 = client.newRequest("resources/unsubscribe")
                 .put("params", new JsonObject().put("uri", uri1));
         client.sendAndForget(un1);
         client.waitForResponse(un1);

--- a/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/sampling/SamplingDefaultTimeoutTest.java
+++ b/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/sampling/SamplingDefaultTimeoutTest.java
@@ -47,7 +47,7 @@ public class SamplingDefaultTimeoutTest extends McpServerTest {
                 .build()
                 .connect();
 
-        JsonObject request = client.newMessage("tools/call")
+        JsonObject request = client.newRequest("tools/call")
                 .put("params", new JsonObject()
                         .put("name", "samplingDefaultTimeout"));
         client.sendAndForget(request);

--- a/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/sampling/SamplingTest.java
+++ b/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/sampling/SamplingTest.java
@@ -38,7 +38,7 @@ public class SamplingTest extends McpServerTest {
                 .build()
                 .connect();
 
-        JsonObject request = client.newMessage("tools/call")
+        JsonObject request = client.newRequest("tools/call")
                 .put("params", new JsonObject()
                         .put("name", "samplingFoo"));
         client.sendAndForget(request);

--- a/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/sampling/SamplingTimeoutTest.java
+++ b/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/sampling/SamplingTimeoutTest.java
@@ -47,7 +47,7 @@ public class SamplingTimeoutTest extends McpServerTest {
                 .build()
                 .connect();
 
-        JsonObject request = client.newMessage("tools/call")
+        JsonObject request = client.newRequest("tools/call")
                 .put("params", new JsonObject()
                         .put("name", "samplingDefaultTimeout"));
         client.sendAndForget(request);

--- a/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/streamablehttp/InitFailedStreamableTest.java
+++ b/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/streamablehttp/InitFailedStreamableTest.java
@@ -40,7 +40,7 @@ public class InitFailedStreamableTest extends McpServerTest {
     public void testFailures() {
         McpStreamableTestClient client = McpAssured.newConnectedStreamableClient();
         URI mcpEndpoint = client.mcpEndpoint();
-        JsonObject initMessage = client.newMessage("initialize");
+        JsonObject initMessage = client.newRequest("initialize");
         JsonObject params = new JsonObject()
                 .put("clientInfo", new JsonObject()
                         .put("name", "test")

--- a/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/streamablehttp/InitPostAttemptTest.java
+++ b/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/streamablehttp/InitPostAttemptTest.java
@@ -24,7 +24,7 @@ public class InitPostAttemptTest extends McpServerTest {
     public void testFailures() {
         McpSseTestClient client = McpAssured.newConnectedSseClient();
         URI sseEndpoint = client.sseEndpoint();
-        JsonObject initMessage = client.newMessage("initialize");
+        JsonObject initMessage = client.newRequest("initialize");
         JsonObject params = new JsonObject()
                 .put("clientInfo", new JsonObject()
                         .put("name", "test")

--- a/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/streamablehttp/TerminateSessionTest.java
+++ b/transports/sse/deployment/src/test/java/io/quarkiverse/mcp/server/test/streamablehttp/TerminateSessionTest.java
@@ -47,7 +47,7 @@ public class TerminateSessionTest extends McpServerTest {
                 .when()
                 .headers(Map.of(MCP_SESSION_ID_HEADER, client.mcpSessionId(), HttpHeaders.ACCEPT + "",
                         "application/json, text/event-stream"))
-                .body(client.newMessage(McpAssured.PING))
+                .body(client.newRequest(McpAssured.PING))
                 .post(client.mcpEndpoint())
                 .then()
                 .statusCode(404);


### PR DESCRIPTION
- resolves #307

This PR supersedes https://github.com/quarkiverse/quarkus-mcp-server/pull/319.

The main difference is the API that looks like:

```java
        @Tool(description = "Some tool description")
        String myTool(Cancellation cancellation) {
            while (someCondition) {
                if (cancellation.check().isRequested()) {
                    throw new OperationCancellationException();
                }
                // do something...
                TimeUnit.MILLISECONDS.sleep(500);
            }
            return "OK";
        }
```

I.e. the `Cancellation` argument is injected automatically (and it knows the relevant connection id and request id).