### PR TITLE
Introduce quarkus-mcp-server-bom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,12 +31,9 @@
   </scm>
 
     <properties>
-        <compiler-plugin.version>3.14.0</compiler-plugin.version>
-        <maven.compiler.release>17</maven.compiler.release>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <quarkus.version>3.20.2.2</quarkus.version>
         <jsonschema-generator.version>4.38.0</jsonschema-generator.version>
+        <sundrio.version>0.201.0</sundrio.version>
         <swagger-annotations.version>2.2.36</swagger-annotations.version>
     </properties>
 
@@ -61,19 +58,41 @@
                     <version>${quarkus.version}</version>
                 </plugin>
                 <plugin>
-                    <artifactId>maven-compiler-plugin</artifactId>
-                    <version>${compiler-plugin.version}</version>
-                    <configuration>
-                        <parameters>true</parameters>
-                    </configuration>
-                </plugin>
-                <plugin>
                     <groupId>io.quarkus</groupId>
                     <artifactId>quarkus-config-doc-maven-plugin</artifactId>
                     <version>${quarkus.version}</version>
                 </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>io.sundr</groupId>
+                <artifactId>sundr-maven-plugin</artifactId>
+                <version>${sundrio.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate-bom</goal>
+                        </goals>
+                        <configuration>
+                            <boms>
+                                <bom>
+                                    <artifactId>quarkus-mcp-server-bom</artifactId>
+                                    <name>Quarkus MCP Server - BOM</name>
+                                    <description>Centralized dependencyManagement for the Quarkus MCP Server Project</description>
+                                    <modules>
+                                        <excludes>
+                                            <exclude>io.quarkiverse.mcp:*-integration-tests</exclude>
+                                            <exclude>io.quarkiverse.mcp:quarkus-mcp-server-docs</exclude>
+                                        </excludes>
+                                    </modules>
+                                </bom>
+                            </boms>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
     <profiles>


### PR DESCRIPTION
Also cleanup pom.xml from values already defined in quarkiverse-parent

This is the generated BOM:

```xml
<?xml version='1.0' encoding='UTF-8'?>
<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
    <modelVersion>4.0.0</modelVersion>

    <groupId>io.quarkiverse.mcp</groupId>
    <artifactId>quarkus-mcp-server-bom</artifactId>
    <version>999-SNAPSHOT</version>
    <name>Quarkus MCP Server - BOM</name>
    <packaging>pom</packaging>
    <description>Centralized dependencyManagement for the Quarkus MCP Server Project</description>
    
    <url>https://quarkiverse.io</url>    
    <licenses>
        <license>
            <name>Apache License, Version 2.0</name>
            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
            <distribution>repo</distribution>
        </license>
    </licenses>
    
    
    <scm>
        <connection>scm:git:git@github.com:quarkiverse/quarkus-mcp-server.git</connection>
        <developerConnection>scm:git:git@github.com:quarkiverse/quarkus-mcp-server.git</developerConnection>
        <url>https://github.com/quarkiverse/quarkus-mcp-server</url>
        <tag>HEAD</tag>
    </scm>
            
    <developers>
        <developer>
            <id>quarkus</id>
            <name>Quarkus Community</name>
        </developer>
    </developers>
    <dependencyManagement>
        <dependencies>
            <dependency>
                <groupId>io.quarkiverse.mcp</groupId>
                <artifactId>quarkus-mcp-server-core</artifactId>
                <version>999-SNAPSHOT</version>
            </dependency>
            <dependency>
                <groupId>io.quarkiverse.mcp</groupId>
                <artifactId>quarkus-mcp-server-core-deployment</artifactId>
                <version>999-SNAPSHOT</version>
            </dependency>
            <dependency>
                <groupId>io.quarkiverse.mcp</groupId>
                <artifactId>quarkus-mcp-server-sse-client</artifactId>
                <version>999-SNAPSHOT</version>
            </dependency>
            <dependency>
                <groupId>io.quarkiverse.mcp</groupId>
                <artifactId>quarkus-mcp-server-sse</artifactId>
                <version>999-SNAPSHOT</version>
            </dependency>
            <dependency>
                <groupId>io.quarkiverse.mcp</groupId>
                <artifactId>quarkus-mcp-server-test</artifactId>
                <version>999-SNAPSHOT</version>
            </dependency>
            <dependency>
                <groupId>io.quarkiverse.mcp</groupId>
                <artifactId>quarkus-mcp-server-sse-deployment</artifactId>
                <version>999-SNAPSHOT</version>
            </dependency>
            <dependency>
                <groupId>io.quarkiverse.mcp</groupId>
                <artifactId>quarkus-mcp-server-stdio</artifactId>
                <version>999-SNAPSHOT</version>
            </dependency>
            <dependency>
                <groupId>io.quarkiverse.mcp</groupId>
                <artifactId>quarkus-mcp-server-stdio-deployment</artifactId>
                <version>999-SNAPSHOT</version>
            </dependency>
            <dependency>
                <groupId>io.quarkiverse.mcp</groupId>
                <artifactId>quarkus-mcp-stdio-sse-proxy</artifactId>
                <version>999-SNAPSHOT</version>
            </dependency>
            <dependency>
                <groupId>io.quarkiverse.mcp</groupId>
                <artifactId>quarkus-mcp-server-cli-adapter</artifactId>
                <version>999-SNAPSHOT</version>
            </dependency>
            <dependency>
                <groupId>io.quarkiverse.mcp</groupId>
                <artifactId>quarkus-mcp-server-cli-adapter-deployment</artifactId>
                <version>999-SNAPSHOT</version>
            </dependency>
        </dependencies>
    </dependencyManagement>
</project>
```
