### PR TITLE
core: introduce basic metrics support

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/McpServerProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/McpServerProcessor.java
@@ -21,6 +21,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -91,6 +92,7 @@ import io.quarkiverse.mcp.server.runtime.JsonTextResourceContentsEncoder;
 import io.quarkiverse.mcp.server.runtime.McpMetadata;
 import io.quarkiverse.mcp.server.runtime.McpObjectMapperCustomizer;
 import io.quarkiverse.mcp.server.runtime.McpServerRecorder;
+import io.quarkiverse.mcp.server.runtime.MicrometerMcpMetrics;
 import io.quarkiverse.mcp.server.runtime.NotificationManagerImpl;
 import io.quarkiverse.mcp.server.runtime.PromptCompletionManagerImpl;
 import io.quarkiverse.mcp.server.runtime.PromptEncoderResultMapper;
@@ -138,6 +140,7 @@ import io.quarkus.deployment.builditem.GeneratedClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveClassBuildItem;
 import io.quarkus.deployment.builditem.nativeimage.ReflectiveHierarchyBuildItem;
 import io.quarkus.deployment.execannotations.ExecutionModelAnnotationsAllowedBuildItem;
+import io.quarkus.deployment.metrics.MetricsCapabilityBuildItem;
 import io.quarkus.deployment.recording.RecorderContext;
 import io.quarkus.deployment.util.JandexUtil;
 import io.quarkus.gizmo.BytecodeCreator;
@@ -152,6 +155,7 @@ import io.quarkus.gizmo.MethodCreator;
 import io.quarkus.gizmo.MethodDescriptor;
 import io.quarkus.gizmo.ResultHandle;
 import io.quarkus.gizmo.SignatureBuilder;
+import io.quarkus.runtime.metrics.MetricsFactory;
 import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.Json;
 
@@ -570,6 +574,14 @@ class McpServerProcessor {
                             validationErrors, reflectiveClasses);
                 }
             }
+        }
+    }
+
+    @BuildStep
+    void addMetricsSupport(BuildProducer<AdditionalBeanBuildItem> additionalBeans,
+            Optional<MetricsCapabilityBuildItem> metricsCapability) {
+        if (metricsCapability.map(m -> m.metricsSupported(MetricsFactory.MICROMETER)).orElse(false)) {
+            additionalBeans.produce(AdditionalBeanBuildItem.unremovableOf(MicrometerMcpMetrics.class));
         }
     }
 

--- a/core/runtime/pom.xml
+++ b/core/runtime/pom.xml
@@ -47,6 +47,12 @@
             <version>${jsonschema-generator.version}</version>
             <optional>true</optional>
         </dependency>
+        <!-- Integration with Micrometer extension -->
+        <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-core</artifactId>
+            <optional>true</optional>
+        </dependency>
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpMetrics.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpMetrics.java
@@ -1,0 +1,13 @@
+package io.quarkiverse.mcp.server.runtime;
+
+import java.util.function.ToDoubleFunction;
+
+import io.quarkiverse.mcp.server.McpMethod;
+import io.vertx.core.json.JsonObject;
+
+public interface McpMetrics {
+
+    <T> void createMcpConnectionsGauge(T stateObject, ToDoubleFunction<T> valueFunction);
+
+    void mcpRequestCompleted(McpMethod method, JsonObject message, McpRequest mcpRequest, long duration, Throwable failure);
+}

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/MicrometerMcpMetrics.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/MicrometerMcpMetrics.java
@@ -1,0 +1,80 @@
+package io.quarkiverse.mcp.server.runtime;
+
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.ToDoubleFunction;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import io.micrometer.core.instrument.Timer;
+import io.quarkiverse.mcp.server.McpMethod;
+import io.vertx.core.json.JsonObject;
+
+@Singleton
+public class MicrometerMcpMetrics implements McpMetrics {
+
+    private static final String MCP_SERVER_CONNECTIONS_ACTIVE = "mcp.server.connections.active";
+    private static final String MCP_SERVER_REQUESTS_PREFIX = "mcp.server.requests.";
+    private static final String MCP_SERVER = "mcp.server";
+    private static final String TOOL_NAME = "tool.name";
+    private static final String PROMPT_NAME = "prompt.name";
+    private static final String RESOURCE_URI = "resource.uri";
+    private static final String FAILURE = "failure";
+    private static final String NONE = "none";
+
+    private final Map<McpMethod, String> mcpMethodNames;
+
+    @Inject
+    MeterRegistry meterRegistry;
+
+    MicrometerMcpMetrics() {
+        // Note that we can't use a timer with the same name but a different set of tags
+        // https://docs.micrometer.io/micrometer/reference/implementations/prometheus.html#_limitation_on_same_name_with_different_set_of_tag_keys
+        mcpMethodNames = new EnumMap<>(McpMethod.class);
+        for (McpMethod m : McpMethod.values()) {
+            mcpMethodNames.put(m, MCP_SERVER_REQUESTS_PREFIX + m.jsonRpcName().replace("/", "."));
+        }
+    }
+
+    @Override
+    public <T> void createMcpConnectionsGauge(T stateObject, ToDoubleFunction<T> valueFunction) {
+        meterRegistry.gauge(MCP_SERVER_CONNECTIONS_ACTIVE, stateObject, valueFunction);
+    }
+
+    @Override
+    public void mcpRequestCompleted(McpMethod method, JsonObject message, McpRequest mcpRequest, long duration,
+            Throwable failure) {
+        Timer.builder(mcpMethodNames.get(method))
+                .tags(MCP_SERVER, mcpRequest.serverName(), FAILURE, failure(failure))
+                .tags(createTags(method, message, mcpRequest))
+                .register(meterRegistry)
+                .record(duration, TimeUnit.MILLISECONDS);
+    }
+
+    private Tags createTags(McpMethod method, JsonObject message, McpRequest mcpRequest) {
+        return switch (method) {
+            case TOOLS_CALL -> Tags.of(
+                    TOOL_NAME, Messages.getParams(message).getString("name"));
+            case RESOURCES_READ -> Tags.of(
+                    RESOURCE_URI, Messages.getParams(message).getString("uri"));
+            case PROMPTS_GET -> Tags.of(
+                    PROMPT_NAME, Messages.getParams(message).getString("name"));
+            default -> Tags.empty();
+        };
+    }
+
+    static String failure(Throwable throwable) {
+        if (throwable == null) {
+            return NONE;
+        }
+        if (throwable.getCause() == null) {
+            return throwable.getClass().getSimpleName();
+        }
+        return throwable.getCause().getClass().getSimpleName();
+    }
+
+}

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/config/McpServerRuntimeConfig.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/config/McpServerRuntimeConfig.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 
 import io.quarkiverse.mcp.server.McpLog.LogLevel;
 import io.smallrye.config.WithDefault;
+import io.smallrye.config.WithName;
 
 public interface McpServerRuntimeConfig {
 
@@ -82,6 +83,13 @@ public interface McpServerRuntimeConfig {
      */
     @WithDefault("30m")
     Duration connectionIdleTimeout();
+
+    /**
+     * If collection of metrics is enabled when the Micrometer extension is present.
+     */
+    @WithName("metrics.enabled")
+    @WithDefault("false")
+    boolean metricsEnabled();
 
     public interface TrafficLogging {
 

--- a/docs/modules/ROOT/pages/includes/quarkus-mcp-server-core.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-mcp-server-core.adoc
@@ -1144,6 +1144,32 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-mcp-server-core_quarkus-mcp[icon:question-circle[title=More information about the Duration format]]
 |`+++30M+++`
 
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-metrics-enabled]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-metrics-enabled[`quarkus.mcp.server.metrics.enabled`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.metrics.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.mcp.server."server-name".metrics.enabled`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server."server-name".metrics.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+If collection of metrics is enabled when the Micrometer extension is present.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_METRICS_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_METRICS_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
 |===
 
 ifndef::no-duration-note[]

--- a/docs/modules/ROOT/pages/includes/quarkus-mcp-server-core_quarkus.mcp.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-mcp-server-core_quarkus.mcp.adoc
@@ -1144,6 +1144,32 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-mcp-server-core_quarkus-mcp[icon:question-circle[title=More information about the Duration format]]
 |`+++30M+++`
 
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-metrics-enabled]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-metrics-enabled[`quarkus.mcp.server.metrics.enabled`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.metrics.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.mcp.server."server-name".metrics.enabled`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server."server-name".metrics.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+If collection of metrics is enabled when the Micrometer extension is present.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_METRICS_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_METRICS_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++false+++`
+
 |===
 
 ifndef::no-duration-note[]

--- a/transports/http/deployment/pom.xml
+++ b/transports/http/deployment/pom.xml
@@ -99,6 +99,11 @@
             <version>${swagger-annotations.version}</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+          <groupId>io.quarkus</groupId>
+          <artifactId>quarkus-micrometer-registry-prometheus-deployment</artifactId>
+          <scope>test</scope>
+      </dependency>
     </dependencies>
 
     <build>

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/metrics/MetricsTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/metrics/MetricsTest.java
@@ -1,0 +1,154 @@
+package io.quarkiverse.mcp.server.test.metrics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.search.Search;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.quarkiverse.mcp.server.Prompt;
+import io.quarkiverse.mcp.server.PromptMessage;
+import io.quarkiverse.mcp.server.PromptResponse;
+import io.quarkiverse.mcp.server.RequestUri;
+import io.quarkiverse.mcp.server.Resource;
+import io.quarkiverse.mcp.server.ResourceTemplate;
+import io.quarkiverse.mcp.server.TextResourceContents;
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolArg;
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkiverse.mcp.server.test.McpAssured.McpStreamableTestClient;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MetricsTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = defaultConfig()
+            .withApplicationRoot(root -> root
+                    .addClasses(MyFeatures.class))
+            .overrideConfigKey("quarkus.mcp.server.metrics.enabled", "true");
+
+    @Inject
+    MeterRegistry registry;
+
+    @BeforeAll
+    static void addSimpleRegistry() {
+        Metrics.globalRegistry.add(new SimpleMeterRegistry());
+    }
+
+    @Test
+    void testMetrics() throws InterruptedException {
+        McpStreamableTestClient client = McpAssured.newConnectedStreamableClient();
+        client.when()
+                .toolsCall("alpha", toolResponse -> {
+                    assertEquals("20", toolResponse.firstContent().asText().text());
+                })
+                .toolsCall("alpha", Map.of("price", 1), toolResponse -> {
+                    assertEquals("2", toolResponse.firstContent().asText().text());
+                })
+                .toolsCall("bravo", toolResponse -> {
+                    assertEquals("20", toolResponse.firstContent().asText().text());
+                })
+                .promptsGet("charlie", promptResponse -> {
+                    assertEquals("ok", promptResponse.firstMessage().content().asText().text());
+                })
+                .promptsList(page -> {
+                    assertEquals(1, page.size());
+                })
+                .toolsList(page -> {
+                    assertEquals(2, page.size());
+                })
+                .resourcesTemplatesList(page -> {
+                    assertEquals(1, page.size());
+                })
+                .thenAssertResults();
+
+        assertEquals(1, registry.find("mcp.server.connections.active").gauge().value());
+
+        assertTimer("mcp.server.requests.tools.call", timer -> {
+            assertNotNull(timer);
+            assertEquals(2, timer.count());
+        }, "tool.name", "alpha");
+
+        assertTimer("mcp.server.requests.tools.call", timer -> {
+            assertNotNull(timer);
+            assertEquals(1, timer.count());
+        }, "tool.name", "bravo");
+
+        assertTimer("mcp.server.requests.tools.list", timer -> {
+            assertEquals(1, timer.count());
+        });
+
+        assertTimer("mcp.server.requests.prompts.get", timer -> {
+            assertNotNull(timer);
+            assertEquals(1, timer.count());
+        }, "prompt.name", "charlie");
+
+        assertTimer("mcp.server.requests.prompts.list", timer -> {
+            assertEquals(1, timer.count());
+        });
+
+        assertTimer("mcp.server.requests.resources.templates.list", timer -> {
+            assertEquals(1, timer.count());
+        });
+    }
+
+    private void assertTimer(String name, Consumer<Timer> assertion, String... tags) throws InterruptedException {
+        Search search = registry.find(name);
+        if (tags.length > 0) {
+            search.tags(tags);
+        }
+        int i = 0;
+        while (search.timer() == null && i++ < 10) {
+            TimeUnit.MILLISECONDS.sleep(50);
+        }
+        Timer found = search.timer();
+        if (found == null) {
+            fail("Timer not found");
+        }
+        assertion.accept(found);
+    }
+
+    public static class MyFeatures {
+
+        @Tool
+        String alpha(@ToolArg(defaultValue = "10") int price) {
+            return "" + price * 2;
+        }
+
+        @Tool
+        String bravo(@ToolArg(defaultValue = "10") int price) {
+            return "" + price * 2;
+        }
+
+        @Prompt
+        PromptResponse charlie() {
+            return PromptResponse.withMessages(PromptMessage.withUserRole("ok"));
+        }
+
+        @Resource(uri = "file:///project/delta")
+        TextResourceContents delta(RequestUri uri) {
+            return TextResourceContents.create(uri.value(), "3");
+        }
+
+        @ResourceTemplate(uriTemplate = "file:///{path}")
+        TextResourceContents echo(String path, RequestUri uri) {
+            return TextResourceContents.create(uri.value(), "foo:" + path);
+        }
+
+    }
+
+}

--- a/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/SseMcpMessageHandler.java
+++ b/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/SseMcpMessageHandler.java
@@ -16,6 +16,7 @@ import io.quarkiverse.mcp.server.runtime.ContextSupport;
 import io.quarkiverse.mcp.server.runtime.McpConnectionBase;
 import io.quarkiverse.mcp.server.runtime.McpMessageHandler;
 import io.quarkiverse.mcp.server.runtime.McpMetadata;
+import io.quarkiverse.mcp.server.runtime.McpMetrics;
 import io.quarkiverse.mcp.server.runtime.McpRequestImpl;
 import io.quarkiverse.mcp.server.runtime.NotificationManagerImpl;
 import io.quarkiverse.mcp.server.runtime.PromptCompletionManagerImpl;
@@ -64,10 +65,11 @@ public class SseMcpMessageHandler extends McpMessageHandler<SseMcpRequest> imple
             CurrentVertxRequest currentVertxRequest,
             Instance<CurrentIdentityAssociation> currentIdentityAssociation,
             McpMetadata metadata,
-            Vertx vertx) {
+            Vertx vertx,
+            Instance<McpMetrics> metrics) {
         super(config, connectionManager, promptManager, toolManager, resourceManager, promptCompleteManager,
                 resourceTemplateManager, resourceTemplateCompleteManager, initManager, serverRequests, metadata, vertx,
-                initialChecks);
+                initialChecks, metrics.isResolvable() ? metrics.get() : null);
         this.currentVertxRequest = currentVertxRequest;
         this.currentIdentityAssociation = currentIdentityAssociation.isResolvable() ? currentIdentityAssociation.get() : null;
     }

--- a/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/StreamableHttpMcpMessageHandler.java
+++ b/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/StreamableHttpMcpMessageHandler.java
@@ -42,6 +42,7 @@ import io.quarkiverse.mcp.server.runtime.FeatureMetadata;
 import io.quarkiverse.mcp.server.runtime.McpConnectionBase;
 import io.quarkiverse.mcp.server.runtime.McpMessageHandler;
 import io.quarkiverse.mcp.server.runtime.McpMetadata;
+import io.quarkiverse.mcp.server.runtime.McpMetrics;
 import io.quarkiverse.mcp.server.runtime.McpRequestImpl;
 import io.quarkiverse.mcp.server.runtime.Messages;
 import io.quarkiverse.mcp.server.runtime.NotificationManagerImpl;
@@ -112,11 +113,12 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
             CurrentVertxRequest currentVertxRequest,
             Instance<CurrentIdentityAssociation> currentIdentityAssociation,
             McpMetadata metadata,
-            Vertx vertx) {
+            Vertx vertx,
+            Instance<McpMetrics> metrics) {
         super(config, connectionManager, promptManager, toolManager, resourceManager, promptCompleteManager,
                 resourceTemplateManager, resourceTemplateCompleteManager, notificationManager, responseHandlers, metadata,
                 vertx,
-                initialChecks);
+                initialChecks, metrics.isResolvable() ? metrics.get() : null);
         this.metadata = metadata;
         this.currentVertxRequest = currentVertxRequest;
         this.currentIdentityAssociation = currentIdentityAssociation.isResolvable() ? currentIdentityAssociation.get() : null;

--- a/transports/stdio/runtime/src/main/java/io/quarkiverse/mcp/server/stdio/runtime/StdioMcpMessageHandler.java
+++ b/transports/stdio/runtime/src/main/java/io/quarkiverse/mcp/server/stdio/runtime/StdioMcpMessageHandler.java
@@ -13,6 +13,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Singleton;
 
 import org.jboss.logging.Logger;
@@ -25,6 +26,7 @@ import io.quarkiverse.mcp.server.runtime.ConnectionManager;
 import io.quarkiverse.mcp.server.runtime.ContextSupport;
 import io.quarkiverse.mcp.server.runtime.McpMessageHandler;
 import io.quarkiverse.mcp.server.runtime.McpMetadata;
+import io.quarkiverse.mcp.server.runtime.McpMetrics;
 import io.quarkiverse.mcp.server.runtime.McpRequestImpl;
 import io.quarkiverse.mcp.server.runtime.NotificationManagerImpl;
 import io.quarkiverse.mcp.server.runtime.PromptCompletionManagerImpl;
@@ -67,10 +69,11 @@ public class StdioMcpMessageHandler extends McpMessageHandler<StdioMcpRequest> {
             ResponseHandlers responseHandlers,
             @All List<InitialCheck> initialChecks,
             McpMetadata metadata,
-            Vertx vertx) {
+            Vertx vertx,
+            Instance<McpMetrics> metrics) {
         super(config, connectionManager, promptManager, toolManager, resourceManager, promptCompleteManager,
                 resourceTemplateManager, resourceTemplateCompleteManager, initManager, responseHandlers, metadata, vertx,
-                initialChecks);
+                initialChecks, metrics.isResolvable() ? metrics.get() : null);
         this.executor = Executors.newSingleThreadExecutor();
         if (config.servers().size() > 1) {
             throw new IllegalStateException("Multiple server configurations are not supported for the stdio transport");

--- a/transports/websocket/deployment/src/main/java/io/quarkiverse/mcp/server/websocket/deployment/WebSocketMcpServerProcessor.java
+++ b/transports/websocket/deployment/src/main/java/io/quarkiverse/mcp/server/websocket/deployment/WebSocketMcpServerProcessor.java
@@ -10,6 +10,7 @@ import org.jboss.jandex.AnnotationInstance;
 import io.quarkiverse.mcp.server.InitialCheck;
 import io.quarkiverse.mcp.server.runtime.ConnectionManager;
 import io.quarkiverse.mcp.server.runtime.McpMetadata;
+import io.quarkiverse.mcp.server.runtime.McpMetrics;
 import io.quarkiverse.mcp.server.runtime.NotificationManagerImpl;
 import io.quarkiverse.mcp.server.runtime.PromptCompletionManagerImpl;
 import io.quarkiverse.mcp.server.runtime.PromptManagerImpl;
@@ -89,6 +90,7 @@ public class WebSocketMcpServerProcessor {
                     McpMetadata.class,
                     Vertx.class,
                     List.class,
+                    Instance.class,
                     Instance.class
             };
             MethodCreator constructor = endpointCreator.getConstructorCreator(params);
@@ -110,6 +112,9 @@ public class WebSocketMcpServerProcessor {
                     // Instance<CurrentIdentityAssociation>
                     .addParameterType(Type.parameterizedType(Type.classType(Instance.class),
                             Type.classType(CurrentIdentityAssociation.class)))
+                    // Instance<McpMetrics>
+                    .addParameterType(Type.parameterizedType(Type.classType(Instance.class),
+                            Type.classType(McpMetrics.class)))
                     .build());
             // @All List<InitialCheck>
             constructor.getParameterAnnotations(12).addAnnotation(All.class);
@@ -131,7 +136,8 @@ public class WebSocketMcpServerProcessor {
                     constructor.getMethodParam(10),
                     constructor.getMethodParam(11),
                     constructor.getMethodParam(12),
-                    constructor.getMethodParam(13));
+                    constructor.getMethodParam(13),
+                    constructor.getMethodParam(14));
             constructor.returnVoid();
 
             // WebSocketMcpMessageHandler.serverName()

--- a/transports/websocket/runtime/src/main/java/io/quarkiverse/mcp/server/websocket/runtime/WebSocketMcpMessageHandler.java
+++ b/transports/websocket/runtime/src/main/java/io/quarkiverse/mcp/server/websocket/runtime/WebSocketMcpMessageHandler.java
@@ -14,6 +14,7 @@ import io.quarkiverse.mcp.server.runtime.ConnectionManager;
 import io.quarkiverse.mcp.server.runtime.ContextSupport;
 import io.quarkiverse.mcp.server.runtime.McpMessageHandler;
 import io.quarkiverse.mcp.server.runtime.McpMetadata;
+import io.quarkiverse.mcp.server.runtime.McpMetrics;
 import io.quarkiverse.mcp.server.runtime.McpRequestImpl;
 import io.quarkiverse.mcp.server.runtime.NotificationManagerImpl;
 import io.quarkiverse.mcp.server.runtime.PromptCompletionManagerImpl;
@@ -60,10 +61,11 @@ public abstract class WebSocketMcpMessageHandler extends McpMessageHandler<WebSo
             McpMetadata metadata,
             Vertx vertx,
             @All List<InitialCheck> initialChecks,
-            Instance<CurrentIdentityAssociation> currentIdentityAssociation) {
+            Instance<CurrentIdentityAssociation> currentIdentityAssociation,
+            Instance<McpMetrics> metrics) {
         super(config, connectionManager, promptManager, toolManager, resourceManager, promptCompleteManager,
                 resourceTemplateManager, resourceTemplateCompleteManager, initManager, responseHandlers, metadata, vertx,
-                initialChecks);
+                initialChecks, metrics.isResolvable() ? metrics.get() : null);
         this.currentIdentityAssociation = currentIdentityAssociation.isResolvable() ? currentIdentityAssociation.get() : null;
     }
 


### PR DESCRIPTION
- resolves #589

NOTE: We do not include connection/session ids in the tags to avoid [high cardinality tags](https://docs.micrometer.io/micrometer/reference/concepts/high-cardinality-tags-detector.html).