### PR TITLE
core: mitigate McpServer backward compatibility issue

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/McpServerProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/McpServerProcessor.java
@@ -563,7 +563,8 @@ class McpServerProcessor {
 
     private Set<String> initServerBindings(McpServersBuildTimeConfig config, IndexView index, MethodInfo method) {
         Set<String> ret = new HashSet<String>();
-        if (config.supportMultiServerBindings()) {
+        Optional<Boolean> multiServerBindings = config.supportMultiServerBindings();
+        if (multiServerBindings.orElse(true)) {
             // The set of bindings includes all values declared on the feature method and all values defined on the declaring class of the feature
             List<AnnotationInstance> methodAnnotations = method.declaredAnnotationsWithRepeatable(DotNames.MCP_SERVER, index);
             List<AnnotationInstance> classAnnotations = method.declaringClass()
@@ -574,15 +575,18 @@ class McpServerProcessor {
             for (AnnotationInstance a : classAnnotations) {
                 ret.add(a.value().asString());
             }
-            if (ret.size() > 1 && methodAnnotations.size() == 1 && classAnnotations.size() == 1) {
+            if (ret.size() > 1 && methodAnnotations.size() == 1 && classAnnotations.size() == 1
+                    && multiServerBindings.isEmpty()) {
                 // In versions 1.10 and lower, the method-level annotation overrode the class-level one;
-                // now both are merged - warn users who may be relying on the old behavior
-                LOG.warnf(
-                        "Feature method %s#%s() is bound to servers %s because @McpServer bindings declared on"
-                                + " the method and the declaring class are now merged."
-                                + " In previous versions, the method-level binding would override the class-level one."
-                                + " Set 'quarkus.mcp.server.support-multi-server-bindings=false' to revert to the old behavior.",
-                        method.declaringClass().name().withoutPackagePrefix(), method.name(), ret);
+                // now both are merged - fail the build if the user has not explicitly opted in
+                throw new IllegalStateException(
+                        String.format(
+                                "Feature method %s#%s() is bound to servers %s because @McpServer bindings declared on"
+                                        + " the method and the declaring class are now merged."
+                                        + " In previous versions, the method-level binding would override the class-level one."
+                                        + " Set 'quarkus.mcp.server.support-multi-server-bindings=true' to use the new merge behavior,"
+                                        + " or 'quarkus.mcp.server.support-multi-server-bindings=false' to revert to the old behavior.",
+                                method.declaringClass().name().withoutPackagePrefix(), method.name(), ret));
             }
         } else {
             // Compatibility mode - only a single binding is allowed

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/McpServer.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/McpServer.java
@@ -21,7 +21,9 @@ import io.quarkiverse.mcp.server.McpServer.McpServers;
  * sense anymore. Instead, all values declared on a class are included in the set of servers for a feature. If you need to
  * revert to the previous behavior you can set the {@code quarkus.mcp.server.support-multi-server-bindings} configuration
  * property to {@code false}. Then the previous rules will apply and multiple server bindings will then result in a
- * build failure.
+ * build failure. If the property is not set explicitly and an ambiguous pattern is detected (a feature method and its
+ * declaring class both declare different {@code @McpServer} values), the build will fail with an error explaining the
+ * options.
  *
  * @see Tool
  * @see Prompt

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/config/McpServersBuildTimeConfig.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/config/McpServersBuildTimeConfig.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.mcp.server.runtime.config;
 
 import java.util.Map;
+import java.util.Optional;
 
 import io.quarkiverse.mcp.server.McpServer;
 import io.quarkus.runtime.annotations.ConfigDocMapKey;
@@ -28,9 +29,11 @@ public interface McpServersBuildTimeConfig {
     /**
      * If set to `true` then it's possible to bind a feature (such as tool or resource) to multiple server configurations.
      * If set to `false` then only a single binding is allowed.
+     * <p>
+     * If not set explicitly and an ambiguous binding pattern is detected (i.e. a feature method and its declaring class both
+     * declare different {@code @McpServer} values), the build will fail with an error explaining the options.
      */
-    @WithDefault("true")
-    boolean supportMultiServerBindings();
+    Optional<Boolean> supportMultiServerBindings();
 
     /**
      * Server configurations.

--- a/docs/modules/ROOT/pages/includes/quarkus-mcp-server-core.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-mcp-server-core.adoc
@@ -39,6 +39,8 @@ endif::add-copy-button-to-config-props[]
 --
 If set to `true` then it's possible to bind a feature (such as tool or resource) to multiple server configurations. If set to `false` then only a single binding is allowed.
 
+If not set explicitly and an ambiguous binding pattern is detected (i.e. a feature method and its declaring class both declare different `@McpServer` values), the build will fail with an error explaining the options.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_SUPPORT_MULTI_SERVER_BINDINGS+++[]
@@ -48,7 +50,7 @@ Environment variable: `+++QUARKUS_MCP_SERVER_SUPPORT_MULTI_SERVER_BINDINGS+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean
-|`+++true+++`
+|
 
 a| [[quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-enabled]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-enabled[`quarkus.mcp.server.schema-generator.jackson.enabled`]##
 ifdef::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-mcp-server-core_quarkus.mcp.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-mcp-server-core_quarkus.mcp.adoc
@@ -39,6 +39,8 @@ endif::add-copy-button-to-config-props[]
 --
 If set to `true` then it's possible to bind a feature (such as tool or resource) to multiple server configurations. If set to `false` then only a single binding is allowed.
 
+If not set explicitly and an ambiguous binding pattern is detected (i.e. a feature method and its declaring class both declare different `@McpServer` values), the build will fail with an error explaining the options.
+
 
 ifdef::add-copy-button-to-env-var[]
 Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_SUPPORT_MULTI_SERVER_BINDINGS+++[]
@@ -48,7 +50,7 @@ Environment variable: `+++QUARKUS_MCP_SERVER_SUPPORT_MULTI_SERVER_BINDINGS+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean
-|`+++true+++`
+|
 
 a| [[quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-enabled]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-schema-generator-jackson-enabled[`quarkus.mcp.server.schema-generator.jackson.enabled`]##
 ifdef::add-copy-button-to-config-props[]


### PR DESCRIPTION
- fail the build if quarkus.mcp.server.support-multi-server-bindings is unset and ambiguous pattern is detected