### PR TITLE
streamable: make it possible to perform dummy initialization

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-mcp-server-http.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-mcp-server-http.adoc
@@ -62,5 +62,38 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++false+++`
 
+a|icon:lock[title=Fixed at build time] [[quarkus-mcp-server-http_quarkus-mcp-server-http-streamable-dummy-init]] [.property-path]##link:#quarkus-mcp-server-http_quarkus-mcp-server-http-streamable-dummy-init[`quarkus.mcp.server.http.streamable.dummy-init`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.http.streamable.dummy-init+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.mcp.server."server-name".http.streamable.dummy-init`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server."server-name".http.streamable.dummy-init+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+If set to `true` then the server performs a dummy initialization when the first message from the client is not
+`initialize`. A new MCP session is created for each request. The capability negotiation and protocol version
+agreement is completely skipped, so the dummy client supports no capabilities.
+
+Dummy initialization can be used to simulate stateless communication. However, it's not efficient and some
+features may not work properly.
+
+This config property will be deprecated once the stateless mode is codified in the MCP specification.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_HTTP_STREAMABLE_DUMMY_INIT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_HTTP_STREAMABLE_DUMMY_INIT+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
 |===
 

--- a/docs/modules/ROOT/pages/includes/quarkus-mcp-server-http_quarkus.mcp.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-mcp-server-http_quarkus.mcp.adoc
@@ -62,5 +62,38 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++false+++`
 
+a|icon:lock[title=Fixed at build time] [[quarkus-mcp-server-http_quarkus-mcp-server-http-streamable-dummy-init]] [.property-path]##link:#quarkus-mcp-server-http_quarkus-mcp-server-http-streamable-dummy-init[`quarkus.mcp.server.http.streamable.dummy-init`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.http.streamable.dummy-init+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.mcp.server."server-name".http.streamable.dummy-init`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server."server-name".http.streamable.dummy-init+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+If set to `true` then the server performs a dummy initialization when the first message from the client is not
+`initialize`. A new MCP session is created for each request. The capability negotiation and protocol version
+agreement is completely skipped, so the dummy client supports no capabilities.
+
+Dummy initialization can be used to simulate stateless communication. However, it's not efficient and some
+features may not work properly.
+
+This config property will be deprecated once the stateless mode is codified in the MCP specification.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_HTTP_STREAMABLE_DUMMY_INIT+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_HTTP_STREAMABLE_DUMMY_INIT+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
 |===
 

--- a/test/src/main/java/io/quarkiverse/mcp/server/test/McpAssured.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/McpAssured.java
@@ -128,6 +128,8 @@ public class McpAssured {
 
         /**
          * Disconnect the client and terminate the MCP connection.
+         * <p>
+         * Does not necessarily terminate the session on the server.
          */
         void disconnect();
 
@@ -335,6 +337,11 @@ public class McpAssured {
          * @return the current MCP session id
          */
         String mcpSessionId();
+
+        /**
+         * Terminates the current MCP session on the server.
+         */
+        void terminateSession();
 
         public interface Builder extends McpTestClient.Builder<Builder> {
 

--- a/test/src/main/java/io/quarkiverse/mcp/server/test/McpStreamableClient.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/McpStreamableClient.java
@@ -43,8 +43,23 @@ class McpStreamableClient extends SseClient {
                 .header("Accept", "application/json")
                 .POST(BodyPublishers.ofString(body));
         headers.forEach(builder::header);
+        return doSend(builder.build());
+    }
+
+    HttpResponse<String> sendTerminate(MultiMap headers) {
+        HttpRequest.Builder builder = HttpRequest.newBuilder()
+                .uri(mcpEndpoint)
+                .version(Version.HTTP_1_1)
+                .header("Accept", "text/event-stream")
+                .header("Accept", "application/json")
+                .DELETE();
+        headers.forEach(builder::header);
+        return doSend(builder.build());
+    }
+
+    private HttpResponse<String> doSend(HttpRequest request) {
         try {
-            return httpClient.send(builder.build(), BodyHandlers.ofString());
+            return httpClient.send(request, BodyHandlers.ofString());
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new IllegalStateException("Interrupted");

--- a/test/src/main/java/io/quarkiverse/mcp/server/test/McpStreamableTestClientImpl.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/McpStreamableTestClientImpl.java
@@ -147,6 +147,15 @@ class McpStreamableTestClientImpl extends McpTestClientBase<McpStreamableAssert,
     }
 
     @Override
+    public void terminateSession() {
+        MultiMap headers = MultiMap.caseInsensitiveMultiMap();
+        if (mcpSessionId != null) {
+            headers.add("Mcp-Session-Id", mcpSessionId);
+        }
+        client.sendTerminate(headers);
+    }
+
+    @Override
     public McpStreamableAssert when() {
         return new McpStreamableAssertImpl();
     }

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/dummyinit/DummyInitTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/dummyinit/DummyInitTest.java
@@ -1,0 +1,102 @@
+package io.quarkiverse.mcp.server.test.dummyinit;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.net.URI;
+import java.util.stream.StreamSupport;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.McpConnection;
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.WrapBusinessError;
+import io.quarkiverse.mcp.server.http.runtime.StreamableHttpMcpMessageHandler;
+import io.quarkiverse.mcp.server.runtime.ConnectionManager;
+import io.quarkiverse.mcp.server.runtime.McpConnectionBase;
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkiverse.mcp.server.test.McpAssured.McpStreamableTestClient;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.json.JsonObject;
+
+public class DummyInitTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .withApplicationRoot(
+                    root -> root.addClasses(MyTools.class))
+            .overrideConfigKey("quarkus.mcp.server.http.streamable.dummy-init", "true");
+
+    @Inject
+    ConnectionManager connectionManager;
+
+    @Test
+    public void testToolCall() {
+        int id = 0;
+        McpStreamableTestClient client = McpAssured.newConnectedStreamableClient();
+        URI endpoint = client.mcpEndpoint();
+        client.terminateSession();
+        client.disconnect();
+
+        JsonObject response = new JsonObject(RestAssured.given()
+                .when()
+                // Non-existent session should not be a problem
+                .headers(StreamableHttpMcpMessageHandler.MCP_SESSION_ID_HEADER, "definitelyDoesNotExist",
+                        HttpHeaders.ACCEPT + "", "application/json, text/event-stream")
+                .body(toolsCall("bravo", id++).encode())
+                .post(endpoint)
+                .then()
+                .statusCode(200)
+                .extract().body().asString());
+        String connectionId = response.getJsonObject("result").getJsonArray("content").getJsonObject(0).getString("text");
+        assertFalse(connectionManager.has(connectionId));
+        assertFalse(response.getJsonObject("result").getBoolean("isError"));
+
+        response = new JsonObject(RestAssured.given()
+                .when()
+                // .log().all()
+                .headers(HttpHeaders.ACCEPT + "",
+                        "application/json, text/event-stream")
+                .body(toolsCall("charlie", id++).encode())
+                .post(endpoint)
+                .then()
+                .statusCode(200)
+                .extract().body().asString());
+        assertTrue(response.getJsonObject("result").getBoolean("isError"));
+        assertFalse(connectionManager.iterator().hasNext(), "Connections: "
+                + StreamSupport.stream(connectionManager.spliterator(), false).map(McpConnectionBase::id).toList());
+    }
+
+    private JsonObject toolsCall(String name, int id) {
+        return new JsonObject()
+                .put("jsonrpc", "2.0")
+                .put("method", McpAssured.TOOLS_CALL)
+                .put("id", id)
+                .put("params", new JsonObject().put("name", name));
+    }
+
+    public static class MyTools {
+
+        @Tool
+        String bravo(McpConnection connection) {
+            if (!connection.initialRequest().implementation().name()
+                    .equals(StreamableHttpMcpMessageHandler.DUMMY_INIT_IMPL_NAME)) {
+                throw new IllegalStateException();
+            }
+            return connection.id();
+        }
+
+        @WrapBusinessError
+        @Tool
+        String charlie() {
+            throw new IllegalArgumentException();
+        }
+    }
+
+}

--- a/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/HttpMcpServerRecorder.java
+++ b/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/HttpMcpServerRecorder.java
@@ -45,7 +45,7 @@ public class HttpMcpServerRecorder {
 
     private static final Logger LOG = Logger.getLogger(HttpMcpServerRecorder.class);
 
-    static final String CONTEXT_KEY = "mcp.sse.server-name";
+    static final String CONTEXT_KEY = "mcp.http.server-name";
 
     private final RuntimeValue<McpServersRuntimeConfig> config;
 

--- a/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/StreamableHttpMcpConnection.java
+++ b/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/StreamableHttpMcpConnection.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.mcp.server.http.runtime;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CopyOnWriteArrayList;
 
 import org.jboss.logging.Logger;
@@ -18,7 +19,7 @@ class StreamableHttpMcpConnection extends McpConnectionBase {
     private final List<SubsidiarySse> sseStreams;
 
     StreamableHttpMcpConnection(String id, McpServerRuntimeConfig serverConfig) {
-        super(id, serverConfig);
+        super(id, Objects.requireNonNull(serverConfig));
         this.sseStreams = new CopyOnWriteArrayList<>();
     }
 

--- a/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/config/McpHttpServerRuntimeConfig.java
+++ b/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/config/McpHttpServerRuntimeConfig.java
@@ -1,0 +1,40 @@
+package io.quarkiverse.mcp.server.http.runtime.config;
+
+import io.smallrye.config.WithDefault;
+
+public interface McpHttpServerRuntimeConfig {
+
+    /**
+     * HTTP transport configuration.
+     */
+    Http http();
+
+    public interface Http {
+
+        /**
+         * Streamable HTTP transport configuration.
+         */
+        Streamable streamable();
+
+        public interface Streamable {
+
+            /**
+             * If set to `true` then the server performs a dummy initialization when the first message from the client is not
+             * `initialize`. A new MCP session is created for each request. The capability negotiation and protocol version
+             * agreement is completely skipped, so the dummy client supports no capabilities.
+             *
+             * Dummy initialization can be used to simulate stateless communication. However, it's not efficient and some
+             * features may not work properly.
+             *
+             * This config property will be deprecated once the stateless mode is codified in the MCP specification.
+             *
+             * @asciidoclet
+             */
+            @WithDefault("false")
+            boolean dummyInit();
+
+        }
+
+    }
+
+}

--- a/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/config/McpHttpServersRuntimeConfig.java
+++ b/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/config/McpHttpServersRuntimeConfig.java
@@ -1,0 +1,27 @@
+package io.quarkiverse.mcp.server.http.runtime.config;
+
+import java.util.Map;
+
+import io.quarkiverse.mcp.server.McpServer;
+import io.quarkus.runtime.annotations.ConfigDocMapKey;
+import io.quarkus.runtime.annotations.ConfigPhase;
+import io.quarkus.runtime.annotations.ConfigRoot;
+import io.smallrye.config.ConfigMapping;
+import io.smallrye.config.WithDefaults;
+import io.smallrye.config.WithParentName;
+import io.smallrye.config.WithUnnamedKey;
+
+@ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+@ConfigMapping(prefix = "quarkus.mcp.server")
+public interface McpHttpServersRuntimeConfig {
+
+    /**
+     * HTTP server configurations.
+     */
+    @ConfigDocMapKey("server-name")
+    @WithParentName
+    @WithDefaults
+    @WithUnnamedKey(McpServer.DEFAULT)
+    Map<String, McpHttpServerRuntimeConfig> servers();
+
+}


### PR DESCRIPTION
- and relax the requirement for client initialization
- can be used to simulate stateless communication