### PR TITLE
Tool input/output guardrails

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/DotNames.java
+++ b/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/DotNames.java
@@ -44,10 +44,12 @@ import io.quarkiverse.mcp.server.ResourceTemplateCompletionManager;
 import io.quarkiverse.mcp.server.ResourceTemplateManager;
 import io.quarkiverse.mcp.server.Roots;
 import io.quarkiverse.mcp.server.Sampling;
+import io.quarkiverse.mcp.server.SupportedExecutionModels;
 import io.quarkiverse.mcp.server.TextContent;
 import io.quarkiverse.mcp.server.TextResourceContents;
 import io.quarkiverse.mcp.server.Tool;
 import io.quarkiverse.mcp.server.ToolArg;
+import io.quarkiverse.mcp.server.ToolGuardrails;
 import io.quarkiverse.mcp.server.ToolManager;
 import io.quarkiverse.mcp.server.ToolResponse;
 import io.smallrye.common.annotation.Blocking;
@@ -115,5 +117,7 @@ class DotNames {
     static final DotName ELICITATION = DotName.createSimple(Elicitation.class);
     static final DotName META_FIELD = DotName.createSimple(MetaField.class);
     static final DotName META_FIELDS = DotName.createSimple(MetaField.MetaFields.class);
+    static final DotName TOOL_GUARDRAILS = DotName.createSimple(ToolGuardrails.class);
+    static final DotName SUPPORTED_EXEC_MODELS = DotName.createSimple(SupportedExecutionModels.class);
 
 }

--- a/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/FeatureMethodBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/FeatureMethodBuildItem.java
@@ -1,13 +1,16 @@
 package io.quarkiverse.mcp.server.deployment;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import org.jboss.jandex.DotName;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.Type;
 
 import io.quarkiverse.mcp.server.Content;
 import io.quarkiverse.mcp.server.Content.Annotations;
+import io.quarkiverse.mcp.server.ExecutionModel;
 import io.quarkiverse.mcp.server.ToolManager;
 import io.quarkiverse.mcp.server.runtime.Feature;
 import io.quarkus.arc.processor.BeanInfo;
@@ -17,6 +20,7 @@ import io.quarkus.builder.item.MultiBuildItem;
 final class FeatureMethodBuildItem extends MultiBuildItem {
 
     private final Feature feature;
+    private final ExecutionModel executionModel;
 
     // Invocation info
     private final BeanInfo bean;
@@ -43,6 +47,9 @@ final class FeatureMethodBuildItem extends MultiBuildItem {
     private final Type outputSchemaGenerator;
     private final Type inputSchemaGenerator;
 
+    private final List<DotName> inputGuardrails;
+    private final List<DotName> outputGuardrails;
+
     // Server config name
     private final String server;
 
@@ -54,7 +61,10 @@ final class FeatureMethodBuildItem extends MultiBuildItem {
             String server, boolean structuredContent, Type outputSchemaFrom, Type outputSchemaGenerator,
             Type inputSchemaGenerator,
             Content.Annotations resourceAnnotations,
-            Map<String, String> metadata) {
+            Map<String, String> metadata,
+            List<DotName> inputGuardrails,
+            List<DotName> outputGuardrails,
+            ExecutionModel executionModel) {
         this.bean = Objects.requireNonNull(bean);
         this.method = Objects.requireNonNull(method);
         this.invoker = Objects.requireNonNull(invoker);
@@ -73,6 +83,9 @@ final class FeatureMethodBuildItem extends MultiBuildItem {
         this.inputSchemaGenerator = inputSchemaGenerator;
         this.resourceAnnotations = resourceAnnotations;
         this.metadata = Objects.requireNonNull(metadata);
+        this.inputGuardrails = inputGuardrails;
+        this.outputGuardrails = outputGuardrails;
+        this.executionModel = executionModel;
     }
 
     BeanInfo getBean() {
@@ -145,6 +158,18 @@ final class FeatureMethodBuildItem extends MultiBuildItem {
 
     Map<String, String> getMetadata() {
         return metadata;
+    }
+
+    public List<DotName> getInputGuardrails() {
+        return inputGuardrails;
+    }
+
+    public List<DotName> getOutputGuardrails() {
+        return outputGuardrails;
+    }
+
+    public ExecutionModel getExecutionModel() {
+        return executionModel;
     }
 
     boolean isTool() {

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/ExecutionModel.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/ExecutionModel.java
@@ -1,0 +1,27 @@
+package io.quarkiverse.mcp.server;
+
+/**
+ * An execution model of a feature method.
+ *
+ * @see Tool
+ * @see Prompt
+ * @see Resource
+ */
+public enum ExecutionModel {
+
+    /**
+     * Feature is considered blocking and should be executed on a worker thread.
+     */
+    WORKER_THREAD,
+
+    /**
+     * Feature is considered blocking and should be executed on a virtual thread.
+     */
+    VIRTUAL_THREAD,
+
+    /**
+     * Feature method is considered non-blocking and should be executed on an event loop thread.
+     */
+    EVENT_LOOP
+
+}

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/FeatureManager.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/FeatureManager.java
@@ -4,7 +4,6 @@ import java.time.Instant;
 import java.util.function.Function;
 
 import io.quarkiverse.mcp.server.FeatureManager.FeatureInfo;
-import io.quarkiverse.mcp.server.runtime.ExecutionModel;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.json.JsonObject;
 
@@ -52,6 +51,11 @@ public interface FeatureManager<INFO extends FeatureInfo> extends Iterable<INFO>
         }
 
         JsonObject asJson();
+
+        /**
+         * @return the execution model
+         */
+        ExecutionModel executionModel();
 
     }
 

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/SupportedExecutionModels.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/SupportedExecutionModels.java
@@ -1,0 +1,26 @@
+package io.quarkiverse.mcp.server;
+
+import static io.quarkiverse.mcp.server.ExecutionModel.EVENT_LOOP;
+import static io.quarkiverse.mcp.server.ExecutionModel.VIRTUAL_THREAD;
+import static io.quarkiverse.mcp.server.ExecutionModel.WORKER_THREAD;
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+/**
+ * Defines the supported execution models for a tool guardrail.
+ *
+ * @see ToolInputGuardrail
+ * @see ToolOutputGuardrail
+ */
+@Retention(RUNTIME)
+@Target(TYPE)
+public @interface SupportedExecutionModels {
+
+    /**
+     * The supported execution models.
+     */
+    ExecutionModel[] value() default { EVENT_LOOP, VIRTUAL_THREAD, WORKER_THREAD };
+}

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/ToolGuardrails.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/ToolGuardrails.java
@@ -1,0 +1,40 @@
+package io.quarkiverse.mcp.server;
+
+import static java.lang.annotation.ElementType.METHOD;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import io.smallrye.common.annotation.Experimental;
+
+/**
+ * Associate guardrails with a tool call.
+ *
+ * @see Tool
+ * @see ToolInputGuardrail
+ * @see ToolOutputGuardrail
+ */
+@Experimental("This API is experimental and may change in the future")
+@Retention(RUNTIME)
+@Target(METHOD)
+public @interface ToolGuardrails {
+
+    /**
+     * Input guardrails can be used to validate and/or transform the arguments of a tool call.
+     * <p>
+     * The guardrails are executed in the specified order before a tool call.
+     *
+     * @see ToolInputGuardrail
+     */
+    Class<? extends ToolInputGuardrail>[] input() default {};
+
+    /**
+     * Output guardrails can be used to validate and/or transform the result of a tool call.
+     * <p>
+     * The guardrails are executed in the specified order after a tool call.
+     *
+     * @see ToolOutputGuardrail
+     */
+    Class<? extends ToolOutputGuardrail>[] output() default {};
+}

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/ToolInputGuardrail.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/ToolInputGuardrail.java
@@ -1,0 +1,99 @@
+package io.quarkiverse.mcp.server;
+
+import io.quarkiverse.mcp.server.ToolManager.ToolInfo;
+import io.smallrye.common.annotation.CheckReturnValue;
+import io.smallrye.common.annotation.Experimental;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Input guardrails can be used to validate and/or transform the arguments of a tool call.
+ * <p>
+ * Implementations must be CDI beans, or declare a public no-args constructor. In case of CDI, there must be exactly one bean
+ * that has the implementation class in its set of bean types, otherwise the build fails. Qualifiers are ignored. Furthermore,
+ * the context of the bean must be active during execution. If the scope is {@link jakarta.enterprise.context.Dependent} then
+ * the bean instance is reused for all invocations of a given tool.
+ * <p>
+ * Execution of a guardrail must not block the caller thread unless blocking is allowed. An implementation class can be
+ * annotated with {@link SupportedExecutionModels} to supply the list of supported execution models. If a tool declares a
+ * guardrail with unsupported execution model then the build fails. By default, a guardrail should support all execution models.
+ * <p>
+ * An implementation can inspect the execution model of the current tool with {@link ToolInfo#executionModel()}, or use
+ * {@link io.quarkus.runtime.BlockingOperationControl#isBlockingAllowed()} to detect if blocking is allowed on the current
+ * thread. If blocking is not allowed but an implementation still needs to perform a blocking operation then it has to offload
+ * the execution on a worker thread.
+ *
+ * @see SupportedExecutionModels
+ * @see ToolOutputGuardrail
+ */
+@Experimental("This API is experimental and may change in the future")
+public interface ToolInputGuardrail {
+
+    /**
+     * Note that the container always calls {@link #applyAsync(ToolInputContext)} that delegates to
+     * {@link #apply(ToolInputContext)} by default.
+     *
+     * @param context
+     * @see ToolCallException
+     */
+    default void apply(ToolInputContext context) {
+    }
+
+    /**
+     * An implemetation:
+     * <ul>
+     * <li>should throw {@link ToolCallException} or return a {@link Uni} that emits a {@link ToolCallException} failure if
+     * the validation fails,</li>
+     * <li>can replace the current arguments with {@link ToolInputContext#setArguments(JsonObject)}.</li>
+     * </ul>
+     *
+     * @param context
+     * @return the uni
+     * @see ToolCallException
+     */
+    @CheckReturnValue
+    default Uni<Void> applyAsync(ToolInputContext context) {
+        apply(context);
+        return Uni.createFrom().voidItem();
+    }
+
+    interface ToolInputContext {
+
+        /**
+         * @return the current tool
+         */
+        ToolInfo getTool();
+
+        /**
+         * @return the current connection
+         */
+        McpConnection getConnection();
+
+        /**
+         * @return the id of the current request
+         */
+        RequestId getRequestId();
+
+        /**
+         * Consumers should never modify the arguments directly. Instead, a new instance of arguments should be set with
+         * {@link #setArguments(JsonObject)}.
+         *
+         * @return the current arguments
+         */
+        JsonObject getArguments();
+
+        /**
+         * @return the {@code _meta} part of the message
+         */
+        Meta getMeta();
+
+        /**
+         * Set the current arguments.
+         *
+         * @param arguments
+         */
+        void setArguments(JsonObject arguments);
+
+    }
+
+}

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/ToolManager.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/ToolManager.java
@@ -123,6 +123,18 @@ public interface ToolManager extends FeatureManager<ToolInfo> {
         ToolDefinition setMetadata(Map<MetaKey, Object> metadata);
 
         /**
+         * @param inputGuardrails
+         * @return self
+         */
+        ToolDefinition setInputGuardrails(List<Class<? extends ToolInputGuardrail>> inputGuardrails);
+
+        /**
+         * @param outputGuardrails
+         * @return self
+         */
+        ToolDefinition setOutputGuardrails(List<Class<? extends ToolOutputGuardrail>> outputGuardrails);
+
+        /**
          * @return the tool info
          * @throws IllegalArgumentException if a tool with the given name already exits
          */

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/ToolOutputGuardrail.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/ToolOutputGuardrail.java
@@ -1,0 +1,90 @@
+package io.quarkiverse.mcp.server;
+
+import io.quarkiverse.mcp.server.ToolManager.ToolInfo;
+import io.smallrye.common.annotation.CheckReturnValue;
+import io.smallrye.common.annotation.Experimental;
+import io.smallrye.mutiny.Uni;
+
+/**
+ * Output guardrails can be used to validate and/or transform the result of a tool call.
+ * <p>
+ * Implementations must be CDI beans, or declare a public no-args constructor. In case of CDI, there must be exactly one bean
+ * that has the implementation class in its set of bean types, otherwise the build fails. Qualifiers are ignored. Furthermore,
+ * the context of the bean must be active during execution. If the scope is {@link jakarta.enterprise.context.Dependent} then
+ * the bean instance is reused for all invocations of a given tool.
+ * <p>
+ * Execution of a guardrail must not block the caller thread unless blocking is allowed. An implementation class can be
+ * annotated with {@link SupportedExecutionModels} to supply the list of supported execution models. If a tool declares a
+ * guardrail with unsupported execution model then the build fails. By default, a guardrail should support all execution models.
+ * <p>
+ * An implementation can inspect the execution model of the current tool with {@link ToolInfo#executionModel()}, or use
+ * {@link io.quarkus.runtime.BlockingOperationControl#isBlockingAllowed()} to detect if blocking is allowed on the current
+ * thread. If blocking is not allowed but an implementation still needs to perform a blocking operation then it has to offload
+ * the execution on a worker thread.
+ *
+ * @see SupportedExecutionModels
+ * @see ToolInputGuardrail
+ */
+@Experimental("This API is experimental and may change in the future")
+public interface ToolOutputGuardrail {
+
+    /**
+     * Note that the container always calls {@link #applyAsync(ToolOutputContext)} that delegates to
+     * {@link #apply(ToolOutputContext)} by default.
+     *
+     * @param context
+     * @see ToolCallException
+     */
+    default void apply(ToolOutputContext context) {
+    }
+
+    /**
+     * An implemetation can replace the current response with {@link ToolOutputContext#setResponse(ToolResponse)}.
+     *
+     * @param context
+     * @return the uni
+     * @see ToolCallException
+     */
+    @CheckReturnValue
+    default Uni<Void> applyAsync(ToolOutputContext context) {
+        apply(context);
+        return Uni.createFrom().voidItem();
+    }
+
+    interface ToolOutputContext {
+
+        /**
+         * @return the current tool
+         */
+        ToolInfo getTool();
+
+        /**
+         * @return the current connection
+         */
+        McpConnection getConnection();
+
+        /**
+         * @return the id of the current request
+         */
+        RequestId getRequestId();
+
+        /**
+         * @return the {@code _meta} part of the message
+         */
+        Meta getMeta();
+
+        /**
+         * @return the current response
+         */
+        ToolResponse getResponse();
+
+        /**
+         * Set the current response.
+         *
+         * @param response
+         */
+        void setResponse(ToolResponse response);
+
+    }
+
+}

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/ToolResponse.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/ToolResponse.java
@@ -3,6 +3,7 @@ package io.quarkiverse.mcp.server;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.NoSuchElementException;
 
 /**
  * Response to a {@code tools/call} request from the client.
@@ -80,6 +81,13 @@ public record ToolResponse(boolean isError,
         if (content == null && structuredContent == null) {
             throw new IllegalArgumentException("content must not be null");
         }
+    }
+
+    public Content firstContent() {
+        if (content.isEmpty()) {
+            throw new NoSuchElementException();
+        }
+        return content.get(0);
     }
 
 }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/CompletionMessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/CompletionMessageHandler.java
@@ -19,7 +19,7 @@ public abstract class CompletionMessageHandler extends MessageHandler {
         this.responseHandlers = responseHandlers;
     }
 
-    protected abstract Future<CompletionResponse> execute(String key, ArgumentProviders argProviders,
+    protected abstract Future<CompletionResponse> execute(String key, JsonObject message, ArgumentProviders argProviders,
             McpRequest mcpRequest) throws McpException;
 
     protected String referenceName(JsonObject ref) {
@@ -30,7 +30,6 @@ public abstract class CompletionMessageHandler extends MessageHandler {
             McpRequest mcpRequest) {
         String referenceName = referenceName(ref);
         String argumentName = argument.getString("name");
-
         LOG.debugf("Complete %s for argument %s [id: %s]", referenceName, argumentName, id);
 
         String key = referenceName + "_" + argumentName;
@@ -40,7 +39,7 @@ public abstract class CompletionMessageHandler extends MessageHandler {
                 Messages.getProgressToken(message), responseHandlers, mcpRequest.serverName());
 
         try {
-            Future<CompletionResponse> fu = execute(key, argProviders, mcpRequest);
+            Future<CompletionResponse> fu = execute(key, message, argProviders, mcpRequest);
             return fu.compose(completionResponse -> {
                 JsonObject result = new JsonObject();
                 JsonObject completion = new JsonObject()

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ExecutionModel.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ExecutionModel.java
@@ -1,9 +1,0 @@
-package io.quarkiverse.mcp.server.runtime;
-
-public enum ExecutionModel {
-
-    WORKER_THREAD,
-    VIRTUAL_THREAD,
-    EVENT_LOOP
-
-}

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/FeatureMetadata.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/FeatureMetadata.java
@@ -5,6 +5,7 @@ import java.util.function.Function;
 
 import jakarta.enterprise.invoke.Invoker;
 
+import io.quarkiverse.mcp.server.ExecutionModel;
 import io.quarkiverse.mcp.server.runtime.ResultMappers.Result;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.json.Json;

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/FeatureMethodInfo.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/FeatureMethodInfo.java
@@ -23,7 +23,9 @@ public record FeatureMethodInfo(String name,
         Class<? extends OutputSchemaGenerator> outputSchemaGenerator,
         Class<? extends InputSchemaGenerator<?>> inputSchemaGenerator,
         // meta key (prefix + name) -> json
-        Map<String, String> metadata) {
+        Map<String, String> metadata,
+        List<Class<?>> inputGuardrails,
+        List<Class<?>> outputGuardrails) {
 
     public List<FeatureArgument> serializedArguments() {
         if (arguments == null) {

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpMessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpMessageHandler.java
@@ -288,12 +288,7 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
                 List<NotificationManager.NotificationInfo> infos = notificationManager.infosForRequest(mcpRequest)
                         .filter(n -> n.type() == Type.INITIALIZED).toList();
                 if (!infos.isEmpty()) {
-                    ArgumentProviders argProviders = new ArgumentProviders(message, Map.of(), mcpRequest.connection(), null,
-                            null,
-                            // For notifications/initialized we always use the connection as a sender
-                            mcpRequest.connection(),
-                            null, responseHandlers, mcpRequest.serverName());
-                    FeatureExecutionContext featureExecutionContext = new FeatureExecutionContext(argProviders, mcpRequest);
+                    FeatureExecutionContext featureExecutionContext = new FeatureExecutionContext(message, mcpRequest);
                     for (NotificationManager.NotificationInfo notification : infos) {
                         callNotification(notification, featureExecutionContext, mcpRequest);
                     }
@@ -436,9 +431,7 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
         List<NotificationManager.NotificationInfo> infos = notificationManager.infosForRequest(mcpRequest)
                 .filter(n -> n.type() == Type.ROOTS_LIST_CHANGED).toList();
         if (!infos.isEmpty()) {
-            ArgumentProviders argProviders = new ArgumentProviders(message, Map.of(), mcpRequest.connection(), null, null,
-                    mcpRequest.sender(), null, responseHandlers, mcpRequest.serverName());
-            FeatureExecutionContext featureExecutionContext = new FeatureExecutionContext(argProviders, mcpRequest);
+            FeatureExecutionContext featureExecutionContext = new FeatureExecutionContext(message, mcpRequest);
             for (NotificationManager.NotificationInfo notification : infos) {
                 callNotification(notification, featureExecutionContext);
             }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/Messages.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/Messages.java
@@ -98,8 +98,16 @@ public class Messages {
         return Cursor.FIRST_PAGE;
     }
 
+    public static JsonObject getParams(JsonObject message) {
+        return message.getJsonObject("params");
+    }
+
+    public static JsonObject getArguments(JsonObject params) {
+        return params.getJsonObject("arguments");
+    }
+
     static Object getProgressToken(JsonObject message) {
-        JsonObject params = message.getJsonObject("params");
+        JsonObject params = getParams(message);
         if (params != null) {
             JsonObject meta = params.getJsonObject("_meta");
             if (meta != null) {

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/NotificationManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/NotificationManagerImpl.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.mcp.server.runtime;
 
+import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -54,6 +55,17 @@ public class NotificationManagerImpl extends FeatureManagerBase<Void, Notificati
             return fi;
         }
         return null;
+    }
+
+    @Override
+    protected ArgumentProviders argProviders(JsonObject message, McpRequest mcpRequest, JsonObject arguments) {
+        Sender sender = mcpRequest.sender();
+        if (McpMessageHandler.NOTIFICATIONS_INITIALIZED.equals(message.getString("method"))) {
+            // For notifications/initialized we always use the connection as a sender
+            sender = mcpRequest.connection();
+        }
+        return new ArgumentProviders(message, Map.of(), mcpRequest.connection(), null, null,
+                sender, null, responseHandlers, mcpRequest.serverName());
     }
 
     @Override

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/PromptCompleteMessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/PromptCompleteMessageHandler.java
@@ -6,6 +6,7 @@ import io.quarkiverse.mcp.server.CompletionResponse;
 import io.quarkiverse.mcp.server.McpException;
 import io.quarkiverse.mcp.server.runtime.FeatureManagerBase.FeatureExecutionContext;
 import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
 
 class PromptCompleteMessageHandler extends CompletionMessageHandler {
 
@@ -17,9 +18,10 @@ class PromptCompleteMessageHandler extends CompletionMessageHandler {
     }
 
     @Override
-    protected Future<CompletionResponse> execute(String key, ArgumentProviders argProviders, McpRequest mcpRequest)
+    protected Future<CompletionResponse> execute(String key, JsonObject message, ArgumentProviders argProviders,
+            McpRequest mcpRequest)
             throws McpException {
-        return manager.execute(key, new FeatureExecutionContext(argProviders, mcpRequest));
+        return manager.execute(key, new FeatureExecutionContext(message, mcpRequest, argProviders));
     }
 
 }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/PromptMessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/PromptMessageHandler.java
@@ -1,6 +1,5 @@
 package io.quarkiverse.mcp.server.runtime;
 
-import java.util.Map;
 import java.util.Objects;
 
 import org.jboss.logging.Logger;
@@ -61,15 +60,9 @@ class PromptMessageHandler extends MessageHandler {
         JsonObject params = message.getJsonObject("params");
         String promptName = params.getString("name");
         LOG.debugf("Get prompt %s [id: %s]", promptName, id);
-
-        Map<String, Object> args = params.containsKey("arguments") ? params.getJsonObject("arguments").getMap() : Map.of();
-        ArgumentProviders argProviders = new ArgumentProviders(message, args, mcpRequest.connection(), id, null,
-                mcpRequest.sender(),
-                Messages.getProgressToken(message), manager.responseHandlers, mcpRequest.serverName());
-
         try {
             Future<PromptResponse> fu = manager.execute(promptName,
-                    new FeatureExecutionContext(argProviders, mcpRequest));
+                    new FeatureExecutionContext(message, mcpRequest));
             return fu.compose(promptResponse -> {
                 JsonObject result = new JsonObject();
                 if (promptResponse.description() != null) {

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceMessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceMessageHandler.java
@@ -91,12 +91,11 @@ class ResourceMessageHandler extends MessageHandler {
             return mcpRequest.sender().sendError(id, JsonRpcErrorCodes.INVALID_PARAMS, "Resource URI not defined");
         }
         LOG.debugf("Read resource %s [id: %s]", resourceUri, id);
-
         ArgumentProviders argProviders = new ArgumentProviders(message, Map.of(), mcpRequest.connection(), id, resourceUri,
                 mcpRequest.sender(), Messages.getProgressToken(message), manager.responseHandlers, mcpRequest.serverName());
         try {
             Future<ResourceResponse> fu = manager.execute(resourceUri,
-                    new FeatureExecutionContext(argProviders, mcpRequest));
+                    new FeatureExecutionContext(message, mcpRequest, argProviders));
             return fu.compose(resourceResponse -> {
                 if (resourceResponse == null) {
                     return mcpRequest.sender().sendError(id, JsonRpcErrorCodes.RESOURCE_NOT_FOUND,

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceTemplateCompleteMessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceTemplateCompleteMessageHandler.java
@@ -23,9 +23,10 @@ class ResourceTemplateCompleteMessageHandler extends CompletionMessageHandler {
     }
 
     @Override
-    protected Future<CompletionResponse> execute(String key, ArgumentProviders argProviders, McpRequest mcpRequest)
+    protected Future<CompletionResponse> execute(String key, JsonObject message, ArgumentProviders argProviders,
+            McpRequest mcpRequest)
             throws McpException {
-        return manager.execute(key, new FeatureExecutionContext(argProviders, mcpRequest));
+        return manager.execute(key, new FeatureExecutionContext(message, mcpRequest, argProviders));
     }
 
 }

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -363,6 +363,78 @@ While the specification says _SHOULD_, some MCP clients actually expect the JSON
 To address this compatibility point, the configuration property `quarkus.mcp.server.tools.structured-content.compatibility-mode` enables the backward compatibility mode, in either a global manner or by MCP server as needed.
 ====
 
+=== Guardrails
+
+WARNING: This API is experimental and may change in the future.
+
+The guardrails can be applied to safeguard a tool call.
+Input guardrails can be used to validate and/or transform the arguments of a `tools/call`.
+Output guardrails, on the other hand, can be used to validate and/or transform the result of a call.
+
+.`ToolInputGuardrail` Example
+[source,java]
+----
+import java.util.regex.Pattern;
+import io.quarkiverse.mcp.server.ToolCallException;
+import io.quarkiverse.mcp.server.ToolInputGuardrail;
+
+public class EmailFormatValidator implements ToolInputGuardrail { <1>
+
+   private static final Pattern EMAIL_PATTERN = Pattern.compile("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$");
+
+   @Override
+   public void apply(ToolInputContext context) { <2>
+      String email = context.getArguments().getString("to");
+      if (!EMAIL_PATTERN.matcher(email).matches()) {
+         throw new ToolCallException("Invalid email format: " + email); <3>
+      }
+   }
+}
+----
+<1> Guardrails implementations must be CDI beans, or declare a public no-args constructor.
+<2> The container always calls the non-blocking `ToolInputGuardrail#applyAsync(ToolInputContext)` that delegates to the blocking `ToolInputGuardrail#apply(ToolInputContext)}` by default.
+<3> An implementation should throw `ToolCallException` or return a `Uni` that emits a `ToolCallException` failure if the validation fails.
+
+The `@io.quarkiverse.mcp.server.ToolGuardrails` annotation is used to associate guardrails with a specific `@Tool` method.
+
+.`@ToolGuardrails` Example
+[source,java]
+----
+public class MyTools {
+
+   @ToolGuardrails(input = EmailFormatValidator.class) <1>
+   @Tool
+   String sendMail(String to, String body) {
+      return "Mail sent to: " + to;
+   }
+}
+----
+<1> The guardrails are executed in the specified order before a tool call.
+
+An guardrail implementation class can be annotated with `@io.quarkiverse.mcp.server.SupportedExecutionModels` to supply the list of supported execution models.
+If a tool declares a guardrail with unsupported execution model then the build fails.
+Unless annotated with `@SupportedExecutionModels` a guardrail should support all execution models.
+
+[source,java]
+----
+@SupportedExecutionModels(WORKER_THREAD) <1>
+public class MyOutputGuardrail implements ToolOutputGuardrail {
+
+   @Override
+   public Uni<Void> applyAsync(ToolOutputContext context) {
+      // ...
+      return Uni.createFrom().voidItem();
+   }
+}
+----
+<1> This guardrail may not be used for a tool that is considered non-blocking and is executed on an event loop thread.
+
+Execution of a guardrail must not block the caller thread unless blocking is allowed.
+An guardrail implementation can inspect the execution model of the current tool with `ToolInfo#executionModel()`, or use
+`io.quarkus.runtime.BlockingOperationControl#isBlockingAllowed()` to detect if blocking is allowed on the current thread.
+If blocking is not allowed but an implementation still needs to perform a blocking operation then it has to offload the execution on a worker thread.
+
+TIP: Guardrails can be also applied to a tool that is registered programmatically with the `ToolManager` API. More specifically, the guardrails can be associated with `ToolDefinition#setInputGuardrails()` and `ToolDefinition#setOutputGuardrails()` methods.  
 
 == Prompts
 

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/guardrails/ToolGuardrailsAmbiguousBeansTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/guardrails/ToolGuardrailsAmbiguousBeansTest.java
@@ -1,0 +1,50 @@
+package io.quarkiverse.mcp.server.test.tools.guardrails;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolCallException;
+import io.quarkiverse.mcp.server.ToolGuardrails;
+import io.quarkiverse.mcp.server.ToolInputGuardrail;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ToolGuardrailsAmbiguousBeansTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(InvalidTools.class, Alpha.class, Bravo.class);
+            })
+            .setExpectedException(IllegalStateException.class, true);
+
+    @Test
+    public void test() {
+        fail();
+    }
+
+    public static class InvalidTools {
+
+        @ToolGuardrails(input = Alpha.class)
+        @Tool
+        String foo() {
+            throw new ToolCallException("boom");
+        }
+
+    }
+
+    @Singleton
+    public static class Alpha implements ToolInputGuardrail {
+
+    }
+
+    @Singleton
+    public static class Bravo extends Alpha {
+
+    }
+
+}

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/guardrails/ToolGuardrailsInvalidExecModelProgrammaticTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/guardrails/ToolGuardrailsInvalidExecModelProgrammaticTest.java
@@ -1,0 +1,51 @@
+package io.quarkiverse.mcp.server.test.tools.guardrails;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.ExecutionModel;
+import io.quarkiverse.mcp.server.SupportedExecutionModels;
+import io.quarkiverse.mcp.server.ToolInputGuardrail;
+import io.quarkiverse.mcp.server.ToolManager;
+import io.quarkiverse.mcp.server.ToolResponse;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ToolGuardrailsInvalidExecModelProgrammaticTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(EventLoopGuardrail.class);
+            });
+
+    @Inject
+    ToolManager toolManager;
+
+    @Test
+    public void testFailure() {
+        IllegalArgumentException iae = assertThrows(IllegalArgumentException.class, () -> {
+            toolManager.newTool("foo")
+                    .setDescription("Foo")
+                    // Blocking handler
+                    .setHandler(ta -> ToolResponse.success("ok"))
+                    .setInputGuardrails(List.of(EventLoopGuardrail.class))
+                    .register();
+        });
+        assertTrue(iae.getMessage().endsWith(ExecutionModel.WORKER_THREAD.toString()), iae.getMessage());
+    }
+
+    @Singleton
+    @SupportedExecutionModels(ExecutionModel.EVENT_LOOP)
+    public static class EventLoopGuardrail implements ToolInputGuardrail {
+
+    }
+
+}

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/guardrails/ToolGuardrailsInvalidExecModelTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/guardrails/ToolGuardrailsInvalidExecModelTest.java
@@ -1,0 +1,48 @@
+package io.quarkiverse.mcp.server.test.tools.guardrails;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.ExecutionModel;
+import io.quarkiverse.mcp.server.SupportedExecutionModels;
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolCallException;
+import io.quarkiverse.mcp.server.ToolGuardrails;
+import io.quarkiverse.mcp.server.ToolInputGuardrail;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ToolGuardrailsInvalidExecModelTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(InvalidTools.class, EventLoopGuardrail.class);
+            })
+            .setExpectedException(IllegalStateException.class, true);
+
+    @Test
+    public void test() {
+        fail();
+    }
+
+    public static class InvalidTools {
+
+        @ToolGuardrails(input = EventLoopGuardrail.class)
+        @Tool
+        String foo() {
+            throw new ToolCallException("boom");
+        }
+
+    }
+
+    @Singleton
+    @SupportedExecutionModels(ExecutionModel.EVENT_LOOP)
+    public static class EventLoopGuardrail implements ToolInputGuardrail {
+
+    }
+
+}

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/guardrails/ToolGuardrailsNotABeanTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/guardrails/ToolGuardrailsNotABeanTest.java
@@ -1,0 +1,46 @@
+package io.quarkiverse.mcp.server.test.tools.guardrails;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolCallException;
+import io.quarkiverse.mcp.server.ToolGuardrails;
+import io.quarkiverse.mcp.server.ToolInputGuardrail;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class ToolGuardrailsNotABeanTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(InvalidTools.class, InvalidGuardrail.class);
+            })
+            .setExpectedException(IllegalStateException.class, true);
+
+    @Test
+    public void test() {
+        fail();
+    }
+
+    public static class InvalidTools {
+
+        @ToolGuardrails(input = InvalidGuardrail.class)
+        @Tool
+        String foo() {
+            throw new ToolCallException("boom");
+        }
+
+    }
+
+    // neither a CDI bean, nor a no-args constructor
+    public static class InvalidGuardrail implements ToolInputGuardrail {
+
+        private InvalidGuardrail(String name) {
+        }
+
+    }
+
+}

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/guardrails/ToolGuardrailsTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/guardrails/ToolGuardrailsTest.java
@@ -1,0 +1,179 @@
+package io.quarkiverse.mcp.server.test.tools.guardrails;
+
+import static io.quarkiverse.mcp.server.ExecutionModel.WORKER_THREAD;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.SupportedExecutionModels;
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolCallException;
+import io.quarkiverse.mcp.server.ToolGuardrails;
+import io.quarkiverse.mcp.server.ToolInputGuardrail;
+import io.quarkiverse.mcp.server.ToolManager;
+import io.quarkiverse.mcp.server.ToolOutputGuardrail;
+import io.quarkiverse.mcp.server.ToolResponse;
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkiverse.mcp.server.test.McpAssured.McpStreamableTestClient;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+import io.smallrye.mutiny.Uni;
+import io.vertx.core.json.JsonObject;
+
+public class ToolGuardrailsTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .withApplicationRoot(
+                    root -> root.addClasses(MyTools.class, MyInputGuardrail.class, MyOutputGuardrail1.class,
+                            MyOutputGuardrail2.class, EmailFormatValidator.class));
+
+    @Inject
+    ToolManager toolManager;
+
+    @Test
+    public void testContents() {
+        toolManager.newTool("charlie")
+                .setDescription("Charlie tool")
+                .addArgument("age", "Age", true, int.class)
+                .setInputGuardrails(List.of(CharlieInputGuardrail.class))
+                .setOutputGuardrails(List.of(MyOutputGuardrail1.class, MyOutputGuardrail2.class))
+                .setHandler(toolArguments -> {
+                    return ToolResponse.success(toolArguments.args().get("age").toString());
+                })
+                .register();
+
+        McpStreamableTestClient client = McpAssured.newConnectedStreamableClient();
+
+        client.when()
+                .toolsCall("alpha", Map.of("bravo", "ping"), toolResponse -> {
+                    assertFalse(toolResponse.isError());
+                    assertEquals("ko:ok:PING", toolResponse.firstContent().asText().text());
+                })
+                .toolsCall("mail", Map.of("to", "wrong_@", "body", "hey"), toolResponse -> {
+                    assertTrue(toolResponse.isError());
+                    assertEquals("Invalid email format: wrong_@", toolResponse.content().get(0).asText().text());
+                })
+                .toolsCall("charlie", Map.of("age", 10), toolResponse -> {
+                    assertFalse(toolResponse.isError());
+                    assertEquals("ko:ok:20", toolResponse.firstContent().asText().text());
+                })
+                .thenAssertResults();
+
+        MyInputGuardrail.fail = true;
+
+        client.when()
+                .toolsCall("alpha", Map.of("bravo", "ping"), toolResponse -> {
+                    assertTrue(toolResponse.isError());
+                    assertEquals("Fail!", toolResponse.firstContent().asText().text());
+                })
+                .thenAssertResults();
+
+        MyInputGuardrail.fail = false;
+        MyOutputGuardrail1.fail = true;
+
+        client.when()
+                .toolsCall("alpha", Map.of("bravo", "ping"), toolResponse -> {
+                    assertTrue(toolResponse.isError());
+                    assertEquals("FAIL!", toolResponse.firstContent().asText().text());
+                })
+                .thenAssertResults();
+    }
+
+    public static class MyTools {
+
+        @ToolGuardrails(input = MyInputGuardrail.class, output = { MyOutputGuardrail1.class, MyOutputGuardrail2.class })
+        @Tool
+        String alpha(String bravo) {
+            return bravo;
+        }
+
+        @ToolGuardrails(input = EmailFormatValidator.class)
+        @Tool
+        String mail(String to, String body) {
+            return "Mail sent to: " + to;
+        }
+
+    }
+
+    @Singleton
+    public static class MyInputGuardrail implements ToolInputGuardrail {
+
+        static volatile boolean fail = false;
+
+        @Override
+        public void apply(ToolInputContext context) {
+            if (!context.getTool().name().equals("alpha")) {
+                throw new IllegalStateException();
+            }
+            if (fail) {
+                throw new ToolCallException("Fail!");
+            }
+            context.setArguments(new JsonObject().put("bravo", context.getArguments().getString("bravo").toUpperCase()));
+        }
+
+    }
+
+    @Singleton
+    public static class MyOutputGuardrail1 implements ToolOutputGuardrail {
+
+        static volatile boolean fail = false;
+
+        @Override
+        public void apply(ToolOutputContext context) {
+            if (fail) {
+                throw new ToolCallException("FAIL!");
+            }
+            context.setResponse(ToolResponse.success("ok:" + context.getResponse().firstContent().asText().text()));
+        }
+
+    }
+
+    @SupportedExecutionModels(WORKER_THREAD)
+    @Singleton
+    public static class MyOutputGuardrail2 implements ToolOutputGuardrail {
+
+        @Override
+        public Uni<Void> applyAsync(ToolOutputContext context) {
+            context.setResponse(ToolResponse.success("ko:" + context.getResponse().firstContent().asText().text()));
+            return Uni.createFrom().voidItem();
+        }
+
+    }
+
+    public static class EmailFormatValidator implements ToolInputGuardrail {
+
+        private static final Pattern EMAIL_PATTERN = Pattern.compile("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$");
+
+        @Override
+        public void apply(ToolInputContext context) {
+            String email = context.getArguments().getString("to");
+            if (!EMAIL_PATTERN.matcher(email).matches()) {
+                throw new ToolCallException("Invalid email format: " + email);
+            }
+        }
+    }
+
+    public static class CharlieInputGuardrail implements ToolInputGuardrail {
+
+        @Override
+        public void apply(ToolInputContext context) {
+            if (!context.getTool().name().equals("charlie")) {
+                throw new IllegalStateException();
+            }
+            context.setArguments(new JsonObject().put("age", context.getArguments().getInteger("age") * 2));
+        }
+
+    }
+
+}


### PR DESCRIPTION
This is the first iteration of a POC for tool input/output guardrails (https://github.com/quarkiverse/quarkus-mcp-server/issues/523).

It was inspired by the API from [quarkus-langchain4j](https://github.com/quarkiverse/quarkus-langchain4j).

The `EmailFormatValidator` example from the javadoc of `io.quarkiverse.langchain4j.guardrails.ToolInputGuardrail` could be rewritten as:
```java
public class EmailFormatValidator implements ToolInputGuardrail {

        private static final Pattern EMAIL_PATTERN = Pattern.compile("^[A-Za-z0-9+_.-]+@[A-Za-z0-9.-]+$");

        @Override
        public void apply(ToolInputContext context) {
            String email = context.getArguments().getString("to");
            if (!EMAIL_PATTERN.matcher(email).matches()) {
                throw new ToolCallException("Invalid email format: " + email);
            }
        }
 }
```
There are a few differences:

- guardrails may support various execution models (worker thread, virtual thread, event loop); `@SupportedExecutionModels` can be used to supply the list of supported execution models; if a tool declares a guardrail with unsupported exec model the build fails
- a single annotation (`@ToolGuardrails`) is used to associate both input and output guardrails
- `ToolInputContext`/`ToolInputContext` provide access to specific APIs (such as `ToolInfo` or `McpConnection`)

TODO:

- [x] add support for tools added programmatically
- [ ] ~add support for "global" guardrails that are automatically associated with all tools; `@GlobalGuardrail` or something like that...~ global enablement probably does not make sense at this stage
- [x] docs