### PR TITLE
core: remove deprecated ResourceInfo#sendUpdate()

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/ResourceManager.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/ResourceManager.java
@@ -51,14 +51,6 @@ public interface ResourceManager extends FeatureManager<ResourceInfo> {
          */
         void sendUpdateAndForget();
 
-        /**
-         * @deprecated Use {@link #sendUpdateAndForget()} instead
-         */
-        @Deprecated(forRemoval = true, since = "1.1")
-        default void sendUpdate() {
-            sendUpdateAndForget();
-        }
-
     }
 
     /**

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpMessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpMessageHandler.java
@@ -510,7 +510,7 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
         return new InitialRequest(implementation, protocolVersion, List.copyOf(clientCapabilities), transport());
     }
 
-    private static final List<String> SUPPORTED_PROTOCOL_VERSIONS = List.of("2025-03-26", "2024-11-05");
+    private static final List<String> SUPPORTED_PROTOCOL_VERSIONS = List.of("2025-06-18", "2025-03-26", "2024-11-05");
 
     private Map<String, Object> serverInfo(MCP_REQUEST mcpRequest, InitialRequest initialRequest) {
         Map<String, Object> info = new HashMap<>();

--- a/test/src/main/java/io/quarkiverse/mcp/server/test/McpStreamableTestClientImpl.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/McpStreamableTestClientImpl.java
@@ -241,7 +241,7 @@ class McpStreamableTestClientImpl extends McpTestClientBase<McpStreamableAssert,
 
         private String name = "test-client";
         private String version = "1.0";
-        private String protocolVersion = "2024-11-05";
+        private String protocolVersion = "2025-06-18";
         private String mcpPath = "/mcp";
         private Set<ClientCapability> clientCapabilities = Set.of();
         private URI baseUri = McpAssured.baseUri;


### PR DESCRIPTION
- also update supported MCP versions