### PR TITLE
core - programmatic API: use interfaces instead of records for arguments

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/CompletionManager.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/CompletionManager.java
@@ -68,9 +68,8 @@ public interface CompletionManager extends FeatureManager<CompletionInfo> {
 
     }
 
-    // TODO: replace this record with an interface that extends a common ancestor
-    record CompletionArguments(String argumentValue, McpConnection connection, McpLog log, RequestId requestId,
-            Progress progress, Roots roots, Sampling sampling, Cancellation cancellation) {
+    interface CompletionArguments extends RequestFeatureArguments {
 
+        String argumentValue();
     }
 }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/FeatureManager.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/FeatureManager.java
@@ -55,7 +55,7 @@ public interface FeatureManager<INFO extends FeatureInfo> extends Iterable<INFO>
 
     }
 
-    interface FeatureDefinition<INFO extends FeatureInfo, ARGUMENTS, RESPONSE, THIS extends FeatureDefinition<INFO, ARGUMENTS, RESPONSE, THIS>> {
+    interface FeatureDefinition<INFO extends FeatureInfo, ARGUMENTS extends FeatureArguments, RESPONSE, THIS extends FeatureDefinition<INFO, ARGUMENTS, RESPONSE, THIS>> {
 
         /**
          *
@@ -106,6 +106,28 @@ public interface FeatureManager<INFO extends FeatureInfo> extends Iterable<INFO>
          * @return the info
          */
         INFO register();
+    }
+
+    interface RequestFeatureArguments extends FeatureArguments {
+
+        RequestId requestId();
+
+        Progress progress();
+
+        Cancellation cancellation();
+
+    }
+
+    interface FeatureArguments {
+
+        McpConnection connection();
+
+        McpLog log();
+
+        Roots roots();
+
+        Sampling sampling();
+
     }
 
 }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/NotificationManager.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/NotificationManager.java
@@ -62,7 +62,8 @@ public interface NotificationManager extends FeatureManager<NotificationInfo> {
 
     }
 
-    record NotificationArguments(McpConnection connection, McpLog log, Roots roots, Sampling sampling) {
+    interface NotificationArguments extends FeatureArguments {
+
     }
 
 }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/PromptManager.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/PromptManager.java
@@ -72,12 +72,13 @@ public interface PromptManager extends FeatureManager<PromptInfo> {
 
     }
 
-    // TODO: replace this record with an interface that extends a common ancestor
-    record PromptArguments(Map<String, String> args, McpConnection connection, McpLog log, RequestId requestId,
-            Progress progress, Roots roots, Sampling sampling, Cancellation cancellation) {
+    record PromptArgument(String name, String description, boolean required, String defaultValue) {
+
     }
 
-    record PromptArgument(String name, String description, boolean required, String defaultValue) {
+    interface PromptArguments extends RequestFeatureArguments {
+
+        Map<String, String> args();
 
     }
 }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/ResourceManager.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/ResourceManager.java
@@ -81,9 +81,9 @@ public interface ResourceManager extends FeatureManager<ResourceInfo> {
 
     }
 
-    // TODO: replace this record with an interface that extends a common ancestor
-    record ResourceArguments(McpConnection connection, McpLog log, RequestId requestId, RequestUri requestUri,
-            Progress progress, Roots roots, Sampling sampling, Cancellation cancellation) {
+    interface ResourceArguments extends RequestFeatureArguments {
+
+        RequestUri requestUri();
 
     }
 

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/ResourceTemplateManager.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/ResourceTemplateManager.java
@@ -69,10 +69,11 @@ public interface ResourceTemplateManager extends FeatureManager<ResourceTemplate
 
     }
 
-    // TODO: replace this record with an interface that extends a common ancestor
-    record ResourceTemplateArguments(Map<String, String> args, McpConnection connection, McpLog log, RequestId requestId,
-            RequestUri requestUri, Progress progress, Roots roots, Sampling sampling, Cancellation cancellation) {
+    interface ResourceTemplateArguments extends RequestFeatureArguments {
 
+        Map<String, String> args();
+
+        RequestUri requestUri();
     }
 
 }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/ToolManager.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/ToolManager.java
@@ -84,9 +84,10 @@ public interface ToolManager extends FeatureManager<ToolInfo> {
 
     }
 
-    // TODO: replace this record with an interface that extends a common ancestor
-    record ToolArguments(Map<String, Object> args, McpConnection connection, McpLog log, RequestId requestId, Progress progress,
-            Roots roots, Sampling sampling, Cancellation cancellation) {
+    public interface ToolArguments extends RequestFeatureArguments {
+
+        Map<String, Object> args();
+
     }
 
     record ToolArgument(String name, String description, boolean required, java.lang.reflect.Type type, String defaultValue) {

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/CompletionManagerBase.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/CompletionManagerBase.java
@@ -13,7 +13,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.quarkiverse.mcp.server.CompletionManager;
 import io.quarkiverse.mcp.server.CompletionManager.CompletionInfo;
 import io.quarkiverse.mcp.server.CompletionResponse;
-import io.quarkiverse.mcp.server.RequestId;
+import io.quarkiverse.mcp.server.McpLog;
 import io.quarkus.security.identity.CurrentIdentityAssociation;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.Vertx;
@@ -166,14 +166,31 @@ public abstract class CompletionManagerBase extends FeatureManagerBase<Completio
 
         @Override
         protected CompletionArguments createArguments(ArgumentProviders argumentProviders) {
-            return new CompletionArguments(argumentProviders.args().get(argumentName).toString(),
-                    argumentProviders.connection(),
-                    log(feature().toString().toLowerCase() + ":" + name, name, argumentProviders),
-                    new RequestId(argumentProviders.requestId()),
-                    ProgressImpl.from(argumentProviders),
-                    RootsImpl.from(argumentProviders),
-                    SamplingImpl.from(argumentProviders),
-                    CancellationImpl.from(argumentProviders));
+            return new CompletionArgumentsImpl(argumentProviders, argumentProviders.args().get(argumentName).toString(),
+                    log(feature().toString().toLowerCase() + ":" + name, name, argumentProviders));
+        }
+
+    }
+
+    static class CompletionArgumentsImpl extends AbstractRequestFeatureArguments implements CompletionArguments {
+
+        private final String argumentValue;
+        private final McpLog log;
+
+        CompletionArgumentsImpl(ArgumentProviders argProviders, String argumentValue, McpLog log) {
+            super(argProviders);
+            this.argumentValue = argumentValue;
+            this.log = log;
+        }
+
+        @Override
+        public McpLog log() {
+            return log;
+        }
+
+        @Override
+        public String argumentValue() {
+            return argumentValue;
         }
 
     }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/NotificationManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/NotificationManagerImpl.java
@@ -12,6 +12,7 @@ import jakarta.inject.Singleton;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import io.quarkiverse.mcp.server.McpLog;
 import io.quarkiverse.mcp.server.Notification;
 import io.quarkiverse.mcp.server.Notification.Type;
 import io.quarkiverse.mcp.server.NotificationManager;
@@ -178,10 +179,24 @@ public class NotificationManagerImpl extends FeatureManagerBase<Void, Notificati
 
         @Override
         protected NotificationArguments createArguments(ArgumentProviders argumentProviders) {
-            return new NotificationArguments(argumentProviders.connection(),
-                    log(Feature.NOTIFICATION.toString().toLowerCase() + ":" + name, name, argumentProviders),
-                    RootsImpl.from(argumentProviders),
-                    SamplingImpl.from(argumentProviders));
+            return new NotificationArgumentsImpl(argumentProviders,
+                    log(Feature.NOTIFICATION.toString().toLowerCase() + ":" + name, name, argumentProviders));
+        }
+
+    }
+
+    static class NotificationArgumentsImpl extends AbstractFeatureArguments implements NotificationArguments {
+
+        private final McpLog log;
+
+        NotificationArgumentsImpl(ArgumentProviders argProviders, McpLog log) {
+            super(argProviders);
+            this.log = log;
+        }
+
+        @Override
+        public McpLog log() {
+            return log;
         }
 
     }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/PromptManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/PromptManagerImpl.java
@@ -20,11 +20,11 @@ import org.jboss.logging.Logger;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.quarkiverse.mcp.server.McpConnection;
+import io.quarkiverse.mcp.server.McpLog;
 import io.quarkiverse.mcp.server.PromptFilter;
 import io.quarkiverse.mcp.server.PromptManager;
 import io.quarkiverse.mcp.server.PromptManager.PromptInfo;
 import io.quarkiverse.mcp.server.PromptResponse;
-import io.quarkiverse.mcp.server.RequestId;
 import io.quarkus.arc.All;
 import io.quarkus.security.identity.CurrentIdentityAssociation;
 import io.smallrye.mutiny.Uni;
@@ -230,13 +230,8 @@ public class PromptManagerImpl extends FeatureManagerBase<PromptResponse, Prompt
                     args.put(a.name(), a.defaultValue());
                 }
             }
-            return new PromptArguments(args, argumentProviders.connection(),
-                    log(Feature.PROMPT.toString().toLowerCase() + ":" + name, name, argumentProviders),
-                    new RequestId(argumentProviders.requestId()),
-                    ProgressImpl.from(argumentProviders),
-                    RootsImpl.from(argumentProviders),
-                    SamplingImpl.from(argumentProviders),
-                    CancellationImpl.from(argumentProviders));
+            return new PromptArgumentsImpl(argumentProviders, args,
+                    log(Feature.PROMPT.toString().toLowerCase() + ":" + name, name, argumentProviders));
         }
 
         @Override
@@ -253,6 +248,29 @@ public class PromptManagerImpl extends FeatureManagerBase<PromptResponse, Prompt
             }
             prompt.put("arguments", arguments);
             return prompt;
+        }
+
+    }
+
+    static class PromptArgumentsImpl extends AbstractRequestFeatureArguments implements PromptArguments {
+
+        private final Map<String, String> args;
+        private final McpLog log;
+
+        PromptArgumentsImpl(ArgumentProviders argProviders, Map<String, String> args, McpLog log) {
+            super(argProviders);
+            this.args = Map.copyOf(args);
+            this.log = log;
+        }
+
+        @Override
+        public McpLog log() {
+            return log;
+        }
+
+        @Override
+        public Map<String, String> args() {
+            return args;
         }
 
     }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceManagerImpl.java
@@ -18,7 +18,7 @@ import org.jboss.logging.Logger;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.quarkiverse.mcp.server.McpConnection;
-import io.quarkiverse.mcp.server.RequestId;
+import io.quarkiverse.mcp.server.McpLog;
 import io.quarkiverse.mcp.server.RequestUri;
 import io.quarkiverse.mcp.server.ResourceContentsEncoder;
 import io.quarkiverse.mcp.server.ResourceFilter;
@@ -287,21 +287,39 @@ public class ResourceManagerImpl extends FeatureManagerBase<ResourceResponse, Re
 
         @Override
         protected ResourceArguments createArguments(ArgumentProviders argumentProviders) {
-            return new ResourceArguments(
-                    argumentProviders.connection(),
-                    log(Feature.RESOURCE.toString().toLowerCase() + ":" + name, name, argumentProviders),
-                    new RequestId(argumentProviders.requestId()),
+            return new ResourceArgumentsImpl(
+                    argumentProviders,
                     new RequestUri(argumentProviders.uri()),
-                    ProgressImpl.from(argumentProviders),
-                    RootsImpl.from(argumentProviders),
-                    SamplingImpl.from(argumentProviders),
-                    CancellationImpl.from(argumentProviders));
+                    log(Feature.RESOURCE.toString().toLowerCase() + ":" + name, name, argumentProviders));
         }
 
         @Override
         public void sendUpdateAndForget() {
             ResourceManagerImpl.this.sendUpdateNotifications(uri());
         }
+    }
+
+    static class ResourceArgumentsImpl extends AbstractRequestFeatureArguments implements ResourceArguments {
+
+        private final RequestUri requestUri;
+        private final McpLog log;
+
+        ResourceArgumentsImpl(ArgumentProviders argProviders, RequestUri requestUri, McpLog log) {
+            super(argProviders);
+            this.requestUri = requestUri;
+            this.log = log;
+        }
+
+        @Override
+        public McpLog log() {
+            return log;
+        }
+
+        @Override
+        public RequestUri requestUri() {
+            return requestUri;
+        }
+
     }
 
     class ResourceDefinitionImpl extends

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceTemplateManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceTemplateManagerImpl.java
@@ -23,7 +23,7 @@ import org.jboss.logging.Logger;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.quarkiverse.mcp.server.McpConnection;
-import io.quarkiverse.mcp.server.RequestId;
+import io.quarkiverse.mcp.server.McpLog;
 import io.quarkiverse.mcp.server.RequestUri;
 import io.quarkiverse.mcp.server.ResourceContentsEncoder;
 import io.quarkiverse.mcp.server.ResourceResponse;
@@ -305,16 +305,41 @@ public class ResourceTemplateManagerImpl extends FeatureManagerBase<ResourceResp
             // Use variable matching to extract method arguments
             Map<String, String> matchedVariables = getVariableMatcher(name)
                     .matchVariables(argumentProviders.uri());
-            return new ResourceTemplateArguments(
+            return new ResourceTemplateArgumentsImpl(argumentProviders,
                     matchedVariables,
-                    argumentProviders.connection(),
-                    log(Feature.RESOURCE_TEMPLATE.toString().toLowerCase() + ":" + name, name, argumentProviders),
-                    new RequestId(argumentProviders.requestId()),
                     new RequestUri(argumentProviders.uri()),
-                    ProgressImpl.from(argumentProviders),
-                    RootsImpl.from(argumentProviders),
-                    SamplingImpl.from(argumentProviders),
-                    CancellationImpl.from(argumentProviders));
+                    log(Feature.RESOURCE_TEMPLATE.toString().toLowerCase() + ":" + name, name, argumentProviders));
+        }
+
+    }
+
+    static class ResourceTemplateArgumentsImpl extends AbstractRequestFeatureArguments implements ResourceTemplateArguments {
+
+        private final Map<String, String> args;
+        private final RequestUri requestUri;
+        private final McpLog log;
+
+        ResourceTemplateArgumentsImpl(ArgumentProviders argProviders, Map<String, String> args, RequestUri requestUri,
+                McpLog log) {
+            super(argProviders);
+            this.args = Map.copyOf(args);
+            this.requestUri = requestUri;
+            this.log = log;
+        }
+
+        @Override
+        public McpLog log() {
+            return log;
+        }
+
+        @Override
+        public Map<String, String> args() {
+            return args;
+        }
+
+        @Override
+        public RequestUri requestUri() {
+            return requestUri;
         }
 
     }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ToolManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ToolManagerImpl.java
@@ -28,7 +28,7 @@ import com.github.victools.jsonschema.generator.SchemaVersion;
 
 import io.quarkiverse.mcp.server.DefaultValueConverter;
 import io.quarkiverse.mcp.server.McpConnection;
-import io.quarkiverse.mcp.server.RequestId;
+import io.quarkiverse.mcp.server.McpLog;
 import io.quarkiverse.mcp.server.ToolFilter;
 import io.quarkiverse.mcp.server.ToolManager;
 import io.quarkiverse.mcp.server.ToolManager.ToolInfo;
@@ -355,14 +355,32 @@ public class ToolManagerImpl extends FeatureManagerBase<ToolResponse, ToolInfo> 
                     args.put(a.name(), convert(a.defaultValue(), a.type()));
                 }
             }
-            return new ToolArguments(args,
-                    argumentProviders.connection(),
-                    log(Feature.TOOL.toString().toLowerCase() + ":" + name, name, argumentProviders),
-                    new RequestId(argumentProviders.requestId()),
-                    ProgressImpl.from(argumentProviders),
-                    RootsImpl.from(argumentProviders),
-                    SamplingImpl.from(argumentProviders),
-                    CancellationImpl.from(argumentProviders));
+            return new ToolArgumentsImpl(argumentProviders, args,
+                    log(Feature.TOOL.toString().toLowerCase() + ":" + name, name, argumentProviders));
+        }
+
+    }
+
+    static class ToolArgumentsImpl extends AbstractRequestFeatureArguments implements ToolArguments {
+
+        private final Map<String, Object> args;
+
+        private final McpLog log;
+
+        ToolArgumentsImpl(ArgumentProviders argProviders, Map<String, Object> args, McpLog log) {
+            super(argProviders);
+            this.args = Map.copyOf(args);
+            this.log = log;
+        }
+
+        @Override
+        public McpLog log() {
+            return log;
+        }
+
+        @Override
+        public Map<String, Object> args() {
+            return args;
         }
 
     }


### PR DESCRIPTION
- note that this change is not binary compatible, however it's necessary for further evolution of the API