### PR TITLE
Extract the ObjectMapperCustomizer logic from DefaultSchemaGenerator

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/McpServerProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/McpServerProcessor.java
@@ -84,6 +84,7 @@ import io.quarkiverse.mcp.server.runtime.FeatureMethodInfo;
 import io.quarkiverse.mcp.server.runtime.JsonTextContentEncoder;
 import io.quarkiverse.mcp.server.runtime.JsonTextResourceContentsEncoder;
 import io.quarkiverse.mcp.server.runtime.McpMetadata;
+import io.quarkiverse.mcp.server.runtime.McpObjectMapperCustomizer;
 import io.quarkiverse.mcp.server.runtime.McpServerRecorder;
 import io.quarkiverse.mcp.server.runtime.NotificationManagerImpl;
 import io.quarkiverse.mcp.server.runtime.PromptCompletionManagerImpl;
@@ -163,6 +164,7 @@ class McpServerProcessor {
         unremovable.addBeanClass("io.quarkiverse.mcp.server.runtime.ConnectionManager");
         unremovable.addBeanClass(ResponseHandlers.class);
         unremovable.addBeanClass(DefaultSchemaGenerator.class);
+        unremovable.addBeanClass(McpObjectMapperCustomizer.class);
         // Managers
         unremovable.addBeanClasses(PromptManagerImpl.class, ToolManagerImpl.class, ResourceManagerImpl.class,
                 PromptCompletionManagerImpl.class, ResourceTemplateManagerImpl.class,

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/DefaultSchemaGenerator.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/DefaultSchemaGenerator.java
@@ -5,33 +5,18 @@ import java.util.List;
 
 import jakarta.inject.Singleton;
 
-import com.fasterxml.jackson.annotation.JsonInclude;
-import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.victools.jsonschema.generator.Option;
 import com.github.victools.jsonschema.generator.OptionPreset;
 import com.github.victools.jsonschema.generator.SchemaGenerator;
 import com.github.victools.jsonschema.generator.SchemaGeneratorConfigBuilder;
 import com.github.victools.jsonschema.generator.SchemaVersion;
 
-import io.quarkiverse.mcp.server.AudioContent;
-import io.quarkiverse.mcp.server.BlobResourceContents;
-import io.quarkiverse.mcp.server.CompletionResponse;
-import io.quarkiverse.mcp.server.EmbeddedResource;
-import io.quarkiverse.mcp.server.ImageContent;
 import io.quarkiverse.mcp.server.OutputSchemaGenerator;
-import io.quarkiverse.mcp.server.PromptResponse;
-import io.quarkiverse.mcp.server.ResourceLink;
-import io.quarkiverse.mcp.server.ResourceResponse;
-import io.quarkiverse.mcp.server.TextContent;
-import io.quarkiverse.mcp.server.TextResourceContents;
-import io.quarkiverse.mcp.server.ToolResponse;
 import io.quarkus.arc.All;
-import io.quarkus.jackson.ObjectMapperCustomizer;
 
 @Singleton
-public class DefaultSchemaGenerator implements OutputSchemaGenerator, ObjectMapperCustomizer {
+public class DefaultSchemaGenerator implements OutputSchemaGenerator {
 
     private final SchemaGenerator schemaGenerator;
 
@@ -56,29 +41,6 @@ public class DefaultSchemaGenerator implements OutputSchemaGenerator, ObjectMapp
             customizer.customize(configBuilder);
         }
         return new SchemaGenerator(configBuilder.build());
-    }
-
-    @Override
-    public void customize(ObjectMapper objectMapper) {
-        objectMapper.addMixIn(ToolResponse.class, ResponseMixin.class);
-        objectMapper.addMixIn(PromptResponse.class, ResponseMixin.class);
-        objectMapper.addMixIn(ResourceResponse.class, ResponseMixin.class);
-        objectMapper.addMixIn(CompletionResponse.class, ResponseMixin.class);
-
-        objectMapper.addMixIn(TextResourceContents.class, ResponseMixin.class);
-        objectMapper.addMixIn(BlobResourceContents.class, ResponseMixin.class);
-
-        objectMapper.addMixIn(AudioContent.class, ResponseMixin.class);
-        objectMapper.addMixIn(EmbeddedResource.class, ResponseMixin.class);
-        objectMapper.addMixIn(ImageContent.class, ResponseMixin.class);
-        objectMapper.addMixIn(ResourceLink.class, ResponseMixin.class);
-        objectMapper.addMixIn(TextContent.class, ResponseMixin.class);
-
-    }
-
-    @JsonInclude(Include.NON_NULL)
-    static abstract class ResponseMixin {
-
     }
 
 }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpObjectMapperCustomizer.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpObjectMapperCustomizer.java
@@ -1,0 +1,48 @@
+package io.quarkiverse.mcp.server.runtime;
+
+import jakarta.inject.Singleton;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.quarkiverse.mcp.server.AudioContent;
+import io.quarkiverse.mcp.server.BlobResourceContents;
+import io.quarkiverse.mcp.server.CompletionResponse;
+import io.quarkiverse.mcp.server.EmbeddedResource;
+import io.quarkiverse.mcp.server.ImageContent;
+import io.quarkiverse.mcp.server.PromptResponse;
+import io.quarkiverse.mcp.server.ResourceLink;
+import io.quarkiverse.mcp.server.ResourceResponse;
+import io.quarkiverse.mcp.server.TextContent;
+import io.quarkiverse.mcp.server.TextResourceContents;
+import io.quarkiverse.mcp.server.ToolResponse;
+import io.quarkus.jackson.ObjectMapperCustomizer;
+
+@Singleton
+public class McpObjectMapperCustomizer implements ObjectMapperCustomizer {
+
+    @Override
+    public void customize(ObjectMapper objectMapper) {
+        objectMapper.addMixIn(ToolResponse.class, ResponseMixin.class);
+        objectMapper.addMixIn(PromptResponse.class, ResponseMixin.class);
+        objectMapper.addMixIn(ResourceResponse.class, ResponseMixin.class);
+        objectMapper.addMixIn(CompletionResponse.class, ResponseMixin.class);
+
+        objectMapper.addMixIn(TextResourceContents.class, ResponseMixin.class);
+        objectMapper.addMixIn(BlobResourceContents.class, ResponseMixin.class);
+
+        objectMapper.addMixIn(AudioContent.class, ResponseMixin.class);
+        objectMapper.addMixIn(EmbeddedResource.class, ResponseMixin.class);
+        objectMapper.addMixIn(ImageContent.class, ResponseMixin.class);
+        objectMapper.addMixIn(ResourceLink.class, ResponseMixin.class);
+        objectMapper.addMixIn(TextContent.class, ResponseMixin.class);
+
+    }
+
+    @JsonInclude(Include.NON_NULL)
+    static abstract class ResponseMixin {
+
+    }
+
+}


### PR DESCRIPTION
- because ObjectMapper is initialized during STATIC_INIT which may cause troubles when a SchemaGeneratorConfigCustomizer depends on runtime configuration mapping

This was fixed within https://github.com/quarkiverse/quarkus-mcp-server/pull/438 for the main branch.