### PR TITLE
core: revisit dummy initialization for streamable HTTP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,4 @@ pom.xml.tag
 pom.xml.releaseBackup
 pom.xml.versionsBackup
 release.properties
+/.claude/

--- a/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/McpServerProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/McpServerProcessor.java
@@ -83,6 +83,7 @@ import io.quarkiverse.mcp.server.ToolManager.ToolAnnotations;
 import io.quarkiverse.mcp.server.ToolResponse;
 import io.quarkiverse.mcp.server.WrapBusinessError;
 import io.quarkiverse.mcp.server.runtime.BuiltinDefaultValueConverters;
+import io.quarkiverse.mcp.server.runtime.CancellationRequests;
 import io.quarkiverse.mcp.server.runtime.DefaultResourceContentsEncoder;
 import io.quarkiverse.mcp.server.runtime.DefaultSchemaGenerator;
 import io.quarkiverse.mcp.server.runtime.Feature;
@@ -206,6 +207,7 @@ class McpServerProcessor {
         AdditionalBeanBuildItem.Builder unremovable = AdditionalBeanBuildItem.builder().setUnremovable();
         unremovable.addBeanClass("io.quarkiverse.mcp.server.runtime.ConnectionManager");
         unremovable.addBeanClass(ResponseHandlers.class);
+        unremovable.addBeanClass(CancellationRequests.class);
         unremovable.addBeanClass(DefaultSchemaGenerator.class);
         unremovable.addBeanClass(McpObjectMapperCustomizer.class);
         // Managers

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/InitialRequest.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/InitialRequest.java
@@ -9,9 +9,18 @@ import java.util.List;
  * @param protocolVersion the protocol version supported by the client (must not be {@code null})
  * @param clientCapabilities the capabilities supported by the client (must not be {@code null})
  * @param transport the transport used by the client (must not be {@code null})
+ * @param autoInitialized {@code true} if the request was created automatically (without client-initiated initialization)
  */
 public record InitialRequest(Implementation implementation, String protocolVersion,
-        List<ClientCapability> clientCapabilities, Transport transport) {
+        List<ClientCapability> clientCapabilities, Transport transport, boolean autoInitialized) {
+
+    /**
+     * Creates a new initial request with {@code autoInitialized} set to {@code false}.
+     */
+    public InitialRequest(Implementation implementation, String protocolVersion,
+            List<ClientCapability> clientCapabilities, Transport transport) {
+        this(implementation, protocolVersion, clientCapabilities, transport, false);
+    }
 
     public InitialRequest {
         if (implementation == null) {

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ArgumentProviders.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ArgumentProviders.java
@@ -16,7 +16,8 @@ record ArgumentProviders(
         Sender sender,
         Object progressToken,
         ResponseHandlers responseHandlers,
-        String serverName) {
+        String serverName,
+        CancellationRequests cancellationRequests) {
 
     Object getArg(String name) {
         return args != null ? args.get(name) : null;

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/CancellationImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/CancellationImpl.java
@@ -8,20 +8,22 @@ import io.quarkiverse.mcp.server.RequestId;
 public class CancellationImpl implements Cancellation {
 
     static CancellationImpl from(ArgumentProviders argProviders) {
-        return new CancellationImpl(argProviders.connection(), argProviders.requestId());
+        return new CancellationImpl(argProviders.connection(), argProviders.requestId(), argProviders.cancellationRequests());
     }
 
     private final McpConnectionBase connection;
     private final RequestId requestId;
+    private final CancellationRequests cancellationRequests;
 
-    private CancellationImpl(McpConnectionBase connection, Object requestId) {
+    private CancellationImpl(McpConnectionBase connection, Object requestId, CancellationRequests cancellationRequests) {
         this.connection = connection;
         this.requestId = new RequestId(requestId);
+        this.cancellationRequests = cancellationRequests;
     }
 
     @Override
     public Result check() {
-        Optional<String> reason = connection.getCancellationRequest(requestId);
+        Optional<String> reason = cancellationRequests.get(connection, requestId);
         if (reason == null) {
             return new Result(false, Optional.empty());
         } else {

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/CancellationRequests.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/CancellationRequests.java
@@ -1,0 +1,39 @@
+package io.quarkiverse.mcp.server.runtime;
+
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import jakarta.inject.Singleton;
+
+import io.quarkiverse.mcp.server.McpConnection;
+import io.quarkiverse.mcp.server.RequestId;
+import io.vertx.core.json.JsonObject;
+
+@Singleton
+public class CancellationRequests {
+
+    protected final ConcurrentMap<CancellationRequestKey, Optional<String>> cancellationRequests;
+
+    public CancellationRequests() {
+        this.cancellationRequests = new ConcurrentHashMap<>();
+    }
+
+    Optional<String> get(McpConnection connection, RequestId requestId) {
+        return cancellationRequests.get(new CancellationRequestKey(connection.id(), requestId));
+    }
+
+    boolean add(McpConnection connection, RequestId requestId, String reason) {
+        return cancellationRequests.putIfAbsent(new CancellationRequestKey(connection.id(), requestId),
+                Optional.ofNullable(reason)) == null;
+    }
+
+    void remove(McpConnection connection, JsonObject request) {
+        if (!cancellationRequests.isEmpty()) {
+            cancellationRequests.remove(new CancellationRequestKey(connection.id(), new RequestId(Messages.getId(request))));
+        }
+    }
+
+    private record CancellationRequestKey(String connectionId, RequestId requestId) {
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/CompletionManagerBase.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/CompletionManagerBase.java
@@ -33,9 +33,11 @@ public abstract class CompletionManagerBase extends FeatureManagerBase<Completio
             ConnectionManager connectionManager,
             Instance<CurrentIdentityAssociation> currentIdentityAssociation,
             ResponseHandlers responseHandlers,
+            CancellationRequests cancellationRequests,
             McpServersRuntimeConfig config,
             McpMetadata metadata) {
-        super(vertx, mapper, connectionManager, currentIdentityAssociation, responseHandlers, config, metadata);
+        super(vertx, mapper, connectionManager, currentIdentityAssociation, responseHandlers, cancellationRequests, config,
+                metadata);
         this.completions = new ConcurrentHashMap<>();
     }
 

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/CompletionMessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/CompletionMessageHandler.java
@@ -13,10 +13,10 @@ public abstract class CompletionMessageHandler extends MessageHandler {
 
     private static final Logger LOG = Logger.getLogger(CompletionMessageHandler.class);
 
-    private final ResponseHandlers responseHandlers;
+    private final CompletionManagerBase manager;
 
-    protected CompletionMessageHandler(ResponseHandlers responseHandlers) {
-        this.responseHandlers = responseHandlers;
+    protected CompletionMessageHandler(CompletionManagerBase manager) {
+        this.manager = manager;
     }
 
     protected abstract Future<CompletionResponse> execute(String key, JsonObject message, ArgumentProviders argProviders,
@@ -36,7 +36,8 @@ public abstract class CompletionMessageHandler extends MessageHandler {
 
         ArgumentProviders argProviders = new ArgumentProviders(message,
                 Map.of(argumentName, argument.getString("value")), mcpRequest.connection(), id, null, sender,
-                Messages.getProgressToken(message), responseHandlers, mcpRequest.serverName());
+                Messages.getProgressToken(message), manager.responseHandlers, mcpRequest.serverName(),
+                manager.cancellationRequests);
 
         try {
             Future<CompletionResponse> fu = execute(key, message, argProviders, mcpRequest);

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/FeatureManagerBase.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/FeatureManagerBase.java
@@ -78,15 +78,18 @@ public abstract class FeatureManagerBase<RESULT, INFO extends FeatureManager.Fea
 
     final ResponseHandlers responseHandlers;
 
+    final CancellationRequests cancellationRequests;
+
     protected FeatureManagerBase(Vertx vertx, ObjectMapper mapper, ConnectionManager connectionManager,
             Instance<CurrentIdentityAssociation> currentIdentityAssociation, ResponseHandlers responseHandlers,
-            McpServersRuntimeConfig config, McpMetadata metadata) {
+            CancellationRequests cancellationRequests, McpServersRuntimeConfig config, McpMetadata metadata) {
         this.vertx = vertx;
         this.mapper = mapper;
         this.connectionManager = connectionManager;
         this.loggers = new ConcurrentHashMap<>();
         this.currentIdentityAssociation = currentIdentityAssociation.isResolvable() ? currentIdentityAssociation.get() : null;
         this.responseHandlers = responseHandlers;
+        this.cancellationRequests = cancellationRequests;
         this.serverNames = config.invalidServerNameStrategy() == InvalidServerNameStrategy.FAIL ? metadata.serverNames() : null;
     }
 
@@ -139,7 +142,8 @@ public abstract class FeatureManagerBase<RESULT, INFO extends FeatureManager.Fea
         Object id = Messages.getId(message);
         Map<String, Object> args = arguments != null ? arguments.getMap() : new HashMap<>();
         return new ArgumentProviders(message, args, mcpRequest.connection(), id, null,
-                mcpRequest.sender(), getProgressToken(message), responseHandlers, mcpRequest.serverName());
+                mcpRequest.sender(), getProgressToken(message), responseHandlers, mcpRequest.serverName(),
+                cancellationRequests);
     }
 
     record FeatureExecutionContext(JsonObject message, McpRequest mcpRequest, ArgumentProviders argumentProviders) {

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpConnectionBase.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpConnectionBase.java
@@ -3,14 +3,11 @@ package io.quarkiverse.mcp.server.runtime;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Optional;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.quarkiverse.mcp.server.InitialRequest;
 import io.quarkiverse.mcp.server.McpConnection;
 import io.quarkiverse.mcp.server.McpLog.LogLevel;
-import io.quarkiverse.mcp.server.RequestId;
 import io.quarkiverse.mcp.server.runtime.config.McpServerRuntimeConfig;
 import io.vertx.core.json.JsonObject;
 
@@ -32,8 +29,6 @@ public abstract class McpConnectionBase implements McpConnection, Sender {
 
     protected final long idleTimeout;
 
-    protected final ConcurrentMap<RequestId, Optional<String>> cancellationRequests;
-
     protected final String serverName;
 
     protected McpConnectionBase(String id, McpServerRuntimeConfig serverConfig, String serverName) {
@@ -46,7 +41,6 @@ public abstract class McpConnectionBase implements McpConnection, Sender {
         this.autoPingInterval = serverConfig.autoPingInterval();
         this.lastUsed = Instant.now().toEpochMilli();
         this.idleTimeout = serverConfig.connectionIdleTimeout().toMillis();
-        this.cancellationRequests = new ConcurrentHashMap<>();
         this.serverName = serverName;
     }
 
@@ -118,20 +112,6 @@ public abstract class McpConnectionBase implements McpConnection, Sender {
     protected void messageSent(JsonObject message) {
         if (trafficLoggerTextLimit > 0) {
             TrafficLogger.messageSent(message, this, trafficLoggerTextLimit);
-        }
-    }
-
-    Optional<String> getCancellationRequest(RequestId requestId) {
-        return cancellationRequests.get(requestId);
-    }
-
-    boolean addCancellationRequest(RequestId requestId, String reason) {
-        return cancellationRequests.putIfAbsent(requestId, Optional.ofNullable(reason)) == null;
-    }
-
-    void removeCancellationRequest(JsonObject request) {
-        if (!cancellationRequests.isEmpty()) {
-            cancellationRequests.remove(new RequestId(Messages.getId(request)));
         }
     }
 

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpMessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpMessageHandler.java
@@ -89,6 +89,8 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
 
     private final McpRequestValidator mcpRequestValidator;
 
+    private final CancellationRequests cancellationRequests;
+
     protected McpMessageHandler(McpServersRuntimeConfig config, ConnectionManager connectionManager,
             PromptManagerImpl promptManager,
             ToolManagerImpl toolManager, ResourceManagerImpl resourceManager,
@@ -101,7 +103,8 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
             List<InitialCheck> initialChecks,
             List<InitialResponseInfo> initialResponseInfos,
             McpMetrics mcpMetrics,
-            McpRequestValidator mcpRequestValidator) {
+            McpRequestValidator mcpRequestValidator,
+            CancellationRequests cancellationRequests) {
         this.connectionManager = connectionManager;
         this.promptManager = promptManager;
         this.toolManager = toolManager;
@@ -124,6 +127,7 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
         this.vertx = vertx;
         this.mcpMetrics = mcpMetrics;
         this.mcpRequestValidator = mcpRequestValidator;
+        this.cancellationRequests = cancellationRequests;
         this.ongoingRequests = ConcurrentHashMap.newKeySet();
 
         if (config.invalidServerNameStrategy() == InvalidServerNameStrategy.FAIL) {
@@ -239,24 +243,23 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
 
         if (McpMethod.INITIALIZE != method) {
             // Normally the first message must be "initialize"
-
-            // However, we could create a synthetic initial request and perform a dummy initialization
-            InitialRequest dummy = null;
+            // However, automatic initialization can be performed in the dev mode
+            // and the transport can support other ways to supply auto initial requests
+            InitialRequest autoInit = null;
             if (LaunchMode.current() == LaunchMode.DEVELOPMENT
                     && serverConfig(mcpRequest).devMode().dummyInit()) {
-                // In the dev mode, if an MCP client attempts to reconnect an SSE connection but does not reinitialize properly
-                dummy = new InitialRequest(new Implementation("dummy", "1", null),
+                // In the dev mode, perform an automatic initialization
+                autoInit = new InitialRequest(new Implementation("dummy", "1", null),
                         SUPPORTED_PROTOCOL_VERSIONS.get(0),
-                        List.of(), transport());
+                        List.of(), transport(), true);
             } else {
-                // A transport can support other ways to supply dummy initial requests
-                dummy = dummyInitialRequest(mcpRequest);
+                autoInit = autoInitialRequest(mcpRequest);
             }
 
-            if (dummy != null
-                    && mcpRequest.connection().initialize(dummy)
+            if (autoInit != null
+                    && mcpRequest.connection().initialize(autoInit)
                     && mcpRequest.connection().setInitialized()) {
-                LOG.debugf("Connection initialized with dummy initial request: %s [%s]", dummy.implementation().name(),
+                LOG.debugf("Connection initialized with auto initial request: %s [%s]", autoInit.implementation().name(),
                         mcpRequest.connection().id());
                 return operation(method, message, mcpRequest);
             }
@@ -297,7 +300,7 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
         });
     }
 
-    protected InitialRequest dummyInitialRequest(MCP_REQUEST mcpRequest) {
+    protected InitialRequest autoInitialRequest(MCP_REQUEST mcpRequest) {
         return null;
     }
 
@@ -363,7 +366,7 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
     }
 
     private Future<Void> callNotification(NotificationManager.NotificationInfo notification,
-            FeatureExecutionContext featureExecutionContext, McpRequest mcpRequest) {
+            FeatureExecutionContext featureExecutionContext, MCP_REQUEST mcpRequest) {
         // Create a new duplicated context and process the notification on this context
         Context context = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
         VertxContextSafetyToggle.setContextSafe(context, true);
@@ -433,7 +436,7 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
                 mcpRequest.contextEnd();
                 if (ongoingId != null) {
                     ongoingRequests.remove(ongoingId);
-                    mcpRequest.connection().removeCancellationRequest(message);
+                    cancellationRequests.remove(mcpRequest.connection(), message);
                 }
                 if (r.failed()) {
                     ret.fail(r.cause());
@@ -450,7 +453,7 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
                 "Unsupported method: " + message.getString("method"));
     }
 
-    private Future<Void> rootsListChanged(JsonObject message, McpRequest mcpRequest) {
+    private Future<Void> rootsListChanged(JsonObject message, MCP_REQUEST mcpRequest) {
         List<NotificationManager.NotificationInfo> infos = notificationManager
                 .infosForRequest(FilterContextImpl.of(McpMethod.NOTIFICATIONS_ROOTS_LIST_CHANGED, message, mcpRequest))
                 .filter(n -> n.type() == Type.ROOTS_LIST_CHANGED).toList();
@@ -464,14 +467,15 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
 
     }
 
-    private Future<Void> cancelRequest(JsonObject message, McpRequest mcpRequest) {
+    private Future<Void> cancelRequest(JsonObject message, MCP_REQUEST mcpRequest) {
         JsonObject params = Messages.getParams(message);
         if (params != null) {
             Object requestId = params.getValue("requestId");
             // Unknown, completed and invalid requests should be just ignored
             if (requestId != null
                     && ongoingRequests.contains(ongoingId(requestId, mcpRequest))
-                    && mcpRequest.connection().addCancellationRequest(new RequestId(requestId), params.getString("reason"))) {
+                    && cancellationRequests.add(mcpRequest.connection(), new RequestId(requestId),
+                            params.getString("reason"))) {
                 String reason = params.getString("reason");
                 LOG.debugf("Cancel request with id %s: %s [%s]", requestId, reason != null ? reason : "no reason",
                         mcpRequest.connection().id());
@@ -483,11 +487,11 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
         return Future.succeededFuture();
     }
 
-    private String ongoingId(JsonObject message, McpRequest mcpRequest) {
+    private String ongoingId(JsonObject message, MCP_REQUEST mcpRequest) {
         return ongoingId(Messages.isRequest(message) ? Messages.getId(message) : null, mcpRequest);
     }
 
-    private String ongoingId(Object requestId, McpRequest mcpRequest) {
+    private String ongoingId(Object requestId, MCP_REQUEST mcpRequest) {
         if (requestId != null) {
             return requestId + "::" + mcpRequest.connection().id();
         } else {
@@ -495,7 +499,7 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
         }
     }
 
-    private Future<Void> setLogLevel(JsonObject message, McpRequest mcpRequest) {
+    private Future<Void> setLogLevel(JsonObject message, MCP_REQUEST mcpRequest) {
         Object id = Messages.getId(message);
         JsonObject params = Messages.getParams(message);
         String level = params.getString("level");
@@ -514,7 +518,7 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
 
     }
 
-    private Future<Void> complete(JsonObject message, McpRequest mcpRequest) {
+    private Future<Void> complete(JsonObject message, MCP_REQUEST mcpRequest) {
         Object id = Messages.getId(message);
         JsonObject params = Messages.getParams(message);
         JsonObject ref = params.getJsonObject("ref");
@@ -543,13 +547,13 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
         }
     }
 
-    private Future<Void> ping(JsonObject message, McpRequest mcpRequest) {
+    private Future<Void> ping(JsonObject message, MCP_REQUEST mcpRequest) {
         Object id = Messages.getId(message);
         LOG.debugf("Ping [id: %s]", id);
         return mcpRequest.sender().sendResult(id, new JsonObject());
     }
 
-    private Future<Void> progress(JsonObject message, McpRequest mcpRequest) {
+    private Future<Void> progress(JsonObject message, MCP_REQUEST mcpRequest) {
         JsonObject params = Messages.getParams(message);
         String token = "n/a";
         if (params != null) {
@@ -559,7 +563,7 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
         return Future.succeededFuture();
     }
 
-    private Future<Void> close(JsonObject message, McpRequest mcpRequest) {
+    private Future<Void> close(JsonObject message, MCP_REQUEST mcpRequest) {
         if (connectionManager.remove(mcpRequest.connection().id())) {
             LOG.debugf("Connection %s explicitly closed ", mcpRequest.connection().id());
             return Future.succeededFuture();

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/NotificationManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/NotificationManagerImpl.java
@@ -40,8 +40,10 @@ public class NotificationManagerImpl extends FeatureManagerBase<Void, Notificati
             ConnectionManager connectionManager,
             Instance<CurrentIdentityAssociation> currentIdentityAssociation,
             ResponseHandlers responseHandlers,
+            CancellationRequests cancellationRequests,
             McpServersRuntimeConfig config) {
-        super(vertx, mapper, connectionManager, currentIdentityAssociation, responseHandlers, config, metadata);
+        super(vertx, mapper, connectionManager, currentIdentityAssociation, responseHandlers, cancellationRequests, config,
+                metadata);
         this.notifications = new ConcurrentHashMap<>();
         for (FeatureMetadata<Void> notification : metadata.notifications()) {
             NotificationMethod notificationMethod = new NotificationMethod(notification);
@@ -74,7 +76,7 @@ public class NotificationManagerImpl extends FeatureManagerBase<Void, Notificati
             sender = mcpRequest.connection();
         }
         return new ArgumentProviders(message, Map.of(), mcpRequest.connection(), null, null,
-                sender, null, responseHandlers, mcpRequest.serverName());
+                sender, null, responseHandlers, mcpRequest.serverName(), cancellationRequests);
     }
 
     @Override

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/PromptCompleteMessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/PromptCompleteMessageHandler.java
@@ -13,7 +13,7 @@ class PromptCompleteMessageHandler extends CompletionMessageHandler {
     private final PromptCompletionManagerImpl manager;
 
     PromptCompleteMessageHandler(PromptCompletionManagerImpl manager) {
-        super(manager.responseHandlers);
+        super(manager);
         this.manager = Objects.requireNonNull(manager);
     }
 

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/PromptCompletionManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/PromptCompletionManagerImpl.java
@@ -26,8 +26,10 @@ public class PromptCompletionManagerImpl extends CompletionManagerBase implement
             PromptManagerImpl promptManager,
             Instance<CurrentIdentityAssociation> currentIdentityAssociation,
             ResponseHandlers responseHandlers,
+            CancellationRequests cancellationRequests,
             McpServersRuntimeConfig config) {
-        super(vertx, mapper, connectionManager, currentIdentityAssociation, responseHandlers, config, metadata);
+        super(vertx, mapper, connectionManager, currentIdentityAssociation, responseHandlers, cancellationRequests, config,
+                metadata);
         this.promptManager = promptManager;
         for (FeatureMetadata<CompletionResponse> c : metadata.promptCompletions()) {
             String key = c.info().name() + "_"

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/PromptManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/PromptManagerImpl.java
@@ -60,10 +60,12 @@ public class PromptManagerImpl extends FeatureManagerBase<PromptResponse, Prompt
             ConnectionManager connectionManager,
             Instance<CurrentIdentityAssociation> currentIdentityAssociation,
             ResponseHandlers responseHandlers,
+            CancellationRequests cancellationRequests,
             @All List<PromptFilter> filters,
             @Any Instance<IconsProvider> iconsProviders,
             McpServersRuntimeConfig config) {
-        super(vertx, mapper, connectionManager, currentIdentityAssociation, responseHandlers, config, metadata);
+        super(vertx, mapper, connectionManager, currentIdentityAssociation, responseHandlers, cancellationRequests, config,
+                metadata);
         this.prompts = new ConcurrentHashMap<>();
         for (FeatureMetadata<PromptResponse> f : metadata.prompts()) {
             this.prompts.put(f.info().name(), new PromptMethod(f, iconsProviders));

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceManagerImpl.java
@@ -72,10 +72,12 @@ public class ResourceManagerImpl extends FeatureManagerBase<ResourceResponse, Re
             ConnectionManager connectionManager,
             Instance<CurrentIdentityAssociation> currentIdentityAssociation,
             ResponseHandlers responseHandlers,
+            CancellationRequests cancellationRequests,
             @All List<ResourceFilter> filters,
             @Any Instance<IconsProvider> iconsProviders,
             McpServersRuntimeConfig config) {
-        super(vertx, mapper, connectionManager, currentIdentityAssociation, responseHandlers, config, metadata);
+        super(vertx, mapper, connectionManager, currentIdentityAssociation, responseHandlers, cancellationRequests, config,
+                metadata);
         this.resourceTemplateManager = resourceTemplateManager;
         this.uriToResource = new ConcurrentHashMap<>();
         this.resourceNames = Collections.synchronizedSet(new HashSet<>());

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceMessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceMessageHandler.java
@@ -96,7 +96,8 @@ class ResourceMessageHandler extends MessageHandler {
         }
         LOG.debugf("Read resource %s [id: %s]", resourceUri, id);
         ArgumentProviders argProviders = new ArgumentProviders(message, Map.of(), mcpRequest.connection(), id, resourceUri,
-                mcpRequest.sender(), Messages.getProgressToken(message), manager.responseHandlers, mcpRequest.serverName());
+                mcpRequest.sender(), Messages.getProgressToken(message), manager.responseHandlers, mcpRequest.serverName(),
+                manager.cancellationRequests);
         try {
             Future<ResourceResponse> fu = manager.execute(resourceUri,
                     new FeatureExecutionContext(message, mcpRequest, argProviders));

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceTemplateCompleteMessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceTemplateCompleteMessageHandler.java
@@ -13,7 +13,7 @@ class ResourceTemplateCompleteMessageHandler extends CompletionMessageHandler {
     private final ResourceTemplateCompletionManagerImpl manager;
 
     ResourceTemplateCompleteMessageHandler(ResourceTemplateCompletionManagerImpl manager) {
-        super(manager.responseHandlers);
+        super(manager);
         this.manager = Objects.requireNonNull(manager);
     }
 

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceTemplateCompletionManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceTemplateCompletionManagerImpl.java
@@ -31,8 +31,10 @@ public class ResourceTemplateCompletionManagerImpl extends CompletionManagerBase
             ResourceTemplateManagerImpl resourceTemplateManager,
             Instance<CurrentIdentityAssociation> currentIdentityAssociation,
             ResponseHandlers responseHandlers,
+            CancellationRequests cancellationRequests,
             McpServersRuntimeConfig config) {
-        super(vertx, mapper, connectionManager, currentIdentityAssociation, responseHandlers, config, metadata);
+        super(vertx, mapper, connectionManager, currentIdentityAssociation, responseHandlers, cancellationRequests, config,
+                metadata);
         this.nameToUriTemplate = metadata.resourceTemplates()
                 .stream().map(FeatureMetadata::info).collect(Collectors.toMap(FeatureMethodInfo::name, FeatureMethodInfo::uri));
         for (FeatureMetadata<CompletionResponse> c : metadata.resourceTemplateCompletions()) {

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceTemplateManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceTemplateManagerImpl.java
@@ -67,10 +67,12 @@ public class ResourceTemplateManagerImpl extends FeatureManagerBase<ResourceResp
             ConnectionManager connectionManager,
             Instance<CurrentIdentityAssociation> currentIdentityAssociation,
             ResponseHandlers responseHandlers,
+            CancellationRequests cancellationRequests,
             @All List<ResourceTemplateFilter> filters,
             @Any Instance<IconsProvider> iconsProviders,
             McpServersRuntimeConfig config) {
-        super(vertx, mapper, connectionManager, currentIdentityAssociation, responseHandlers, config, metadata);
+        super(vertx, mapper, connectionManager, currentIdentityAssociation, responseHandlers, cancellationRequests, config,
+                metadata);
         this.templates = new ConcurrentHashMap<>();
         for (FeatureMetadata<ResourceResponse> fm : metadata.resourceTemplates()) {
             this.templates.put(fm.info().name(), new ResourceTemplateMetadata(createMatcherFromUriTemplate(fm.info().uri()),
@@ -194,7 +196,8 @@ public class ResourceTemplateManagerImpl extends FeatureManagerBase<ResourceResp
                 .collect(Collectors.toMap(Entry::getKey, e -> e.getValue().toString()));
         argProviders = new ArgumentProviders(argProviders.rawMessage(),
                 matchedVariables, argProviders.connection(), argProviders.requestId(), argProviders.uri(),
-                argProviders.sender(), argProviders.progressToken(), responseHandlers, argProviders.serverName());
+                argProviders.sender(), argProviders.progressToken(), responseHandlers, argProviders.serverName(),
+                cancellationRequests);
         return super.prepareArguments(metadata, argProviders);
     }
 

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ToolManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ToolManagerImpl.java
@@ -94,6 +94,7 @@ public class ToolManagerImpl extends FeatureManagerBase<ToolResponse, ToolInfo> 
             ConnectionManager connectionManager,
             Instance<CurrentIdentityAssociation> currentIdentityAssociation,
             ResponseHandlers responseHandlers,
+            CancellationRequests cancellationRequests,
             @All List<ToolFilter> filters,
             @Any Instance<ToolInputGuardrail> inputGuardrails,
             @Any Instance<ToolOutputGuardrail> outputGuardrails,
@@ -104,7 +105,8 @@ public class ToolManagerImpl extends FeatureManagerBase<ToolResponse, ToolInfo> 
             Instance<OutputSchemaGenerator> outputSchemaGenerator,
             McpServersBuildTimeConfig buildTimeConfig,
             McpServersRuntimeConfig config) {
-        super(vertx, mapper, connectionManager, currentIdentityAssociation, responseHandlers, config, metadata);
+        super(vertx, mapper, connectionManager, currentIdentityAssociation, responseHandlers, cancellationRequests, config,
+                metadata);
         this.tools = new ConcurrentHashMap<>();
         this.inputGuardrails = inputGuardrails;
         this.outputGuardrails = outputGuardrails;

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/config/McpServerRuntimeConfig.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/config/McpServerRuntimeConfig.java
@@ -199,8 +199,12 @@ public interface McpServerRuntimeConfig {
     public interface DevMode {
 
         /**
-         * If set to `true` then if an MCP client attempts to reconnect an SSE connection but does not reinitialize properly,
-         * the server will perform a "dummy" initialization; capability negotiation and protocol version agreement is skipped.
+         * If set to `true` then the server performs an automatic initialization in dev mode when the first message from the
+         * client is not `initialize`; capability negotiation and protocol version agreement is skipped.
+         *
+         * The behavior depends on the transport. For SSE, this is useful when an MCP client attempts to reconnect but does not
+         * reinitialize properly. For Streamable HTTP, this enables the auto-init mode, i.e. the same behavior as
+         * `quarkus.mcp.server.http.streamable.auto-init`.
          *
          * @asciidoclet
          */

--- a/docs/modules/ROOT/pages/includes/quarkus-mcp-server-core.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-mcp-server-core.adoc
@@ -1155,8 +1155,12 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-If set to `true` then if an MCP client attempts to reconnect an SSE connection but does not reinitialize properly,
-the server will perform a "dummy" initialization; capability negotiation and protocol version agreement is skipped.
+If set to `true` then the server performs an automatic initialization in dev mode when the first message from the
+client is not `initialize`; capability negotiation and protocol version agreement is skipped.
+
+The behavior depends on the transport. For SSE, this is useful when an MCP client attempts to reconnect but does not
+reinitialize properly. For Streamable HTTP, this enables the auto-init mode, i.e. the same behavior as
+`quarkus.mcp.server.http.streamable.auto-init`.
 
 
 ifdef::add-copy-button-to-env-var[]

--- a/docs/modules/ROOT/pages/includes/quarkus-mcp-server-core_quarkus.mcp.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-mcp-server-core_quarkus.mcp.adoc
@@ -1155,8 +1155,12 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-If set to `true` then if an MCP client attempts to reconnect an SSE connection but does not reinitialize properly,
-the server will perform a "dummy" initialization; capability negotiation and protocol version agreement is skipped.
+If set to `true` then the server performs an automatic initialization in dev mode when the first message from the
+client is not `initialize`; capability negotiation and protocol version agreement is skipped.
+
+The behavior depends on the transport. For SSE, this is useful when an MCP client attempts to reconnect but does not
+reinitialize properly. For Streamable HTTP, this enables the auto-init mode, i.e. the same behavior as
+`quarkus.mcp.server.http.streamable.auto-init`.
 
 
 ifdef::add-copy-button-to-env-var[]

--- a/docs/modules/ROOT/pages/includes/quarkus-mcp-server-http.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-mcp-server-http.adoc
@@ -114,34 +114,34 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-mcp-server-http_quarkus-mcp-server-http-streamable-dummy-init]] [.property-path]##link:#quarkus-mcp-server-http_quarkus-mcp-server-http-streamable-dummy-init[`+++quarkus.mcp.server.http.streamable.dummy-init+++`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-mcp-server-http_quarkus-mcp-server-http-streamable-auto-init]] [.property-path]##link:#quarkus-mcp-server-http_quarkus-mcp-server-http-streamable-auto-init[`+++quarkus.mcp.server.http.streamable.auto-init+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.mcp.server.http.streamable.dummy-init+++[]
+config_property_copy_button:+++quarkus.mcp.server.http.streamable.auto-init+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`+++quarkus.mcp.server."server-name".http.streamable.dummy-init+++`
+`+++quarkus.mcp.server."server-name".http.streamable.auto-init+++`
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.mcp.server."server-name".http.streamable.dummy-init+++[]
+config_property_copy_button:+++quarkus.mcp.server."server-name".http.streamable.auto-init+++[]
 endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-If set to `true` then the server performs a dummy initialization when the first message from the client is not
-`initialize`. A new MCP session is created for each request. The capability negotiation and protocol version
-agreement is completely skipped, so the dummy client supports no capabilities.
+If set to `true` then the server performs an automatic initialization when the first message from the client is
+not `initialize`. A new MCP session is created for each request. The capability negotiation and protocol version
+agreement is completely skipped, so the auto-initialized client supports no capabilities.
 
-Dummy initialization can be used to simulate stateless communication. However, it's not efficient and some
+Auto-initialization can be used to simulate stateless communication. However, it's not efficient and some
 features may not work properly.
 
 This config property will be deprecated once the stateless mode is codified in the MCP specification.
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_HTTP_STREAMABLE_DUMMY_INIT+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_HTTP_STREAMABLE_AUTO_INIT+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_MCP_SERVER_HTTP_STREAMABLE_DUMMY_INIT+++`
+Environment variable: `+++QUARKUS_MCP_SERVER_HTTP_STREAMABLE_AUTO_INIT+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean

--- a/docs/modules/ROOT/pages/includes/quarkus-mcp-server-http_quarkus.mcp.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-mcp-server-http_quarkus.mcp.adoc
@@ -114,34 +114,34 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-mcp-server-http_quarkus-mcp-server-http-streamable-dummy-init]] [.property-path]##link:#quarkus-mcp-server-http_quarkus-mcp-server-http-streamable-dummy-init[`+++quarkus.mcp.server.http.streamable.dummy-init+++`]##
+a|icon:lock[title=Fixed at build time] [[quarkus-mcp-server-http_quarkus-mcp-server-http-streamable-auto-init]] [.property-path]##link:#quarkus-mcp-server-http_quarkus-mcp-server-http-streamable-auto-init[`+++quarkus.mcp.server.http.streamable.auto-init+++`]##
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.mcp.server.http.streamable.dummy-init+++[]
+config_property_copy_button:+++quarkus.mcp.server.http.streamable.auto-init+++[]
 endif::add-copy-button-to-config-props[]
 
 
-`+++quarkus.mcp.server."server-name".http.streamable.dummy-init+++`
+`+++quarkus.mcp.server."server-name".http.streamable.auto-init+++`
 ifdef::add-copy-button-to-config-props[]
-config_property_copy_button:+++quarkus.mcp.server."server-name".http.streamable.dummy-init+++[]
+config_property_copy_button:+++quarkus.mcp.server."server-name".http.streamable.auto-init+++[]
 endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-If set to `true` then the server performs a dummy initialization when the first message from the client is not
-`initialize`. A new MCP session is created for each request. The capability negotiation and protocol version
-agreement is completely skipped, so the dummy client supports no capabilities.
+If set to `true` then the server performs an automatic initialization when the first message from the client is
+not `initialize`. A new MCP session is created for each request. The capability negotiation and protocol version
+agreement is completely skipped, so the auto-initialized client supports no capabilities.
 
-Dummy initialization can be used to simulate stateless communication. However, it's not efficient and some
+Auto-initialization can be used to simulate stateless communication. However, it's not efficient and some
 features may not work properly.
 
 This config property will be deprecated once the stateless mode is codified in the MCP specification.
 
 
 ifdef::add-copy-button-to-env-var[]
-Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_HTTP_STREAMABLE_DUMMY_INIT+++[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_HTTP_STREAMABLE_AUTO_INIT+++[]
 endif::add-copy-button-to-env-var[]
 ifndef::add-copy-button-to-env-var[]
-Environment variable: `+++QUARKUS_MCP_SERVER_HTTP_STREAMABLE_DUMMY_INIT+++`
+Environment variable: `+++QUARKUS_MCP_SERVER_HTTP_STREAMABLE_AUTO_INIT+++`
 endif::add-copy-button-to-env-var[]
 --
 |boolean

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/dnsrebinding/DnsRebindingDisabledTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/dnsrebinding/DnsRebindingDisabledTest.java
@@ -25,7 +25,7 @@ public class DnsRebindingDisabledTest extends McpServerTest {
             .withApplicationRoot(
                     root -> root.addClasses(MyTools.class))
             .overrideConfigKey("quarkus.mcp.server.http.dns-rebinding-check.enabled", "false")
-            .overrideConfigKey("quarkus.mcp.server.http.streamable.dummy-init", "true");
+            .overrideConfigKey("quarkus.mcp.server.http.streamable.auto-init", "true");
 
     @Test
     public void testNonLocalhostRequestNotRejected() {

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/dummyinit/AutoInitConfigFallbackTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/dummyinit/AutoInitConfigFallbackTest.java
@@ -1,0 +1,84 @@
+package io.quarkiverse.mcp.server.test.dummyinit;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import java.net.URI;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.McpConnection;
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.http.runtime.StreamableHttpMcpMessageHandler;
+import io.quarkiverse.mcp.server.runtime.ConnectionManager;
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkiverse.mcp.server.test.McpAssured.McpStreamableTestClient;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.vertx.core.http.HttpHeaders;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Verify that the old config key {@code quarkus.mcp.server.http.streamable.dummy-init}
+ * still works as a fallback for the new {@code auto-init} key.
+ */
+public class AutoInitConfigFallbackTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .withApplicationRoot(
+                    root -> root.addClasses(MyTools.class))
+            // Use the old config key
+            .overrideConfigKey("quarkus.mcp.server.http.streamable.dummy-init", "true");
+
+    @Inject
+    ConnectionManager connectionManager;
+
+    @Test
+    public void testOldConfigKeyStillWorks() {
+        int id = 0;
+        McpStreamableTestClient client = McpAssured.newConnectedStreamableClient();
+        URI endpoint = client.mcpEndpoint();
+        client.terminateSession();
+        client.disconnect();
+
+        // Send a tool call without a valid session - auto-init should kick in via the old config key
+        JsonObject response = new JsonObject(RestAssured.given()
+                .when()
+                .headers(StreamableHttpMcpMessageHandler.MCP_SESSION_ID_HEADER, "nonExistentSession",
+                        HttpHeaders.ACCEPT + "", "application/json, text/event-stream")
+                .body(toolsCall("echo", id++).encode())
+                .post(endpoint)
+                .then()
+                .statusCode(200)
+                .extract().body().asString());
+        String connectionId = response.getJsonObject("result").getJsonArray("content").getJsonObject(0).getString("text");
+        // The auto-initialized connection should have been removed
+        assertFalse(connectionManager.has(connectionId));
+        assertFalse(response.getJsonObject("result").getBoolean("isError"));
+    }
+
+    private JsonObject toolsCall(String name, int id) {
+        return new JsonObject()
+                .put("jsonrpc", "2.0")
+                .put("method", McpAssured.TOOLS_CALL)
+                .put("id", id)
+                .put("params", new JsonObject().put("name", name));
+    }
+
+    public static class MyTools {
+
+        @Tool
+        String echo(McpConnection connection) {
+            if (!connection.initialRequest().implementation().name()
+                    .equals(StreamableHttpMcpMessageHandler.AUTO_INIT_IMPL_NAME)) {
+                throw new IllegalStateException("Expected auto-init implementation name");
+            }
+            return connection.id();
+        }
+    }
+
+}

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/dummyinit/AutoInitTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/dummyinit/AutoInitTest.java
@@ -27,13 +27,13 @@ import io.restassured.RestAssured;
 import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.json.JsonObject;
 
-public class DummyInitTest extends McpServerTest {
+public class AutoInitTest extends McpServerTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = defaultConfig()
             .withApplicationRoot(
                     root -> root.addClasses(MyTools.class))
-            .overrideConfigKey("quarkus.mcp.server.http.streamable.dummy-init", "true");
+            .overrideConfigKey("quarkus.mcp.server.http.streamable.auto-init", "true");
 
     @Inject
     ConnectionManager connectionManager;
@@ -75,7 +75,7 @@ public class DummyInitTest extends McpServerTest {
         try {
             Awaitility.await().until(() -> !connectionManager.iterator().hasNext());
         } catch (ConditionTimeoutException e) {
-            fail("Some connections still exits: "
+            fail("Some connections still exists: "
                     + StreamSupport.stream(connectionManager.spliterator(), false)
                             .map(c -> c.id() + "[" + c.initialRequest().implementation().name() + "]").toList());
         }
@@ -94,7 +94,7 @@ public class DummyInitTest extends McpServerTest {
         @Tool
         String bravo(McpConnection connection) {
             if (!connection.initialRequest().implementation().name()
-                    .equals(StreamableHttpMcpMessageHandler.DUMMY_INIT_IMPL_NAME)) {
+                    .equals(StreamableHttpMcpMessageHandler.AUTO_INIT_IMPL_NAME)) {
                 throw new IllegalStateException();
             }
             return connection.id();

--- a/transports/http/deployment/src/test/resources/application.properties
+++ b/transports/http/deployment/src/test/resources/application.properties
@@ -1,0 +1,1 @@
+#quarkus.log.category."io.quarkiverse.mcp.server".level=DEBUG

--- a/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/SseMcpMessageHandler.java
+++ b/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/SseMcpMessageHandler.java
@@ -12,6 +12,7 @@ import io.quarkiverse.mcp.server.InitialRequest.Transport;
 import io.quarkiverse.mcp.server.InitialResponseInfo;
 import io.quarkiverse.mcp.server.JsonRpcErrorCodes;
 import io.quarkiverse.mcp.server.http.runtime.SseMcpMessageHandler.SseMcpRequest;
+import io.quarkiverse.mcp.server.runtime.CancellationRequests;
 import io.quarkiverse.mcp.server.runtime.ConnectionManager;
 import io.quarkiverse.mcp.server.runtime.ContextSupport;
 import io.quarkiverse.mcp.server.runtime.McpConnectionBase;
@@ -62,7 +63,8 @@ public class SseMcpMessageHandler extends McpMessageHandler<SseMcpRequest> imple
             ResourceTemplateManagerImpl resourceTemplateManager,
             ResourceTemplateCompletionManagerImpl resourceTemplateCompleteManager,
             NotificationManagerImpl initManager,
-            ResponseHandlers serverRequests,
+            ResponseHandlers responseHandlers,
+            CancellationRequests cancellationRequests,
             @All List<InitialCheck> initialChecks,
             @All List<InitialResponseInfo> initialResponseInfos,
             CurrentVertxRequest currentVertxRequest,
@@ -72,9 +74,9 @@ public class SseMcpMessageHandler extends McpMessageHandler<SseMcpRequest> imple
             Instance<McpMetrics> metrics,
             Instance<McpRequestValidator> mcpRequestValidator) {
         super(config, connectionManager, promptManager, toolManager, resourceManager, promptCompleteManager,
-                resourceTemplateManager, resourceTemplateCompleteManager, initManager, serverRequests, metadata, vertx,
+                resourceTemplateManager, resourceTemplateCompleteManager, initManager, responseHandlers, metadata, vertx,
                 initialChecks, initialResponseInfos, metrics.isResolvable() ? metrics.get() : null,
-                mcpRequestValidator.isResolvable() ? mcpRequestValidator.get() : null);
+                mcpRequestValidator.isResolvable() ? mcpRequestValidator.get() : null, cancellationRequests);
         this.currentVertxRequest = currentVertxRequest;
         this.currentIdentityAssociation = currentIdentityAssociation.isResolvable() ? currentIdentityAssociation.get() : null;
     }

--- a/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/StreamableHttpMcpMessageHandler.java
+++ b/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/StreamableHttpMcpMessageHandler.java
@@ -36,6 +36,7 @@ import io.quarkiverse.mcp.server.http.runtime.StreamableHttpMcpConnection.Subsid
 import io.quarkiverse.mcp.server.http.runtime.StreamableHttpMcpMessageHandler.HttpMcpRequest;
 import io.quarkiverse.mcp.server.http.runtime.config.McpHttpServerRuntimeConfig;
 import io.quarkiverse.mcp.server.http.runtime.config.McpHttpServersRuntimeConfig;
+import io.quarkiverse.mcp.server.runtime.CancellationRequests;
 import io.quarkiverse.mcp.server.runtime.ConnectionManager;
 import io.quarkiverse.mcp.server.runtime.ContextSupport;
 import io.quarkiverse.mcp.server.runtime.FeatureArgument;
@@ -87,14 +88,18 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
 
     public static final String MCP_SESSION_ID_HEADER = "Mcp-Session-Id";
     public static final String MCP_PROTOCOL_VERSION_HEADER = "Mcp-Protocol-Version";
-    public static final String DUMMY_INIT_IMPL_NAME = "quarkus.mcp.http.streamable.dummy";
+    public static final String AUTO_INIT_IMPL_NAME = "quarkus.mcp.http.streamable.dummy";
 
-    private static final InitialRequest DUMMY_INIT_REQUEST = new InitialRequest(
-            new Implementation(DUMMY_INIT_IMPL_NAME, "1", null),
-            // "2025-03-26"
+    private static final InitialRequest AUTO_INIT_REQUEST = new InitialRequest(
+            new Implementation(AUTO_INIT_IMPL_NAME, "1", null),
+            // MCP spec: "if the server does not receive an MCP-Protocol-Version header,
+            // and has no other way to identify the version - for example,
+            // by relying on the protocol version negotiated during initialization
+            // - the server SHOULD assume protocol version 2025-03-26"
             SUPPORTED_PROTOCOL_VERSIONS.get(2),
             List.of(),
-            Transport.STREAMABLE_HTTP);
+            Transport.STREAMABLE_HTTP,
+            true);
 
     private final McpMetadata metadata;
 
@@ -115,6 +120,7 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
             ResourceTemplateCompletionManagerImpl resourceTemplateCompleteManager,
             NotificationManagerImpl notificationManager,
             ResponseHandlers responseHandlers,
+            CancellationRequests cancellationRequests,
             @All List<InitialCheck> initialChecks,
             @All List<InitialResponseInfo> initialResponseInfos,
             CurrentVertxRequest currentVertxRequest,
@@ -126,7 +132,7 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
         super(config, connectionManager, promptManager, toolManager, resourceManager, promptCompleteManager,
                 resourceTemplateManager, resourceTemplateCompleteManager, notificationManager, responseHandlers, metadata,
                 vertx, initialChecks, initialResponseInfos, metrics.isResolvable() ? metrics.get() : null,
-                mcpRequestValidator.isResolvable() ? mcpRequestValidator.get() : null);
+                mcpRequestValidator.isResolvable() ? mcpRequestValidator.get() : null, cancellationRequests);
         this.metadata = metadata;
         this.currentVertxRequest = currentVertxRequest;
         this.currentIdentityAssociation = currentIdentityAssociation.isResolvable() ? currentIdentityAssociation.get() : null;
@@ -159,8 +165,8 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
         } else {
             McpConnectionBase existing = connectionManager.get(mcpSessionId);
             if (existing == null) {
-                if (httpConfig.servers().get(serverName).http().streamable().dummyInit()) {
-                    // We don't care about non-existent session when dummy init is enabled
+                if (httpConfig.servers().get(serverName).http().streamable().autoInit()) {
+                    // We don't care about non-existent session when auto-init is enabled
                     connection = initConnection(serverName);
                 } else {
                     LOG.errorf("Mcp session not found: %s", mcpSessionId);
@@ -212,39 +218,39 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
         }
         HttpMcpRequest mcpRequest = new HttpMcpRequest(serverName, json, connection, securitySupport, ctx.response(),
                 mcpSessionId == null, contextSupport, currentIdentityAssociation, mcpProtocolVersion);
-        ScanResult result = scan(mcpRequest);
-        if (result.forceSseInit()) {
-            mcpRequest.initiateSse();
-        }
-        handle(mcpRequest).onComplete(ar -> {
-            if (ar.succeeded()) {
-                if (mcpRequest.sse.get()) {
-                    // Just close the SSE stream
-                    ctx.response().end();
-                } else {
-                    if (!ctx.response().ended()) {
-                        if (!result.containsRequest()) {
-                            // If the input consists solely of responses/notifications
-                            // then the server MUST return HTTP status 202
-                            ctx.response().setStatusCode(202).end();
-                        } else {
-                            ctx.end();
+        try {
+            ScanResult result = scan(mcpRequest);
+            if (result.forceSseInit()) {
+                mcpRequest.initiateSse();
+            }
+            handle(mcpRequest).onComplete(ar -> {
+                if (ar.succeeded()) {
+                    if (mcpRequest.sse.get()) {
+                        // Just close the SSE stream
+                        ctx.response().end();
+                    } else {
+                        if (!ctx.response().ended()) {
+                            if (!result.containsRequest()) {
+                                // If the input consists solely of responses/notifications
+                                // then the server MUST return HTTP status 202
+                                ctx.response().setStatusCode(202).end();
+                            } else {
+                                ctx.end();
+                            }
                         }
                     }
+                } else {
+                    if (!ctx.response().ended()) {
+                        ctx.response().setStatusCode(500).end();
+                    }
                 }
-            } else {
-                if (!ctx.response().ended()) {
-                    ctx.response().setStatusCode(500).end();
-                }
-            }
 
-            // Make sure the dummy connection is removed
-            if (connection.initialRequest() != null
-                    && DUMMY_INIT_IMPL_NAME.equals(connection.initialRequest().implementation().name())
-                    && connectionManager.remove(connection.id())) {
-                LOG.debugf("Dummy session removed [%s]", connection.id());
-            }
-        });
+                removeAutoInitConnection(connection);
+            });
+        } catch (Exception e) {
+            removeAutoInitConnection(connection);
+            throw e;
+        }
     }
 
     void openSseStream(RoutingContext ctx, ConnectionManager connectionManager, String serverName) {
@@ -302,21 +308,30 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
         return conn;
     }
 
+    private void removeAutoInitConnection(StreamableHttpMcpConnection connection) {
+        if (connection.initialRequest() != null
+                && connection.initialRequest().autoInitialized()
+                && connectionManager.remove(connection.id())) {
+            LOG.debugf("Auto-initialized session removed [%s]", connection.id());
+        }
+    }
+
     @Override
-    protected InitialRequest dummyInitialRequest(HttpMcpRequest mcpRequest) {
+    protected InitialRequest autoInitialRequest(HttpMcpRequest mcpRequest) {
         McpHttpServerRuntimeConfig config = httpConfig.servers().get(mcpRequest.serverName());
-        if (config != null && config.http().streamable().dummyInit()) {
+        if (config != null && config.http().streamable().autoInit()) {
             // "If the server does not receive an MCP-Protocol-Version header, the server SHOULD assume protocol version 2025-03-26"
             // Note that this is inconsistent with initial handshake where the latest supported version is used
             String version = mcpRequest.mcpProtocolVersion;
             if (version == null) {
-                return DUMMY_INIT_REQUEST;
+                return AUTO_INIT_REQUEST;
             }
             return new InitialRequest(
-                    DUMMY_INIT_REQUEST.implementation(),
+                    AUTO_INIT_REQUEST.implementation(),
                     version,
                     List.of(),
-                    Transport.STREAMABLE_HTTP);
+                    Transport.STREAMABLE_HTTP,
+                    true);
         }
         return null;
     }

--- a/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/config/McpHttpConfigBuilderCustomizer.java
+++ b/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/config/McpHttpConfigBuilderCustomizer.java
@@ -17,6 +17,8 @@ public class McpHttpConfigBuilderCustomizer implements SmallRyeConfigBuilderCust
     static final String HTTP_ROOT_PATH = "http.root-path";
     static final String SSE_MESSAGE_ENDPOINT = "sse.message-endpoint.include-query-params";
     static final String HTTP_MESSAGE_ENDPOINT = "http.message-endpoint.include-query-params";
+    static final String STREAMABLE_DUMMY_INIT = "http.streamable.dummy-init";
+    static final String STREAMABLE_AUTO_INIT = "http.streamable.auto-init";
 
     @Override
     public void configBuilder(SmallRyeConfigBuilder builder) {
@@ -36,6 +38,10 @@ public class McpHttpConfigBuilderCustomizer implements SmallRyeConfigBuilderCust
                     return fallback;
                 } else if (name.endsWith(HTTP_MESSAGE_ENDPOINT)) {
                     String fallback = name.substring(0, name.indexOf(HTTP_MESSAGE_ENDPOINT)) + SSE_MESSAGE_ENDPOINT;
+                    LOG.debugf("Fallback %s to %s", name, fallback);
+                    return fallback;
+                } else if (name.endsWith(STREAMABLE_AUTO_INIT)) {
+                    String fallback = name.substring(0, name.indexOf(STREAMABLE_AUTO_INIT)) + STREAMABLE_DUMMY_INIT;
                     LOG.debugf("Fallback %s to %s", name, fallback);
                     return fallback;
                 }
@@ -62,6 +68,10 @@ public class McpHttpConfigBuilderCustomizer implements SmallRyeConfigBuilderCust
                     return relocate;
                 } else if (name.endsWith(SSE_MESSAGE_ENDPOINT)) {
                     String relocate = name.substring(0, name.indexOf(SSE_MESSAGE_ENDPOINT)) + HTTP_MESSAGE_ENDPOINT;
+                    LOG.debugf("Relocate %s to %s", name, relocate);
+                    return relocate;
+                } else if (name.endsWith(STREAMABLE_DUMMY_INIT)) {
+                    String relocate = name.substring(0, name.indexOf(STREAMABLE_DUMMY_INIT)) + STREAMABLE_AUTO_INIT;
                     LOG.debugf("Relocate %s to %s", name, relocate);
                     return relocate;
                 }

--- a/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/config/McpHttpServerRuntimeConfig.java
+++ b/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/config/McpHttpServerRuntimeConfig.java
@@ -27,11 +27,11 @@ public interface McpHttpServerRuntimeConfig {
         public interface Streamable {
 
             /**
-             * If set to `true` then the server performs a dummy initialization when the first message from the client is not
-             * `initialize`. A new MCP session is created for each request. The capability negotiation and protocol version
-             * agreement is completely skipped, so the dummy client supports no capabilities.
+             * If set to `true` then the server performs an automatic initialization when the first message from the client is
+             * not `initialize`. A new MCP session is created for each request. The capability negotiation and protocol version
+             * agreement is completely skipped, so the auto-initialized client supports no capabilities.
              *
-             * Dummy initialization can be used to simulate stateless communication. However, it's not efficient and some
+             * Auto-initialization can be used to simulate stateless communication. However, it's not efficient and some
              * features may not work properly.
              *
              * This config property will be deprecated once the stateless mode is codified in the MCP specification.
@@ -39,7 +39,7 @@ public interface McpHttpServerRuntimeConfig {
              * @asciidoclet
              */
             @WithDefault("false")
-            boolean dummyInit();
+            boolean autoInit();
 
         }
 

--- a/transports/stdio/runtime/src/main/java/io/quarkiverse/mcp/server/stdio/runtime/StdioMcpMessageHandler.java
+++ b/transports/stdio/runtime/src/main/java/io/quarkiverse/mcp/server/stdio/runtime/StdioMcpMessageHandler.java
@@ -23,6 +23,7 @@ import io.quarkiverse.mcp.server.InitialRequest.Transport;
 import io.quarkiverse.mcp.server.InitialResponseInfo;
 import io.quarkiverse.mcp.server.JsonRpcErrorCodes;
 import io.quarkiverse.mcp.server.McpServer;
+import io.quarkiverse.mcp.server.runtime.CancellationRequests;
 import io.quarkiverse.mcp.server.runtime.ConnectionManager;
 import io.quarkiverse.mcp.server.runtime.ContextSupport;
 import io.quarkiverse.mcp.server.runtime.McpMessageHandler;
@@ -69,6 +70,7 @@ public class StdioMcpMessageHandler extends McpMessageHandler<StdioMcpRequest> {
             ResourceTemplateManagerImpl resourceTemplateManager,
             ResourceTemplateCompletionManagerImpl resourceTemplateCompleteManager, NotificationManagerImpl initManager,
             ResponseHandlers responseHandlers,
+            CancellationRequests cancellationRequests,
             @All List<InitialCheck> initialChecks,
             @All List<InitialResponseInfo> initialResponseInfos,
             McpMetadata metadata,
@@ -78,7 +80,7 @@ public class StdioMcpMessageHandler extends McpMessageHandler<StdioMcpRequest> {
         super(config, connectionManager, promptManager, toolManager, resourceManager, promptCompleteManager,
                 resourceTemplateManager, resourceTemplateCompleteManager, initManager, responseHandlers, metadata, vertx,
                 initialChecks, initialResponseInfos, metrics.isResolvable() ? metrics.get() : null,
-                mcpRequestValidator.isResolvable() ? mcpRequestValidator.get() : null);
+                mcpRequestValidator.isResolvable() ? mcpRequestValidator.get() : null, cancellationRequests);
         this.executor = Executors.newSingleThreadExecutor();
         if (config.servers().size() > 1) {
             throw new IllegalStateException("Multiple server configurations are not supported for the stdio transport");

--- a/transports/websocket/deployment/src/main/java/io/quarkiverse/mcp/server/websocket/deployment/WebSocketMcpServerProcessor.java
+++ b/transports/websocket/deployment/src/main/java/io/quarkiverse/mcp/server/websocket/deployment/WebSocketMcpServerProcessor.java
@@ -15,6 +15,7 @@ import org.jboss.logging.Logger;
 import io.quarkiverse.mcp.server.InitialCheck;
 import io.quarkiverse.mcp.server.InitialResponseInfo;
 import io.quarkiverse.mcp.server.deployment.ServerNameBuildItem;
+import io.quarkiverse.mcp.server.runtime.CancellationRequests;
 import io.quarkiverse.mcp.server.runtime.ConnectionManager;
 import io.quarkiverse.mcp.server.runtime.McpMetadata;
 import io.quarkiverse.mcp.server.runtime.McpMetrics;
@@ -120,6 +121,7 @@ public class WebSocketMcpServerProcessor {
                     ResourceTemplateCompletionManagerImpl.class,
                     NotificationManagerImpl.class,
                     ResponseHandlers.class,
+                    CancellationRequests.class,
                     McpMetadata.class,
                     Vertx.class,
                     List.class,
@@ -140,6 +142,7 @@ public class WebSocketMcpServerProcessor {
                     .addParameterType(Type.classType(ResourceTemplateCompletionManagerImpl.class))
                     .addParameterType(Type.classType(NotificationManagerImpl.class))
                     .addParameterType(Type.classType(ResponseHandlers.class))
+                    .addParameterType(Type.classType(CancellationRequests.class))
                     .addParameterType(Type.classType(McpMetadata.class))
                     .addParameterType(Type.classType(Vertx.class))
                     // List<InitialCheck>
@@ -158,9 +161,9 @@ public class WebSocketMcpServerProcessor {
                             Type.classType(McpRequestValidator.class)))
                     .build());
             // @All List<InitialCheck>
-            constructor.getParameterAnnotations(12).addAnnotation(All.class);
-            // @All List<InitialResponseInfo>
             constructor.getParameterAnnotations(13).addAnnotation(All.class);
+            // @All List<InitialResponseInfo>
+            constructor.getParameterAnnotations(14).addAnnotation(All.class);
             // super(...);
             constructor.invokeSpecialMethod(MethodDescriptor.ofConstructor(WebSocketMcpMessageHandler.class, params),
                     constructor.getThis(),
@@ -180,7 +183,8 @@ public class WebSocketMcpServerProcessor {
                     constructor.getMethodParam(13),
                     constructor.getMethodParam(14),
                     constructor.getMethodParam(15),
-                    constructor.getMethodParam(16));
+                    constructor.getMethodParam(16),
+                    constructor.getMethodParam(17));
             constructor.returnVoid();
 
             // WebSocketMcpMessageHandler.serverName()

--- a/transports/websocket/runtime/src/main/java/io/quarkiverse/mcp/server/websocket/runtime/WebSocketMcpMessageHandler.java
+++ b/transports/websocket/runtime/src/main/java/io/quarkiverse/mcp/server/websocket/runtime/WebSocketMcpMessageHandler.java
@@ -11,6 +11,7 @@ import org.jboss.logging.Logger;
 import io.quarkiverse.mcp.server.InitialCheck;
 import io.quarkiverse.mcp.server.InitialRequest.Transport;
 import io.quarkiverse.mcp.server.InitialResponseInfo;
+import io.quarkiverse.mcp.server.runtime.CancellationRequests;
 import io.quarkiverse.mcp.server.runtime.ConnectionManager;
 import io.quarkiverse.mcp.server.runtime.ContextSupport;
 import io.quarkiverse.mcp.server.runtime.McpMessageHandler;
@@ -60,6 +61,7 @@ public abstract class WebSocketMcpMessageHandler extends McpMessageHandler<WebSo
             ResourceTemplateCompletionManagerImpl resourceTemplateCompleteManager,
             NotificationManagerImpl initManager,
             ResponseHandlers responseHandlers,
+            CancellationRequests cancellationRequests,
             McpMetadata metadata,
             Vertx vertx,
             @All List<InitialCheck> initialChecks,
@@ -70,7 +72,7 @@ public abstract class WebSocketMcpMessageHandler extends McpMessageHandler<WebSo
         super(config, connectionManager, promptManager, toolManager, resourceManager, promptCompleteManager,
                 resourceTemplateManager, resourceTemplateCompleteManager, initManager, responseHandlers, metadata, vertx,
                 initialChecks, initialResponseInfos, metrics.isResolvable() ? metrics.get() : null,
-                mcpRequestValidator.isResolvable() ? mcpRequestValidator.get() : null);
+                mcpRequestValidator.isResolvable() ? mcpRequestValidator.get() : null, cancellationRequests);
         this.currentIdentityAssociation = currentIdentityAssociation.isResolvable() ? currentIdentityAssociation.get() : null;
     }
 


### PR DESCRIPTION
- fix a connection leak on error path
- rename the quarkus.mcp.server.http.streamable.dummy-init config property to quarkus.mcp.server.http.streamable.auto-init
- externalize cancellation requests from the MCP connection to make the connection a bit more lightweight