### PR TITLE
core: fix pagination cursor

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/FeatureManager.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/FeatureManager.java
@@ -39,7 +39,7 @@ public interface FeatureManager<INFO extends FeatureInfo> extends Iterable<INFO>
         boolean isMethod();
 
         /**
-         * @return the timestamp this feature was registered
+         * @return the timestamp when this feature was registered
          */
         Instant createdAt();
 

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/Cursor.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/Cursor.java
@@ -1,34 +1,36 @@
 package io.quarkiverse.mcp.server.runtime;
 
-import java.nio.charset.StandardCharsets;
+import java.nio.ByteBuffer;
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.Base64;
 
 /**
  * A composite opaque cursor.
  */
-record Cursor(Instant createdAt, String name) {
+record Cursor(Instant createdAt, Instant snapshotTimestamp) {
 
-    static final Cursor FIRST_PAGE = new Cursor(Instant.EPOCH, null);
-
-    static String encode(Instant createdAt, String name) {
-        String value = createdAt + "$$$" + name;
-        return Base64.getEncoder().encodeToString(value.getBytes(StandardCharsets.UTF_8));
+    static String encode(Instant createdAt, Instant snapshotTimestamp) {
+        // long|int|long|int
+        ByteBuffer buffer = ByteBuffer.allocate(24);
+        buffer.putLong(createdAt.getEpochSecond());
+        buffer.putInt(createdAt.getNano());
+        buffer.putLong(snapshotTimestamp.getEpochSecond());
+        buffer.putInt(snapshotTimestamp.getNano());
+        return Base64.getEncoder().encodeToString(buffer.array());
     }
 
     static Cursor decode(String value) {
         if (value == null || value.isBlank()) {
             throw new IllegalArgumentException("Blank cursor value");
         }
-        String decoded = new String(Base64.getDecoder().decode(value), StandardCharsets.UTF_8);
-        String[] parts = decoded.split("\\$\\$\\$");
-        if (parts.length != 2) {
-            throw new IllegalArgumentException("Invalid parts: " + Arrays.toString(parts));
+        byte[] bytes = Base64.getDecoder().decode(value);
+        if (bytes.length != 24) {
+            throw new IllegalArgumentException("Invalid cursor");
         }
-        Instant createdAt = Instant.parse(parts[0]);
-        String name = parts[1];
-        return new Cursor(createdAt, name);
+        ByteBuffer buffer = ByteBuffer.wrap(bytes);
+        Instant createdAt = Instant.ofEpochSecond(buffer.getLong(), buffer.getInt());
+        Instant snapshotTimestamp = Instant.ofEpochSecond(buffer.getLong(), buffer.getInt());
+        return new Cursor(createdAt, snapshotTimestamp);
     }
 
 }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/FeatureManagerBase.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/FeatureManagerBase.java
@@ -180,9 +180,14 @@ public abstract class FeatureManagerBase<RESULT, INFO extends FeatureManager.Fea
             return new Page<>(infosForRequest(filterContext).sorted().toList(), true);
         }
         List<INFO> result = infosForRequest(filterContext)
-                .filter(r -> r.createdAt().isAfter(cursor.createdAt())
-                        && (cursor.name() == null
-                                || r.name().compareTo(cursor.name()) > 0))
+                .filter(r -> {
+                    if (r.createdAt().isAfter(cursor.createdAt())
+                            && r.createdAt().isBefore(cursor.snapshotTimestamp())) {
+                        return true;
+                    }
+                    LOG.debugf("Skip %s [%s] for %s", r.getClass().getSimpleName(), r.name(), cursor);
+                    return false;
+                })
                 .sorted()
                 // (pageSize + 1) so that we know if a next page exists
                 .limit(pageSize + 1)

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/Messages.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/Messages.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.mcp.server.runtime;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -95,7 +96,7 @@ public class Messages {
                 }
             }
         }
-        return Cursor.FIRST_PAGE;
+        return new Cursor(Instant.EPOCH, Instant.now());
     }
 
     public static Object getId(JsonObject message) {

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/PromptMessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/PromptMessageHandler.java
@@ -50,7 +50,7 @@ class PromptMessageHandler extends MessageHandler {
         }
         if (page.hasNextCursor()) {
             PromptManager.PromptInfo last = page.lastInfo();
-            result.put("nextCursor", Cursor.encode(last.createdAt(), last.name()));
+            result.put("nextCursor", Cursor.encode(last.createdAt(), cursor.snapshotTimestamp()));
         }
         return mcpRequest.sender().sendResult(id, result);
     }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceMessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceMessageHandler.java
@@ -78,7 +78,7 @@ class ResourceMessageHandler extends MessageHandler {
         }
         if (page.hasNextCursor()) {
             ResourceInfo last = page.lastInfo();
-            result.put("nextCursor", Cursor.encode(last.createdAt(), last.name()));
+            result.put("nextCursor", Cursor.encode(last.createdAt(), cursor.snapshotTimestamp()));
         }
         return mcpRequest.sender().sendResult(id, result);
     }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceTemplateMessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceTemplateMessageHandler.java
@@ -45,7 +45,7 @@ class ResourceTemplateMessageHandler extends MessageHandler {
         }
         if (page.hasNextCursor()) {
             ResourceTemplateManager.ResourceTemplateInfo last = page.lastInfo();
-            result.put("nextCursor", Cursor.encode(last.createdAt(), last.name()));
+            result.put("nextCursor", Cursor.encode(last.createdAt(), cursor.snapshotTimestamp()));
         }
         return mcpRequest.sender().sendResult(id, result);
     }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ToolMessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ToolMessageHandler.java
@@ -59,7 +59,7 @@ class ToolMessageHandler extends MessageHandler {
         }
         if (page.hasNextCursor()) {
             ToolManager.ToolInfo last = page.lastInfo();
-            result.put("nextCursor", Cursor.encode(last.createdAt(), last.name()));
+            result.put("nextCursor", Cursor.encode(last.createdAt(), cursor.snapshotTimestamp()));
         }
         return mcpRequest.sender().sendResult(id, result);
     }

--- a/core/runtime/src/test/java/io/quarkiverse/mcp/server/runtime/CursorTest.java
+++ b/core/runtime/src/test/java/io/quarkiverse/mcp/server/runtime/CursorTest.java
@@ -10,14 +10,15 @@ public class CursorTest {
 
     @Test
     public void testEncode() {
-        assertEquals("MjAyNS0wMi0xN1QxNzowNzoyNi4xMzgxNjM5MTNaJCQkNg==",
-                Cursor.encode(Instant.parse("2025-02-17T17:07:26.138163913Z"), "6"));
+        assertEquals("AAAAAGezbM4IPDbJAAAAAGezbQoIPDbJ",
+                Cursor.encode(Instant.parse("2025-02-17T17:07:26.138163913Z"),
+                        Instant.parse("2025-02-17T17:08:26.138163913Z")));
     }
 
     @Test
     public void testDecode() {
-        Cursor cursor = Cursor.decode("MjAyNS0wMi0xN1QxNzowNzoyNi4xMzgxNjM5MTNaJCQkNg==");
-        assertEquals("6", cursor.name());
+        Cursor cursor = Cursor.decode("AAAAAGezbM4IPDbJAAAAAGezbQoIPDbJ");
+        assertEquals(Instant.parse("2025-02-17T17:08:26.138163913Z"), cursor.snapshotTimestamp());
         assertEquals(Instant.parse("2025-02-17T17:07:26.138163913Z"), cursor.createdAt());
     }
 

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/ToolsPaginationTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/ToolsPaginationTest.java
@@ -31,10 +31,9 @@ public class ToolsPaginationTest extends McpServerTest {
 
     @Test
     public void testTools() {
-        int loop = 8;
-        for (int i = 1; i <= loop; i++) {
-            String name = i + "";
-            addTool(name);
+        String[] names = { "foo", "bar", "baz", "alpha", "bravo", "charlie", "delta", "echo" };
+        for (int i = 0; i < names.length; i++) {
+            addTool(names[i]);
         }
 
         Instant lastCreatedAt = Instant.EPOCH;
@@ -50,14 +49,48 @@ public class ToolsPaginationTest extends McpServerTest {
                 .toolsList(page -> {
                     cursor.set(page.nextCursor());
                     assertEquals(3, page.size());
-                    assertEquals("1", page.tools().get(0).name());
-                    assertEquals("2", page.tools().get(1).name());
-                    assertEquals("3", page.tools().get(2).name());
+                    assertEquals(names[0], page.tools().get(0).name());
+                    assertEquals(names[1], page.tools().get(1).name());
+                    assertEquals(names[2], page.tools().get(2).name());
+                }).thenAssertResults();
+
+        client.when()
+                .toolsList()
+                .withCursor(cursor.get())
+                .withAssert(page -> {
+                    cursor.set(page.nextCursor());
+                    assertEquals(3, page.size());
+                    assertEquals(names[3], page.tools().get(0).name());
+                    assertEquals(names[4], page.tools().get(1).name());
+                    assertEquals(names[5], page.tools().get(2).name());
+                })
+                .send()
+                .thenAssertResults();
+        client.when()
+                .toolsList()
+                .withCursor(cursor.get())
+                .withAssert(page -> {
+                    cursor.set(page.nextCursor());
+                    assertEquals(2, page.size());
+                    assertEquals(names[6], page.tools().get(0).name());
+                    assertEquals(names[7], page.tools().get(1).name());
+                })
+                .send()
+                .thenAssertResults();
+
+        // start again
+        client.when()
+                .toolsList(page -> {
+                    cursor.set(page.nextCursor());
+                    assertEquals(3, page.size());
+                    assertEquals(names[0], page.tools().get(0).name());
+                    assertEquals(names[1], page.tools().get(1).name());
+                    assertEquals(names[2], page.tools().get(2).name());
                 })
                 .thenAssertResults();
 
         // remove tool from the first page
-        manager.removeTool("2");
+        manager.removeTool(names[1]);
         // add tool "0" - this one should not be visible at all
         addTool("0");
 
@@ -67,9 +100,9 @@ public class ToolsPaginationTest extends McpServerTest {
                 .withAssert(page -> {
                     cursor.set(page.nextCursor());
                     assertEquals(3, page.size());
-                    assertEquals("4", page.tools().get(0).name());
-                    assertEquals("5", page.tools().get(1).name());
-                    assertEquals("6", page.tools().get(2).name());
+                    assertEquals(names[3], page.tools().get(0).name());
+                    assertEquals(names[4], page.tools().get(1).name());
+                    assertEquals(names[5], page.tools().get(2).name());
                 })
                 .send()
                 .thenAssertResults();
@@ -79,8 +112,8 @@ public class ToolsPaginationTest extends McpServerTest {
                 .withCursor(cursor.get())
                 .withAssert(page -> {
                     assertEquals(2, page.size());
-                    assertEquals("7", page.tools().get(0).name());
-                    assertEquals("8", page.tools().get(1).name());
+                    assertEquals(names[6], page.tools().get(0).name());
+                    assertEquals(names[7], page.tools().get(1).name());
                 })
                 .send()
                 .thenAssertResults();


### PR DESCRIPTION
- we cannot use the name to make the cursor resilient to concurrent modifications, instead use a snapshot timestamp
- fixes #672