### PR TITLE
Make it possible to attach additional metadata to feature definitions

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/DotNames.java
+++ b/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/DotNames.java
@@ -21,6 +21,7 @@ import io.quarkiverse.mcp.server.McpConnection;
 import io.quarkiverse.mcp.server.McpLog;
 import io.quarkiverse.mcp.server.McpServer;
 import io.quarkiverse.mcp.server.Meta;
+import io.quarkiverse.mcp.server.MetaField;
 import io.quarkiverse.mcp.server.Notification;
 import io.quarkiverse.mcp.server.Progress;
 import io.quarkiverse.mcp.server.Prompt;
@@ -112,5 +113,7 @@ class DotNames {
     static final DotName RAW_MESSAGE = DotName.createSimple(RawMessage.class);
     static final DotName META = DotName.createSimple(Meta.class);
     static final DotName ELICITATION = DotName.createSimple(Elicitation.class);
+    static final DotName META_FIELD = DotName.createSimple(MetaField.class);
+    static final DotName META_FIELDS = DotName.createSimple(MetaField.MetaFields.class);
 
 }

--- a/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/FeatureMethodBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/FeatureMethodBuildItem.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.mcp.server.deployment;
 
+import java.util.Map;
 import java.util.Objects;
 
 import org.jboss.jandex.MethodInfo;
@@ -45,11 +46,15 @@ final class FeatureMethodBuildItem extends MultiBuildItem {
     // Server config name
     private final String server;
 
+    // meta key (prefix + name) -> json
+    private final Map<String, String> metadata;
+
     FeatureMethodBuildItem(BeanInfo bean, MethodInfo method, InvokerInfo invoker, String name, String title, String description,
             String uri, String mimeType, int size, Feature feature, ToolManager.ToolAnnotations toolAnnotations,
             String server, boolean structuredContent, Type outputSchemaFrom, Type outputSchemaGenerator,
             Type inputSchemaGenerator,
-            Content.Annotations resourceAnnotations) {
+            Content.Annotations resourceAnnotations,
+            Map<String, String> metadata) {
         this.bean = Objects.requireNonNull(bean);
         this.method = Objects.requireNonNull(method);
         this.invoker = Objects.requireNonNull(invoker);
@@ -67,6 +72,7 @@ final class FeatureMethodBuildItem extends MultiBuildItem {
         this.outputSchemaGenerator = outputSchemaGenerator;
         this.inputSchemaGenerator = inputSchemaGenerator;
         this.resourceAnnotations = resourceAnnotations;
+        this.metadata = Objects.requireNonNull(metadata);
     }
 
     BeanInfo getBean() {
@@ -135,6 +141,10 @@ final class FeatureMethodBuildItem extends MultiBuildItem {
 
     Annotations getResourceAnnotations() {
         return resourceAnnotations;
+    }
+
+    Map<String, String> getMetadata() {
+        return metadata;
     }
 
     boolean isTool() {

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/Meta.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/Meta.java
@@ -3,7 +3,7 @@ package io.quarkiverse.mcp.server;
 import io.vertx.core.json.JsonObject;
 
 /**
- * Additional metadata sent from the client to the server.
+ * Additional metadata sent from the client to the server, i.e. the {@code _meta} part of the message.
  * <p>
  * All feature methods can accept this class as a parameter. It will be automatically injected before the
  * method is invoked.

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/MetaField.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/MetaField.java
@@ -1,0 +1,96 @@
+package io.quarkiverse.mcp.server;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import io.quarkiverse.mcp.server.MetaField.MetaFields;
+
+/**
+ * Represents an additional metadata field included in the {@code _meta} object of the relevant definition, such as {@code Tool}
+ * or {@code Resource}. It is a repeatable annotation.
+ * <p>
+ * {@link Tool}, {@link Prompt}, {@link Resource} and {@link ResourceTemplate} methods can be annotated:
+ *
+ * <pre>
+ * <code>
+ * class Tools {
+ *
+ *     {@literal @MetaField(name = "priceLevel", value = "high")}
+ *     {@literal @MetaField(name = "price", type = Type.INT, value = "100")}
+ *     {@literal @Tool(description = "Converts the string value to lower case")}
+ *     String toLowerCase(String value) {
+ *        return value.toLowerCase();
+ *     }
+ *  }
+ *  </code>
+ * </pre>
+ *
+ */
+@Retention(RUNTIME)
+@Target(METHOD)
+@Repeatable(MetaFields.class)
+public @interface MetaField {
+
+    /**
+     * Must be a series of labels separated by dots ({@code .}), followed by a slash ({@code /}).
+     * Labels must start with a letter and end with a letter or digit; interior characters can be letters, digits, or hyphens
+     * ({@code -}).
+     * Some prefixes are reserved for the MCP spec, e.g. {@code modelcontextprotocol.io/} or {@code tools.mcp.com/}.
+     *
+     * @return the prefix (optional)
+     * @see MetaKey
+     */
+    String prefix() default "";
+
+    /**
+     * Must begin and end with an alphanumeric character ({@code [a-z0-9A-Z]}).
+     * May contain hyphens ({@code -}), underscores ({@code _}), dots ({@code .}), and alphanumerics in between.
+     *
+     * @return the name
+     * @see MetaKey
+     */
+    String name();
+
+    /**
+     * @return the type of the value
+     * @see #value()
+     */
+    Type type() default Type.STRING;
+
+    /**
+     * @return the value
+     * @see #type()
+     */
+    String value();
+
+    enum Type {
+        /**
+         * Represents a JSON string value.
+         */
+        STRING,
+        /**
+         * Represents a JSON number value.
+         */
+        INT,
+        /**
+         * Represents a JSON boolean value.
+         */
+        BOOLEAN,
+        /**
+         * Represents any valid JSON value, including arrays and objects.
+         */
+        JSON
+    }
+
+    @Retention(RUNTIME)
+    @Target(METHOD)
+    @interface MetaFields {
+
+        MetaField[] value();
+
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/Prompt.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/Prompt.java
@@ -24,9 +24,14 @@ import io.smallrye.mutiny.Uni;
  * <li>It may also return a {@link Uni} that wraps any of the type mentioned above.</li>
  * </ul>
  *
+ * <p>
+ * If you need to provide additional metadata in the {@code _meta} object of the prompt definition included in the response to
+ * the {@code prompts/list} request, use the {@link MetaField} annotation.
+ *
  * @see PromptResponse
  * @see PromptArg
  * @see PromptResponseEncoder
+ * @see MetaField
  */
 @Retention(RUNTIME)
 @Target(METHOD)

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/PromptManager.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/PromptManager.java
@@ -42,6 +42,8 @@ public interface PromptManager extends FeatureManager<PromptInfo> {
 
         List<PromptArgument> arguments();
 
+        Map<MetaKey, Object> metadata();
+
     }
 
     /**
@@ -92,6 +94,12 @@ public interface PromptManager extends FeatureManager<PromptInfo> {
          * @return self
          */
         PromptDefinition addArgument(String name, String title, String description, boolean required, String defaultValue);
+
+        /**
+         * @param metadata
+         * @return self
+         */
+        PromptDefinition setMetadata(Map<MetaKey, Object> metadata);
 
         /**
          * @return the prompt info

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/Resource.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/Resource.java
@@ -26,9 +26,15 @@ import java.lang.annotation.Target;
  * <p>
  * There is a default resource contents encoder registered; it encodes the returned value as JSON.
  *
+ * <p>
+ * If you need to provide additional metadata in the {@code _meta} object of the resource definition included in the response to
+ * the
+ * {@code resources/list} request, use the {@link MetaField} annotation.
+ *
  * @see ResourceTemplate
  * @see ResourceResponse
  * @see ResourceContentsEncoder
+ * @see MetaField
  */
 @Retention(RUNTIME)
 @Target(METHOD)

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/ResourceManager.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/ResourceManager.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.mcp.server;
 
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 
@@ -47,6 +48,8 @@ public interface ResourceManager extends FeatureManager<ResourceInfo> {
         OptionalInt size();
 
         Optional<Content.Annotations> annotations();
+
+        Map<MetaKey, Object> metadata();
 
         /**
          * Sends update notifications to all subscribers without waiting for the result.
@@ -98,6 +101,12 @@ public interface ResourceManager extends FeatureManager<ResourceInfo> {
          * @return self
          */
         ResourceDefinition setAnnotations(Content.Annotations annotations);
+
+        /**
+         * @param metadata
+         * @return self
+         */
+        ResourceDefinition setMetadata(Map<MetaKey, Object> metadata);
 
         /**
          * @return the resource info

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/ResourceTemplate.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/ResourceTemplate.java
@@ -29,9 +29,15 @@ import io.smallrye.mutiny.Uni;
  * <p>
  * There is a default resource contents encoder registered; it encodes the returned value as JSON.
  *
+ * <p>
+ * If you need to provide additional metadata in the {@code _meta} object of the resource template definition included in the
+ * response to the
+ * {@code resources/templates/list} request, use the {@link MetaField} annotation.
+ *
  * @see Resource
  * @see ResourceResponse
  * @see ResourceContentsEncoder
+ * @see MetaField
  */
 @Retention(RUNTIME)
 @Target(METHOD)

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/ResourceTemplateManager.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/ResourceTemplateManager.java
@@ -44,6 +44,8 @@ public interface ResourceTemplateManager extends FeatureManager<ResourceTemplate
 
         String mimeType();
 
+        Map<MetaKey, Object> metadata();
+
         Optional<Content.Annotations> annotations();
 
     }
@@ -83,6 +85,12 @@ public interface ResourceTemplateManager extends FeatureManager<ResourceTemplate
          * @return self
          */
         ResourceTemplateDefinition setAnnotations(Content.Annotations annotations);
+
+        /**
+         * @param metadata
+         * @return self
+         */
+        ResourceTemplateDefinition setMetadata(Map<MetaKey, Object> metadata);
 
         /**
          * @throws IllegalArgumentException if a resource template with the given name already exits

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/Tool.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/Tool.java
@@ -29,10 +29,15 @@ import java.lang.annotation.Target;
  * <p>
  * There is a default content encoder registered; it encodes the returned value as JSON.
  *
+ * <p>
+ * If you need to provide additional metadata in the {@code _meta} object of the tool definition included in the response to the
+ * {@code tools/list} request, use the {@link MetaField} annotation.
+ *
  * @see ToolResponse
  * @see ToolArg
  * @see ToolResponseEncoder
  * @see ContentEncoder
+ * @see MetaField
  */
 @Retention(RUNTIME)
 @Target(METHOD)

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/ToolManager.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/ToolManager.java
@@ -45,6 +45,8 @@ public interface ToolManager extends FeatureManager<ToolInfo> {
 
         Optional<ToolAnnotations> annotations();
 
+        Map<MetaKey, Object> metadata();
+
     }
 
     /**
@@ -113,6 +115,12 @@ public interface ToolManager extends FeatureManager<ToolInfo> {
          * @return self
          */
         ToolDefinition setInputSchema(Object schema);
+
+        /**
+         * @param metadata
+         * @return self
+         */
+        ToolDefinition setMetadata(Map<MetaKey, Object> metadata);
 
         /**
          * @return the tool info

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/FeatureMetadata.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/FeatureMetadata.java
@@ -1,11 +1,13 @@
 package io.quarkiverse.mcp.server.runtime;
 
+import java.util.Map;
 import java.util.function.Function;
 
 import jakarta.enterprise.invoke.Invoker;
 
 import io.quarkiverse.mcp.server.runtime.ResultMappers.Result;
 import io.smallrye.mutiny.Uni;
+import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
@@ -52,6 +54,13 @@ public record FeatureMetadata<M>(Feature feature,
             if (info.resourceAnnotations() != null) {
                 ret.put("annotations", info.resourceAnnotations());
             }
+        }
+        if (!info.metadata().isEmpty()) {
+            JsonObject meta = new JsonObject();
+            for (Map.Entry<String, String> e : info.metadata().entrySet()) {
+                meta.put(e.getKey(), Json.decodeValue(e.getValue()));
+            }
+            ret.put("_meta", meta);
         }
         return ret;
     }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/FeatureMethodInfo.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/FeatureMethodInfo.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.mcp.server.runtime;
 
 import java.util.List;
+import java.util.Map;
 
 import io.quarkiverse.mcp.server.Content;
 import io.quarkiverse.mcp.server.InputSchemaGenerator;
@@ -20,7 +21,9 @@ public record FeatureMethodInfo(String name,
         String serverName,
         Class<?> outputSchemaFrom,
         Class<? extends OutputSchemaGenerator> outputSchemaGenerator,
-        Class<? extends InputSchemaGenerator<?>> inputSchemaGenerator) {
+        Class<? extends InputSchemaGenerator<?>> inputSchemaGenerator,
+        // meta key (prefix + name) -> json
+        Map<String, String> metadata) {
 
     public List<FeatureArgument> serializedArguments() {
         if (arguments == null) {

--- a/test/src/main/java/io/quarkiverse/mcp/server/test/McpAssured.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/McpAssured.java
@@ -1330,18 +1330,18 @@ public class McpAssured {
     }
 
     public record ToolInfo(String name, String title, String description, JsonObject inputSchema, JsonObject outputSchema,
-            Optional<ToolAnnotations> annotations) {
+            Optional<ToolAnnotations> annotations, JsonObject meta) {
     }
 
-    public record PromptInfo(String name, String title, String description, List<PromptArgument> arguments) {
+    public record PromptInfo(String name, String title, String description, List<PromptArgument> arguments, JsonObject meta) {
     }
 
     public record ResourceInfo(String uri, String mimeType, String name, String title, String description, Integer size,
-            Content.Annotations annotations) {
+            Content.Annotations annotations, JsonObject meta) {
     }
 
     public record ResourceTemplateInfo(String uriTemplate, String mimeType, String name, String title, String description,
-            Content.Annotations annotations) {
+            Content.Annotations annotations, JsonObject meta) {
     }
 
     public record PromptArgument(String name, String title, String description, boolean required) {

--- a/test/src/main/java/io/quarkiverse/mcp/server/test/McpTestClientBase.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/McpTestClientBase.java
@@ -995,7 +995,7 @@ abstract class McpTestClientBase<ASSERT extends McpAssert<ASSERT>, CLIENT extend
         private ResourceInfo parseResource(JsonObject resource) {
             return new ResourceInfo(resource.getString("uri"), resource.getString("mimeType"), resource.getString("name"),
                     resource.getString("title"), resource.getString("description"), resource.getInteger("size"),
-                    Contents.parseAnnotations(resource));
+                    Contents.parseAnnotations(resource), resource.getJsonObject("_meta"));
         }
     }
 
@@ -1021,7 +1021,8 @@ abstract class McpTestClientBase<ASSERT extends McpAssert<ASSERT>, CLIENT extend
                     resource.getString("name"),
                     resource.getString("title"),
                     resource.getString("description"),
-                    Contents.parseAnnotations(resource));
+                    Contents.parseAnnotations(resource),
+                    resource.getJsonObject("_meta"));
         }
     }
 
@@ -1055,7 +1056,7 @@ abstract class McpTestClientBase<ASSERT extends McpAssert<ASSERT>, CLIENT extend
                 }
             }
             return new PromptInfo(prompt.getString("name"), prompt.getString("title"),
-                    prompt.getString("description"), promptArgs);
+                    prompt.getString("description"), promptArgs, prompt.getJsonObject("_meta"));
         }
     }
 
@@ -1138,7 +1139,8 @@ abstract class McpTestClientBase<ASSERT extends McpAssert<ASSERT>, CLIENT extend
                     tool.getString("description"),
                     tool.getJsonObject("inputSchema"),
                     tool.getJsonObject("outputSchema"),
-                    toolAnnotations);
+                    toolAnnotations,
+                    tool.getJsonObject("_meta"));
         }
     }
 

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/MyTools.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/MyTools.java
@@ -17,6 +17,8 @@ import jakarta.inject.Inject;
 import dev.langchain4j.agent.tool.P;
 import io.quarkiverse.mcp.server.Content;
 import io.quarkiverse.mcp.server.McpConnection;
+import io.quarkiverse.mcp.server.MetaField;
+import io.quarkiverse.mcp.server.MetaField.Type;
 import io.quarkiverse.mcp.server.MetaKey;
 import io.quarkiverse.mcp.server.Role;
 import io.quarkiverse.mcp.server.TextContent;
@@ -32,6 +34,13 @@ public class MyTools {
     @Inject
     FooService fooService;
 
+    @MetaField(name = "priceLevel", value = "high")
+    @MetaField(name = "price", type = Type.INT, value = "100")
+    @MetaField(name = "active", type = Type.BOOLEAN, value = "true")
+    @MetaField(name = "activeNumbers", type = Type.JSON, value = "[1, 2, 3]")
+    @MetaField(name = "object", type = Type.JSON, value = """
+            {\"foo\":true}
+            """)
     @Tool
     ToolResponse alpha(@ToolArg(description = "Define the price...") Optional<Integer> price) {
         checkExecutionModel(true);

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/ProgrammaticToolTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/ProgrammaticToolTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkiverse.mcp.server.JsonRpcErrorCodes;
+import io.quarkiverse.mcp.server.MetaKey;
 import io.quarkiverse.mcp.server.ToolManager;
 import io.quarkiverse.mcp.server.ToolManager.ToolArguments;
 import io.quarkiverse.mcp.server.ToolResponse;
@@ -59,6 +60,7 @@ public class ProgrammaticToolTest extends McpServerTest {
                 .toolsList(page -> {
                     assertEquals(1, page.size());
                     assertEquals("ALPHA", page.tools().get(0).title());
+                    assertEquals("ALPHA", page.tools().get(0).meta().getString("upperCaseName"));
                 })
                 .toolsCall("alpha", Map.of("foo", 2), r -> assertEquals("22", r.content().get(0).asText().text()))
                 .thenAssertResults();
@@ -115,6 +117,7 @@ public class ProgrammaticToolTest extends McpServerTest {
                                 lastArgs.set(toolArgs);
                                 return ToolResponse.success(result + toolArgs.args().get("foo"));
                             })
+                    .setMetadata(Map.of(MetaKey.of("upperCaseName"), name.toUpperCase()))
                     .register();
         }
 

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/ToolsTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/ToolsTest.java
@@ -50,6 +50,13 @@ public class ToolsTest extends McpServerTest {
                     assertEquals("integer", priceProperty.getString("type"));
                     assertEquals("Define the price...", priceProperty.getString("description"));
                     assertTrue(schema.getJsonArray("required").isEmpty());
+                    JsonObject meta = alpha.meta();
+                    assertNotNull(meta);
+                    assertEquals("high", meta.getString("priceLevel"));
+                    assertEquals(100, meta.getInteger("price"));
+                    assertTrue(meta.getBoolean("active"));
+                    assertEquals(3, meta.getJsonArray("activeNumbers").getInteger(2));
+                    assertTrue(meta.getJsonObject("object").getBoolean("foo"));
 
                     ToolInfo uniAlpha = page.findByName("uni_alpha");
                     assertEquals("Uni Alpha!", uniAlpha.title());

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/validation/ToolInvalidMetaFieldJsonTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/validation/ToolInvalidMetaFieldJsonTest.java
@@ -1,0 +1,38 @@
+package io.quarkiverse.mcp.server.test.validation;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.MetaField;
+import io.quarkiverse.mcp.server.MetaField.Type;
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolCallException;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ToolInvalidMetaFieldJsonTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(InvalidMetaField.class);
+            })
+            .setExpectedException(IllegalArgumentException.class, true);
+
+    @Test
+    public void test() {
+        fail();
+    }
+
+    public static class InvalidMetaField {
+
+        @MetaField(name = "foo", prefix = "foo.bar/", type = Type.JSON, value = "{{}}")
+        @Tool
+        String foo() {
+            throw new ToolCallException("boom");
+        }
+
+    }
+
+}

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/validation/ToolInvalidMetaFieldNameTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/validation/ToolInvalidMetaFieldNameTest.java
@@ -1,0 +1,37 @@
+package io.quarkiverse.mcp.server.test.validation;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.MetaField;
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolCallException;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ToolInvalidMetaFieldNameTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(InvalidMetaField.class);
+            })
+            .setExpectedException(IllegalArgumentException.class, true);
+
+    @Test
+    public void test() {
+        fail();
+    }
+
+    public static class InvalidMetaField {
+
+        @MetaField(name = "_foo", value = "nok")
+        @Tool
+        String foo() {
+            throw new ToolCallException("boom");
+        }
+
+    }
+
+}

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/validation/ToolInvalidMetaFieldPrefixTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/validation/ToolInvalidMetaFieldPrefixTest.java
@@ -1,0 +1,37 @@
+package io.quarkiverse.mcp.server.test.validation;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.MetaField;
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolCallException;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ToolInvalidMetaFieldPrefixTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(InvalidMetaField.class);
+            })
+            .setExpectedException(IllegalArgumentException.class, true);
+
+    @Test
+    public void test() {
+        fail();
+    }
+
+    public static class InvalidMetaField {
+
+        @MetaField(name = "foo", prefix = "mcp", value = "nok")
+        @Tool
+        String foo() {
+            throw new ToolCallException("boom");
+        }
+
+    }
+
+}


### PR DESCRIPTION
- introduce MetaField annotation
- add setMetadata() to feature definitions (programmatic API)
- fixes #498

The declarative API looks like:
```java
class Tools {
 
    @MetaField(name = "priceLevel", value = "high")
    @MetaField(name = "price", type = Type.INT, value = "100")
    @MetaField(name = "active", type = Type.BOOLEAN, value = "true")
    @MetaField(name = "activeNumbers", type = Type.JSON, value = "[1, 2, 3]")
    @MetaField(name = "object", type = Type.JSON, value = """
            {\"foo\":true}
            """)
    @Tool(description = "Converts the string value to lower case")
    String toLowerCase(String value) {
        return value.toLowerCase();
    }
}
```

CC @jmartisk @cescoffier 