### PR TITLE
transports: make it possible to disable http/websocket transport

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/McpServerProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/McpServerProcessor.java
@@ -194,6 +194,11 @@ class McpServerProcessor {
     }
 
     @BuildStep
+    void serverNames(BuildProducer<ServerNameBuildItem> serverNames) {
+        serverNames.produce(new ServerNameBuildItem(McpServer.DEFAULT));
+    }
+
+    @BuildStep
     void addBeans(BuildProducer<AdditionalBeanBuildItem> additionalBeans) {
         AdditionalBeanBuildItem.Builder unremovable = AdditionalBeanBuildItem.builder().setUnremovable();
         unremovable.addBeanClass("io.quarkiverse.mcp.server.runtime.ConnectionManager");

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/CompletionManagerBase.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/CompletionManagerBase.java
@@ -15,6 +15,7 @@ import io.quarkiverse.mcp.server.CompletionManager;
 import io.quarkiverse.mcp.server.CompletionManager.CompletionInfo;
 import io.quarkiverse.mcp.server.CompletionResponse;
 import io.quarkiverse.mcp.server.McpLog;
+import io.quarkiverse.mcp.server.runtime.config.McpServersRuntimeConfig;
 import io.quarkus.security.identity.CurrentIdentityAssociation;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.Vertx;
@@ -26,9 +27,14 @@ public abstract class CompletionManagerBase extends FeatureManagerBase<Completio
     // key = reference name + "_" + argument name
     protected final ConcurrentMap<String, CompletionInfo> completions;
 
-    protected CompletionManagerBase(Vertx vertx, ObjectMapper mapper, ConnectionManager connectionManager,
-            Instance<CurrentIdentityAssociation> currentIdentityAssociation, ResponseHandlers responseHandlers) {
-        super(vertx, mapper, connectionManager, currentIdentityAssociation, responseHandlers);
+    protected CompletionManagerBase(Vertx vertx,
+            ObjectMapper mapper,
+            ConnectionManager connectionManager,
+            Instance<CurrentIdentityAssociation> currentIdentityAssociation,
+            ResponseHandlers responseHandlers,
+            McpServersRuntimeConfig config,
+            McpMetadata metadata) {
+        super(vertx, mapper, connectionManager, currentIdentityAssociation, responseHandlers, config, metadata);
         this.completions = new ConcurrentHashMap<>();
     }
 
@@ -119,7 +125,7 @@ public abstract class CompletionManagerBase extends FeatureManagerBase<Completio
         private String argumentName;
 
         private CompletionDefinitionImpl(String name) {
-            super(name);
+            super(name, CompletionManagerBase.this.serverNames);
             setDescription("");
         }
 

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/FeatureManagerBase.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/FeatureManagerBase.java
@@ -12,6 +12,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -49,6 +50,8 @@ import io.quarkiverse.mcp.server.RequestUri;
 import io.quarkiverse.mcp.server.Roots;
 import io.quarkiverse.mcp.server.Sampling;
 import io.quarkiverse.mcp.server.runtime.ResultMappers.Result;
+import io.quarkiverse.mcp.server.runtime.config.McpServersRuntimeConfig;
+import io.quarkiverse.mcp.server.runtime.config.McpServersRuntimeConfig.InvalidServerNameStrategy;
 import io.quarkus.security.identity.CurrentIdentityAssociation;
 import io.quarkus.virtual.threads.VirtualThreadsRecorder;
 import io.smallrye.mutiny.Uni;
@@ -71,16 +74,21 @@ public abstract class FeatureManagerBase<RESULT, INFO extends FeatureManager.Fea
 
     protected final CurrentIdentityAssociation currentIdentityAssociation;
 
+    // used to validate server name if InvalidServerNameStrategy.FAIL is set
+    protected final Set<String> serverNames;
+
     final ResponseHandlers responseHandlers;
 
     protected FeatureManagerBase(Vertx vertx, ObjectMapper mapper, ConnectionManager connectionManager,
-            Instance<CurrentIdentityAssociation> currentIdentityAssociation, ResponseHandlers responseHandlers) {
+            Instance<CurrentIdentityAssociation> currentIdentityAssociation, ResponseHandlers responseHandlers,
+            McpServersRuntimeConfig config, McpMetadata metadata) {
         this.vertx = vertx;
         this.mapper = mapper;
         this.connectionManager = connectionManager;
         this.loggers = new ConcurrentHashMap<>();
         this.currentIdentityAssociation = currentIdentityAssociation.isResolvable() ? currentIdentityAssociation.get() : null;
         this.responseHandlers = responseHandlers;
+        this.serverNames = config.invalidServerNameStrategy() == InvalidServerNameStrategy.FAIL ? metadata.serverNames() : null;
     }
 
     public Future<RESULT> execute(String id, FeatureExecutionContext executionContext) throws McpException {
@@ -453,6 +461,7 @@ public abstract class FeatureManagerBase<RESULT, INFO extends FeatureManager.Fea
     protected static abstract class FeatureDefinitionBase<INFO extends FeatureInfo, ARGUMENTS, RESPONSE, THIS extends FeatureDefinitionBase<INFO, ARGUMENTS, RESPONSE, THIS>> {
 
         protected final String name;
+        protected final Set<String> serverNames;
         protected String description;
         protected Function<ARGUMENTS, RESPONSE> fun;
         protected Function<ARGUMENTS, Uni<RESPONSE>> asyncFun;
@@ -460,9 +469,10 @@ public abstract class FeatureManagerBase<RESULT, INFO extends FeatureManager.Fea
         protected String serverName;
         protected List<Icon> icons = List.of();
 
-        protected FeatureDefinitionBase(String name) {
+        protected FeatureDefinitionBase(String name, Set<String> serverNames) {
             this.name = Objects.requireNonNull(name);
             this.serverName = McpServer.DEFAULT;
+            this.serverNames = serverNames;
         }
 
         @SuppressWarnings("unchecked")
@@ -509,6 +519,10 @@ public abstract class FeatureManagerBase<RESULT, INFO extends FeatureManager.Fea
             }
             if (requireDescription && description == null) {
                 throw new IllegalStateException("Description must be set");
+            }
+            if (serverNames != null && !serverNames.contains(serverName)) {
+                // Validate server name if InvalidServerNameStrategy.FAIL
+                throw new IllegalStateException("Invalid server name: " + serverName);
             }
         }
 

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/NotificationManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/NotificationManagerImpl.java
@@ -21,6 +21,7 @@ import io.quarkiverse.mcp.server.Notification;
 import io.quarkiverse.mcp.server.Notification.Type;
 import io.quarkiverse.mcp.server.NotificationManager;
 import io.quarkiverse.mcp.server.NotificationManager.NotificationInfo;
+import io.quarkiverse.mcp.server.runtime.config.McpServersRuntimeConfig;
 import io.quarkus.security.identity.CurrentIdentityAssociation;
 import io.smallrye.mutiny.Uni;
 import io.vertx.core.Vertx;
@@ -32,9 +33,14 @@ public class NotificationManagerImpl extends FeatureManagerBase<Void, Notificati
     // key = notification type + "::" + name
     final ConcurrentMap<String, NotificationInfo> notifications;
 
-    NotificationManagerImpl(McpMetadata metadata, Vertx vertx, ObjectMapper mapper, ConnectionManager connectionManager,
-            Instance<CurrentIdentityAssociation> currentIdentityAssociation, ResponseHandlers responseHandlers) {
-        super(vertx, mapper, connectionManager, currentIdentityAssociation, responseHandlers);
+    NotificationManagerImpl(McpMetadata metadata,
+            Vertx vertx,
+            ObjectMapper mapper,
+            ConnectionManager connectionManager,
+            Instance<CurrentIdentityAssociation> currentIdentityAssociation,
+            ResponseHandlers responseHandlers,
+            McpServersRuntimeConfig config) {
+        super(vertx, mapper, connectionManager, currentIdentityAssociation, responseHandlers, config, metadata);
         this.notifications = new ConcurrentHashMap<>();
         for (FeatureMetadata<Void> notification : metadata.notifications()) {
             NotificationMethod notificationMethod = new NotificationMethod(notification);
@@ -144,7 +150,7 @@ public class NotificationManagerImpl extends FeatureManagerBase<Void, Notificati
         private Notification.Type type;
 
         private NotificationDefinitionImpl(String name) {
-            super(name);
+            super(name, NotificationManagerImpl.this.serverNames);
         }
 
         @Override

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/PromptCompletionManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/PromptCompletionManagerImpl.java
@@ -10,6 +10,7 @@ import io.quarkiverse.mcp.server.JsonRpcErrorCodes;
 import io.quarkiverse.mcp.server.McpException;
 import io.quarkiverse.mcp.server.PromptCompletionManager;
 import io.quarkiverse.mcp.server.PromptManager;
+import io.quarkiverse.mcp.server.runtime.config.McpServersRuntimeConfig;
 import io.quarkus.security.identity.CurrentIdentityAssociation;
 import io.vertx.core.Vertx;
 
@@ -18,10 +19,15 @@ public class PromptCompletionManagerImpl extends CompletionManagerBase implement
 
     private final PromptManagerImpl promptManager;
 
-    protected PromptCompletionManagerImpl(McpMetadata metadata, Vertx vertx, ObjectMapper mapper,
-            ConnectionManager connectionManager, PromptManagerImpl promptManager,
-            Instance<CurrentIdentityAssociation> currentIdentityAssociation, ResponseHandlers responseHandlers) {
-        super(vertx, mapper, connectionManager, currentIdentityAssociation, responseHandlers);
+    protected PromptCompletionManagerImpl(McpMetadata metadata,
+            Vertx vertx,
+            ObjectMapper mapper,
+            ConnectionManager connectionManager,
+            PromptManagerImpl promptManager,
+            Instance<CurrentIdentityAssociation> currentIdentityAssociation,
+            ResponseHandlers responseHandlers,
+            McpServersRuntimeConfig config) {
+        super(vertx, mapper, connectionManager, currentIdentityAssociation, responseHandlers, config, metadata);
         this.promptManager = promptManager;
         for (FeatureMetadata<CompletionResponse> c : metadata.promptCompletions()) {
             String key = c.info().name() + "_"

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/PromptManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/PromptManagerImpl.java
@@ -33,6 +33,7 @@ import io.quarkiverse.mcp.server.PromptFilter;
 import io.quarkiverse.mcp.server.PromptManager;
 import io.quarkiverse.mcp.server.PromptManager.PromptInfo;
 import io.quarkiverse.mcp.server.PromptResponse;
+import io.quarkiverse.mcp.server.runtime.config.McpServersRuntimeConfig;
 import io.quarkus.arc.All;
 import io.quarkus.security.identity.CurrentIdentityAssociation;
 import io.smallrye.mutiny.Uni;
@@ -59,8 +60,9 @@ public class PromptManagerImpl extends FeatureManagerBase<PromptResponse, Prompt
             Instance<CurrentIdentityAssociation> currentIdentityAssociation,
             ResponseHandlers responseHandlers,
             @All List<PromptFilter> filters,
-            @Any Instance<IconsProvider> iconsProviders) {
-        super(vertx, mapper, connectionManager, currentIdentityAssociation, responseHandlers);
+            @Any Instance<IconsProvider> iconsProviders,
+            McpServersRuntimeConfig config) {
+        super(vertx, mapper, connectionManager, currentIdentityAssociation, responseHandlers, config, metadata);
         this.prompts = new ConcurrentHashMap<>();
         for (FeatureMetadata<PromptResponse> f : metadata.prompts()) {
             this.prompts.put(f.info().name(), new PromptMethod(f, iconsProviders));
@@ -218,7 +220,7 @@ public class PromptManagerImpl extends FeatureManagerBase<PromptResponse, Prompt
         private Map<MetaKey, Object> metadata = Map.of();
 
         PromptDefinitionImpl(String name) {
-            super(name);
+            super(name, PromptManagerImpl.this.serverNames);
             this.arguments = new ArrayList<>();
         }
 

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceManagerImpl.java
@@ -40,6 +40,7 @@ import io.quarkiverse.mcp.server.ResourceFilter;
 import io.quarkiverse.mcp.server.ResourceManager;
 import io.quarkiverse.mcp.server.ResourceManager.ResourceInfo;
 import io.quarkiverse.mcp.server.ResourceResponse;
+import io.quarkiverse.mcp.server.runtime.config.McpServersRuntimeConfig;
 import io.quarkus.arc.All;
 import io.quarkus.security.identity.CurrentIdentityAssociation;
 import io.smallrye.mutiny.Uni;
@@ -72,8 +73,9 @@ public class ResourceManagerImpl extends FeatureManagerBase<ResourceResponse, Re
             Instance<CurrentIdentityAssociation> currentIdentityAssociation,
             ResponseHandlers responseHandlers,
             @All List<ResourceFilter> filters,
-            @Any Instance<IconsProvider> iconsProviders) {
-        super(vertx, mapper, connectionManager, currentIdentityAssociation, responseHandlers);
+            @Any Instance<IconsProvider> iconsProviders,
+            McpServersRuntimeConfig config) {
+        super(vertx, mapper, connectionManager, currentIdentityAssociation, responseHandlers, config, metadata);
         this.resourceTemplateManager = resourceTemplateManager;
         this.uriToResource = new ConcurrentHashMap<>();
         this.resourceNames = Collections.synchronizedSet(new HashSet<>());
@@ -442,7 +444,7 @@ public class ResourceManagerImpl extends FeatureManagerBase<ResourceResponse, Re
         private Map<MetaKey, Object> metadata = Map.of();
 
         ResourceDefinitionImpl(String name) {
-            super(name);
+            super(name, ResourceManagerImpl.this.serverNames);
         }
 
         @Override

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceTemplateCompletionManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceTemplateCompletionManagerImpl.java
@@ -13,6 +13,7 @@ import io.quarkiverse.mcp.server.JsonRpcErrorCodes;
 import io.quarkiverse.mcp.server.McpException;
 import io.quarkiverse.mcp.server.ResourceTemplateCompletionManager;
 import io.quarkiverse.mcp.server.runtime.ResourceTemplateManagerImpl.ResourceTemplateMetadata;
+import io.quarkiverse.mcp.server.runtime.config.McpServersRuntimeConfig;
 import io.quarkus.security.identity.CurrentIdentityAssociation;
 import io.vertx.core.Vertx;
 
@@ -23,10 +24,15 @@ public class ResourceTemplateCompletionManagerImpl extends CompletionManagerBase
 
     private final Map<String, String> nameToUriTemplate;
 
-    ResourceTemplateCompletionManagerImpl(McpMetadata metadata, Vertx vertx, ObjectMapper mapper,
-            ConnectionManager connectionManager, ResourceTemplateManagerImpl resourceTemplateManager,
-            Instance<CurrentIdentityAssociation> currentIdentityAssociation, ResponseHandlers responseHandlers) {
-        super(vertx, mapper, connectionManager, currentIdentityAssociation, responseHandlers);
+    ResourceTemplateCompletionManagerImpl(McpMetadata metadata,
+            Vertx vertx,
+            ObjectMapper mapper,
+            ConnectionManager connectionManager,
+            ResourceTemplateManagerImpl resourceTemplateManager,
+            Instance<CurrentIdentityAssociation> currentIdentityAssociation,
+            ResponseHandlers responseHandlers,
+            McpServersRuntimeConfig config) {
+        super(vertx, mapper, connectionManager, currentIdentityAssociation, responseHandlers, config, metadata);
         this.nameToUriTemplate = metadata.resourceTemplates()
                 .stream().map(FeatureMetadata::info).collect(Collectors.toMap(FeatureMethodInfo::name, FeatureMethodInfo::uri));
         for (FeatureMetadata<CompletionResponse> c : metadata.resourceTemplateCompletions()) {

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceTemplateManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceTemplateManagerImpl.java
@@ -40,6 +40,7 @@ import io.quarkiverse.mcp.server.ResourceResponse;
 import io.quarkiverse.mcp.server.ResourceTemplateFilter;
 import io.quarkiverse.mcp.server.ResourceTemplateManager;
 import io.quarkiverse.mcp.server.ResourceTemplateManager.ResourceTemplateInfo;
+import io.quarkiverse.mcp.server.runtime.config.McpServersRuntimeConfig;
 import io.quarkus.arc.All;
 import io.quarkus.security.identity.CurrentIdentityAssociation;
 import io.smallrye.mutiny.Uni;
@@ -66,8 +67,9 @@ public class ResourceTemplateManagerImpl extends FeatureManagerBase<ResourceResp
             Instance<CurrentIdentityAssociation> currentIdentityAssociation,
             ResponseHandlers responseHandlers,
             @All List<ResourceTemplateFilter> filters,
-            @Any Instance<IconsProvider> iconsProviders) {
-        super(vertx, mapper, connectionManager, currentIdentityAssociation, responseHandlers);
+            @Any Instance<IconsProvider> iconsProviders,
+            McpServersRuntimeConfig config) {
+        super(vertx, mapper, connectionManager, currentIdentityAssociation, responseHandlers, config, metadata);
         this.templates = new ConcurrentHashMap<>();
         for (FeatureMetadata<ResourceResponse> fm : metadata.resourceTemplates()) {
             this.templates.put(fm.info().name(), new ResourceTemplateMetadata(createMatcherFromUriTemplate(fm.info().uri()),
@@ -453,7 +455,7 @@ public class ResourceTemplateManagerImpl extends FeatureManagerBase<ResourceResp
         private Map<MetaKey, Object> metadata = Map.of();
 
         ResourceTemplateDefinitionImpl(String name) {
-            super(name);
+            super(name, ResourceTemplateManagerImpl.this.serverNames);
         }
 
         @Override

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ToolManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ToolManagerImpl.java
@@ -101,7 +101,7 @@ public class ToolManagerImpl extends FeatureManagerBase<ToolResponse, ToolInfo> 
             Instance<OutputSchemaGenerator> outputSchemaGenerator,
             McpServersBuildTimeConfig buildTimeConfig,
             McpServersRuntimeConfig config) {
-        super(vertx, mapper, connectionManager, currentIdentityAssociation, responseHandlers);
+        super(vertx, mapper, connectionManager, currentIdentityAssociation, responseHandlers, config, metadata);
         this.tools = new ConcurrentHashMap<>();
         this.inputGuardrails = inputGuardrails;
         this.outputGuardrails = outputGuardrails;
@@ -525,7 +525,7 @@ public class ToolManagerImpl extends FeatureManagerBase<ToolResponse, ToolInfo> 
         private List<Class<? extends ToolOutputGuardrail>> outputGuardrails;
 
         private ToolDefinitionImpl(String name) {
-            super(name);
+            super(name, ToolManagerImpl.this.serverNames);
             this.arguments = new ArrayList<>();
         }
 

--- a/docs/modules/ROOT/pages/concepts-transports.adoc
+++ b/docs/modules/ROOT/pages/concepts-transports.adoc
@@ -57,7 +57,7 @@ This artifact contains both versions of the `HTTP` transport.
 // https://github.com/quarkiverse/quarkus-mcp-server/issues/105
 The MCP endpoint (as defined in `2025-03-26`) is exposed at `\{rootPath}`, i.e. `/mcp` by default.
 The SSE endpoint (as defined in `2024-11-05`) is exposed at `\{rootPath}/sse`, i.e. `/mcp/sse` by default.
-The `\{rootPath}` is set to `mcp` by default, but it can be changed with the `quarkus.mcp.server.sse.root-path` configuration property.
+The `\{rootPath}` is set to `mcp` by default, but it can be changed with the `quarkus.mcp.server.http.root-path` configuration property.
 
 NOTE: The https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#resumability-and-redelivery[Resumability and Redelivery] for the Streamable HTTP is not supported yet.
 

--- a/docs/modules/ROOT/pages/includes/quarkus-mcp-server-http.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-mcp-server-http.adoc
@@ -7,6 +7,32 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
+a|icon:lock[title=Fixed at build time] [[quarkus-mcp-server-http_quarkus-mcp-server-http-enabled]] [.property-path]##link:#quarkus-mcp-server-http_quarkus-mcp-server-http-enabled[`quarkus.mcp.server.http.enabled`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.http.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.mcp.server."server-name".http.enabled`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server."server-name".http.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Enable HTTP transport.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_HTTP_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_HTTP_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-mcp-server-http_quarkus-mcp-server-http-root-path]] [.property-path]##link:#quarkus-mcp-server-http_quarkus-mcp-server-http-root-path[`quarkus.mcp.server.http.root-path`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.mcp.server.http.root-path+++[]

--- a/docs/modules/ROOT/pages/includes/quarkus-mcp-server-http_quarkus.mcp.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-mcp-server-http_quarkus.mcp.adoc
@@ -7,6 +7,32 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
+a|icon:lock[title=Fixed at build time] [[quarkus-mcp-server-http_quarkus-mcp-server-http-enabled]] [.property-path]##link:#quarkus-mcp-server-http_quarkus-mcp-server-http-enabled[`quarkus.mcp.server.http.enabled`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.http.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.mcp.server."server-name".http.enabled`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server."server-name".http.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Enable HTTP transport.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_HTTP_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_HTTP_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-mcp-server-http_quarkus-mcp-server-http-root-path]] [.property-path]##link:#quarkus-mcp-server-http_quarkus-mcp-server-http-root-path[`quarkus.mcp.server.http.root-path`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.mcp.server.http.root-path+++[]

--- a/docs/modules/ROOT/pages/includes/quarkus-mcp-server-websocket.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-mcp-server-websocket.adoc
@@ -7,6 +7,32 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
+a|icon:lock[title=Fixed at build time] [[quarkus-mcp-server-websocket_quarkus-mcp-server-websocket-enabled]] [.property-path]##link:#quarkus-mcp-server-websocket_quarkus-mcp-server-websocket-enabled[`quarkus.mcp.server.websocket.enabled`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.websocket.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.mcp.server."server-name".websocket.enabled`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server."server-name".websocket.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Enable WebSocket transport.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_WEBSOCKET_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_WEBSOCKET_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-mcp-server-websocket_quarkus-mcp-server-websocket-endpoint-path]] [.property-path]##link:#quarkus-mcp-server-websocket_quarkus-mcp-server-websocket-endpoint-path[`quarkus.mcp.server.websocket.endpoint-path`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.mcp.server.websocket.endpoint-path+++[]

--- a/docs/modules/ROOT/pages/includes/quarkus-mcp-server-websocket_quarkus.mcp.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-mcp-server-websocket_quarkus.mcp.adoc
@@ -7,6 +7,32 @@ h|[.header-title]##Configuration property##
 h|Type
 h|Default
 
+a|icon:lock[title=Fixed at build time] [[quarkus-mcp-server-websocket_quarkus-mcp-server-websocket-enabled]] [.property-path]##link:#quarkus-mcp-server-websocket_quarkus-mcp-server-websocket-enabled[`quarkus.mcp.server.websocket.enabled`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.websocket.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`quarkus.mcp.server."server-name".websocket.enabled`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server."server-name".websocket.enabled+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Enable WebSocket transport.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_WEBSOCKET_ENABLED+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_WEBSOCKET_ENABLED+++`
+endif::add-copy-button-to-env-var[]
+--
+|boolean
+|`+++true+++`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-mcp-server-websocket_quarkus-mcp-server-websocket-endpoint-path]] [.property-path]##link:#quarkus-mcp-server-websocket_quarkus-mcp-server-websocket-endpoint-path[`quarkus.mcp.server.websocket.endpoint-path`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.mcp.server.websocket.endpoint-path+++[]

--- a/transports/http/deployment/src/main/java/io/quarkiverse/mcp/server/http/deployment/HttpMcpServerProcessor.java
+++ b/transports/http/deployment/src/main/java/io/quarkiverse/mcp/server/http/deployment/HttpMcpServerProcessor.java
@@ -11,6 +11,8 @@ import java.util.Set;
 
 import jakarta.inject.Singleton;
 
+import org.jboss.logging.Logger;
+
 import io.quarkiverse.mcp.server.deployment.ServerNameBuildItem;
 import io.quarkiverse.mcp.server.http.runtime.HttpMcpServerRecorder;
 import io.quarkiverse.mcp.server.http.runtime.McpServerEndpoints;
@@ -34,6 +36,8 @@ import io.quarkus.vertx.http.deployment.spi.RouteBuildItem;
 
 public class HttpMcpServerProcessor {
 
+    private static Logger LOG = Logger.getLogger(HttpMcpServerProcessor.class);
+
     @BuildStep
     FeatureBuildItem feature() {
         return new FeatureBuildItem("mcp-server-http");
@@ -51,8 +55,10 @@ public class HttpMcpServerProcessor {
 
     @BuildStep
     void serverNames(McpHttpServersBuildTimeConfig config, BuildProducer<ServerNameBuildItem> serverNames) {
-        for (String serverName : config.servers().keySet()) {
-            serverNames.produce(new ServerNameBuildItem(serverName));
+        for (Map.Entry<String, McpHttpServerBuildTimeConfig> e : config.servers().entrySet()) {
+            if (e.getValue().http().enabled()) {
+                serverNames.produce(new ServerNameBuildItem(e.getKey()));
+            }
         }
     }
 
@@ -97,6 +103,10 @@ public class HttpMcpServerProcessor {
         Set<String> rootPaths = new HashSet<>();
         for (Map.Entry<String, McpHttpServerBuildTimeConfig> e : config.servers().entrySet()) {
             String serverName = e.getKey();
+            if (!e.getValue().http().enabled()) {
+                LOG.debugf("HTTP transport disabled for server [%s]", serverName);
+                continue;
+            }
             String rootPath = e.getValue().http().rootPath();
             if (!rootPaths.add(rootPath)) {
                 throw new IllegalStateException("Multiple server configurations define the same root path: " + rootPath);

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/mcpservers/DefaultServerDisabledTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/mcpservers/DefaultServerDisabledTest.java
@@ -1,0 +1,77 @@
+package io.quarkiverse.mcp.server.test.mcpservers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.McpServer;
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkiverse.mcp.server.test.McpAssured.McpStreamableTestClient;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.vertx.core.http.HttpHeaders;
+
+public class DefaultServerDisabledTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = config(500)
+            .withApplicationRoot(
+                    root -> root.addClasses(MyFeatures.class))
+            .overrideConfigKey("quarkus.mcp.server.http.enabled", "false")
+            .overrideConfigKey("quarkus.mcp.server.bravo.http.root-path", "/bravo/mcp");
+
+    static QuarkusUnitTest config(int textLimit) {
+        QuarkusUnitTest ret = defaultConfig(500);
+        if (System.getProperty("logTraffic") != null) {
+            ret.overrideConfigKey("quarkus.mcp.server.bravo.traffic-logging.enabled", "true");
+            ret.overrideConfigKey("quarkus.mcp.server.bravo.traffic-logging.text-limit", "" + textLimit);
+        }
+        return ret;
+    }
+
+    @Test
+    public void testServers() {
+        // HTTP transport is disabled for the default server
+        RestAssured.given()
+                .when()
+                .headers(HttpHeaders.ACCEPT + "", "application/json, text/event-stream")
+                .body("TEST")
+                .post(testUri.toString() + "/mcp")
+                .then()
+                .statusCode(404);
+
+        McpStreamableTestClient client = McpAssured.newStreamableClient()
+                .setMcpPath("/bravo/mcp")
+                .build()
+                .connect();
+
+        client.when()
+                .toolsCall("bravo", response -> {
+                    assertEquals("2", response.content().get(0).asText().text());
+                })
+                .toolsCall("alpha")
+                .withErrorAssert(error -> {
+                    assertEquals("Invalid tool name: alpha", error.message());
+                })
+                .send()
+                .toolsCall("charlie")
+                .withErrorAssert(error -> {
+                    assertEquals("Invalid tool name: charlie", error.message());
+                })
+                .send()
+                .thenAssertResults();
+    }
+
+    public static class MyFeatures {
+
+        @McpServer("bravo")
+        @Tool
+        String bravo() {
+            return "2";
+        }
+
+    }
+}

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/mcpservers/MultipleServersActiveTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/mcpservers/MultipleServersActiveTest.java
@@ -18,9 +18,9 @@ public class MultipleServersActiveTest extends McpServerTest {
     static final QuarkusUnitTest config = config(500)
             .withApplicationRoot(
                     root -> root.addClasses(MyFeatures.class))
-            .overrideConfigKey("quarkus.mcp.server.sse.root-path", "/alpha/mcp")
-            .overrideConfigKey("quarkus.mcp.server.bravo.sse.root-path", "/bravo/mcp")
-            .overrideConfigKey("quarkus.mcp.server.charlie.sse.root-path", "/charlie/mcp");
+            .overrideConfigKey("quarkus.mcp.server.http.root-path", "/alpha/mcp")
+            .overrideConfigKey("quarkus.mcp.server.bravo.http.root-path", "/bravo/mcp")
+            .overrideConfigKey("quarkus.mcp.server.charlie.http.root-path", "/charlie/mcp");
 
     static QuarkusUnitTest config(int textLimit) {
         QuarkusUnitTest ret = defaultConfig(500);

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/mcpservers/MutipleServersTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/mcpservers/MutipleServersTest.java
@@ -3,6 +3,7 @@ package io.quarkiverse.mcp.server.test.mcpservers;
 import static io.quarkiverse.mcp.server.McpServer.DEFAULT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 
@@ -50,7 +51,16 @@ public class MutipleServersTest extends McpServerTest {
     ResourceManager resourceManager;
 
     @Test
-    public void testDefaultServer() {
+    public void testServers() {
+        IllegalStateException ise = assertThrows(IllegalStateException.class, () ->
+        // Fail if InvalidServerNameStrategy == FAIL
+        toolManager.newTool("foo")
+                .setServerName("nonexistent")
+                .setDescription("My foo!")
+                .setHandler(ta -> ToolResponse.success("ok"))
+                .register());
+        assertEquals("Invalid server name: nonexistent", ise.getMessage());
+
         ToolManager.ToolInfo bravo = toolManager.getTool("bravo");
         assertNotNull(bravo);
         assertEquals("bravo", bravo.serverName());

--- a/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/config/McpHttpServerBuildTimeConfig.java
+++ b/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/config/McpHttpServerBuildTimeConfig.java
@@ -12,6 +12,12 @@ public interface McpHttpServerBuildTimeConfig {
     public interface Http {
 
         /**
+         * Enable HTTP transport.
+         */
+        @WithDefault("true")
+        boolean enabled();
+
+        /**
          * The MCP endpoint (as defined in the specification `2025-03-26`) is exposed at `\{rootPath}`. By default, it's `/mcp`.
          *
          * The SSE endpoint (as defined in the specification `2024-11-05`) is exposed at `\{rootPath}/sse`. By default, it's

--- a/transports/websocket/deployment/src/main/java/io/quarkiverse/mcp/server/websocket/deployment/WebSocketMcpServerProcessor.java
+++ b/transports/websocket/deployment/src/main/java/io/quarkiverse/mcp/server/websocket/deployment/WebSocketMcpServerProcessor.java
@@ -2,6 +2,7 @@ package io.quarkiverse.mcp.server.websocket.deployment;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
@@ -9,6 +10,7 @@ import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Singleton;
 
 import org.jboss.jandex.AnnotationInstance;
+import org.jboss.logging.Logger;
 
 import io.quarkiverse.mcp.server.InitialCheck;
 import io.quarkiverse.mcp.server.InitialResponseInfo;
@@ -50,6 +52,8 @@ import io.vertx.core.Vertx;
 
 public class WebSocketMcpServerProcessor {
 
+    private static final Logger LOG = Logger.getLogger(WebSocketMcpServerProcessor.class);
+
     @BuildStep
     FeatureBuildItem feature() {
         return new FeatureBuildItem("mcp-server-websocket");
@@ -66,8 +70,10 @@ public class WebSocketMcpServerProcessor {
 
     @BuildStep
     void serverNames(McpWebSocketServersBuildTimeConfig config, BuildProducer<ServerNameBuildItem> serverNames) {
-        for (String serverName : config.servers().keySet()) {
-            serverNames.produce(new ServerNameBuildItem(serverName));
+        for (Map.Entry<String, McpWebSocketServerBuildTimeConfig> e : config.servers().entrySet()) {
+            if (e.getValue().websocket().enabled()) {
+                serverNames.produce(new ServerNameBuildItem(e.getKey()));
+            }
         }
     }
 
@@ -78,6 +84,10 @@ public class WebSocketMcpServerProcessor {
         // For each WebSocket path we generate a new class that extends WebSocketMcpMessageHandler
         Set<String> endpointPaths = new HashSet<>();
         for (Entry<String, McpWebSocketServerBuildTimeConfig> e : config.servers().entrySet()) {
+            if (!e.getValue().websocket().enabled()) {
+                LOG.debugf("WebSocket transport disabled for server [%s]", e.getKey());
+                continue;
+            }
             String endpointPath = e.getValue().websocket().endpointPath();
             if (!endpointPaths.add(endpointPath)) {
                 throw new IllegalStateException(

--- a/transports/websocket/deployment/src/test/java/io/quarkiverse/mcp/server/websocket/test/mcpservers/DefaultServerDisabledTest.java
+++ b/transports/websocket/deployment/src/test/java/io/quarkiverse/mcp/server/websocket/test/mcpservers/DefaultServerDisabledTest.java
@@ -1,0 +1,77 @@
+package io.quarkiverse.mcp.server.websocket.test.mcpservers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.McpServer;
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkiverse.mcp.server.test.McpAssured.McpWebSocketTestClient;
+import io.quarkiverse.mcp.server.websocket.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.vertx.core.http.HttpHeaders;
+
+public class DefaultServerDisabledTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = config(500)
+            .withApplicationRoot(
+                    root -> root.addClasses(MyFeatures.class))
+            .overrideConfigKey("quarkus.mcp.server.websocket.enabled", "false")
+            .overrideConfigKey("quarkus.mcp.server.bravo.websocket.endpoint-path", "/bravo/mcp");
+
+    static QuarkusUnitTest config(int textLimit) {
+        QuarkusUnitTest ret = defaultConfig(500);
+        if (System.getProperty("logTraffic") != null) {
+            ret.overrideConfigKey("quarkus.mcp.server.bravo.traffic-logging.enabled", "true");
+            ret.overrideConfigKey("quarkus.mcp.server.bravo.traffic-logging.text-limit", "" + textLimit);
+        }
+        return ret;
+    }
+
+    @Test
+    public void testServers() {
+        // HTTP transport is disabled for the default server
+        RestAssured.given()
+                .when()
+                .headers(HttpHeaders.ACCEPT + "", "application/json, text/event-stream")
+                .body("TEST")
+                .post(testUri.toString() + "/mcp")
+                .then()
+                .statusCode(404);
+
+        McpWebSocketTestClient client = McpAssured.newWebSocketClient()
+                .setEndpointPath("/bravo/mcp")
+                .build()
+                .connect();
+
+        client.when()
+                .toolsCall("bravo", response -> {
+                    assertEquals("2", response.content().get(0).asText().text());
+                })
+                .toolsCall("alpha")
+                .withErrorAssert(error -> {
+                    assertEquals("Invalid tool name: alpha", error.message());
+                })
+                .send()
+                .toolsCall("charlie")
+                .withErrorAssert(error -> {
+                    assertEquals("Invalid tool name: charlie", error.message());
+                })
+                .send()
+                .thenAssertResults();
+    }
+
+    public static class MyFeatures {
+
+        @McpServer("bravo")
+        @Tool
+        String bravo() {
+            return "2";
+        }
+
+    }
+}

--- a/transports/websocket/runtime/src/main/java/io/quarkiverse/mcp/server/websocket/runtime/config/McpWebSocketServerBuildTimeConfig.java
+++ b/transports/websocket/runtime/src/main/java/io/quarkiverse/mcp/server/websocket/runtime/config/McpWebSocketServerBuildTimeConfig.java
@@ -12,6 +12,12 @@ public interface McpWebSocketServerBuildTimeConfig {
     public interface WebSocket {
 
         /**
+         * Enable WebSocket transport.
+         */
+        @WithDefault("true")
+        boolean enabled();
+
+        /**
          * The WebSocket MCP endpoint is exposed at `\{endpointPath}`. By default, it's `/mcp/ws`.
          *
          * @asciidoclet


### PR DESCRIPTION
- for a specific server
- also fail if non existent server name is used when a feature is added programmatically and InvalidServerNameStrategy == FAIL
- resolves #633