### PR TITLE
Do not use Runtime configuration during deployment

### DIFF
--- a/transports/sse/runtime/src/main/java/io/quarkiverse/mcp/server/sse/runtime/SseMcpServerRecorder.java
+++ b/transports/sse/runtime/src/main/java/io/quarkiverse/mcp/server/sse/runtime/SseMcpServerRecorder.java
@@ -25,6 +25,7 @@ import io.quarkiverse.mcp.server.sse.runtime.StreamableHttpMcpConnection.Subsidi
 import io.quarkiverse.mcp.server.sse.runtime.config.McpSseServersBuildTimeConfig;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
@@ -46,11 +47,11 @@ public class SseMcpServerRecorder {
 
     static final String CONTEXT_KEY = "mcp.sse.server-name";
 
-    private final McpServersRuntimeConfig config;
+    private final RuntimeValue<McpServersRuntimeConfig> config;
 
     private final McpSseServersBuildTimeConfig sseConfig;
 
-    public SseMcpServerRecorder(McpServersRuntimeConfig config, McpSseServersBuildTimeConfig sseConfig) {
+    public SseMcpServerRecorder(RuntimeValue<McpServersRuntimeConfig> config, McpSseServersBuildTimeConfig sseConfig) {
         this.config = config;
         this.sseConfig = sseConfig;
     }
@@ -121,7 +122,7 @@ public class SseMcpServerRecorder {
 
     public Handler<RoutingContext> createSseEndpointHandler(String mcpPath, String serverName) {
 
-        McpServerRuntimeConfig serverConfig = config.servers().get(serverName);
+        McpServerRuntimeConfig serverConfig = config.getValue().servers().get(serverName);
 
         ArcContainer container = Arc.container();
         ConnectionManager connectionManager = container.instance(ConnectionManager.class).get();

--- a/transports/stdio/runtime/src/main/java/io/quarkiverse/mcp/server/stdio/runtime/StdioMcpServerRecorder.java
+++ b/transports/stdio/runtime/src/main/java/io/quarkiverse/mcp/server/stdio/runtime/StdioMcpServerRecorder.java
@@ -8,6 +8,7 @@ import org.jboss.logging.Logger;
 import io.quarkiverse.mcp.server.stdio.runtime.config.McpStdioRuntimeConfig;
 import io.quarkus.arc.Arc;
 import io.quarkus.arc.ArcContainer;
+import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
 
 @Recorder
@@ -15,16 +16,16 @@ public class StdioMcpServerRecorder {
 
     private static final Logger LOG = Logger.getLogger(StdioMcpServerRecorder.class);
 
-    private final McpStdioRuntimeConfig stdioConfig;
+    private final RuntimeValue<McpStdioRuntimeConfig> stdioConfig;
 
-    public StdioMcpServerRecorder(McpStdioRuntimeConfig stdioConfig) {
+    public StdioMcpServerRecorder(RuntimeValue<McpStdioRuntimeConfig> stdioConfig) {
         this.stdioConfig = stdioConfig;
     }
 
     public void initialize() {
-        if (stdioConfig.enabled()) {
+        if (stdioConfig.getValue().enabled()) {
             PrintStream stdout = System.out;
-            if (stdioConfig.nullSystemOut()) {
+            if (stdioConfig.getValue().nullSystemOut()) {
                 System.setOut(new PrintStream(OutputStream.nullOutputStream()));
             }
             ArcContainer container = Arc.container();


### PR DESCRIPTION
With https://github.com/quarkusio/quarkus/pull/48500, we will disallow the injection of Runtime configuration objects during deployment. The recommended way is to inject it directly into the Recorder, wrapped in a `RuntimeValue`.