### PR TITLE
Relax constraints for feature names

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/McpServerProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/McpServerProcessor.java
@@ -14,6 +14,7 @@ import java.lang.constant.ClassDesc;
 import java.lang.reflect.Modifier;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -493,7 +494,7 @@ class McpServerProcessor {
             }
         }
 
-        // Check duplicate names
+        // Check duplicate names - only report errors when features with the same name have overlapping server bindings
         for (List<FeatureMethodBuildItem> featureMethods : found.values()) {
             Map<String, List<FeatureMethodBuildItem>> byName = featureMethods.stream()
                     .collect(Collectors.toMap(this::getDuplicateValidationName, List::of, (v1, v2) -> {
@@ -504,10 +505,7 @@ class McpServerProcessor {
                     }));
             for (Entry<String, List<FeatureMethodBuildItem>> e : byName.entrySet()) {
                 if (e.getValue().size() > 1) {
-                    String message = "Duplicate feature method found for %s:\n\t%s"
-                            .formatted(e.getKey(),
-                                    e.getValue().stream().map(Object::toString).collect(Collectors.joining("\n\t")));
-                    errors.produce(new ValidationErrorBuildItem(new IllegalStateException(message)));
+                    checkOverlappingServers(e.getKey(), e.getValue(), "Duplicate feature method", errors);
                 }
             }
         }
@@ -522,11 +520,9 @@ class McpServerProcessor {
                         list.addAll(v2);
                         return list;
                     }));
-            for (List<FeatureMethodBuildItem> list : byUri.values()) {
-                if (list.size() > 1) {
-                    String message = "Duplicate resource uri found:\n\t%s"
-                            .formatted(list.stream().map(Object::toString).collect(Collectors.joining("\n\t")));
-                    errors.produce(new ValidationErrorBuildItem(new IllegalStateException(message)));
+            for (Map.Entry<String, List<FeatureMethodBuildItem>> e : byUri.entrySet()) {
+                if (e.getValue().size() > 1) {
+                    checkOverlappingServers(e.getKey(), e.getValue(), "Duplicate resource uri", errors);
                 }
             }
         }
@@ -541,11 +537,9 @@ class McpServerProcessor {
                         list.addAll(v2);
                         return list;
                     }));
-            for (List<FeatureMethodBuildItem> list : byUri.values()) {
-                if (list.size() > 1) {
-                    String message = "Duplicate resource template uri found:\n\t%s"
-                            .formatted(list.stream().map(Object::toString).collect(Collectors.joining("\n\t")));
-                    errors.produce(new ValidationErrorBuildItem(new IllegalStateException(message)));
+            for (Map.Entry<String, List<FeatureMethodBuildItem>> e : byUri.entrySet()) {
+                if (e.getValue().size() > 1) {
+                    checkOverlappingServers(e.getKey(), e.getValue(), "Duplicate resource template uri", errors);
                 }
             }
         }
@@ -818,6 +812,21 @@ class McpServerProcessor {
             return featureMethod.getName() + argumentName;
         }
         return featureMethod.getName();
+    }
+
+    private void checkOverlappingServers(String key, List<FeatureMethodBuildItem> features, String errorPrefix,
+            BuildProducer<ValidationErrorBuildItem> errors) {
+        for (int i = 0; i < features.size(); i++) {
+            for (int j = i + 1; j < features.size(); j++) {
+                if (!Collections.disjoint(features.get(i).getServers(), features.get(j).getServers())) {
+                    String message = "%s found for %s:\n\t%s"
+                            .formatted(errorPrefix, key,
+                                    features.stream().map(Object::toString).collect(Collectors.joining("\n\t")));
+                    errors.produce(new ValidationErrorBuildItem(new IllegalStateException(message)));
+                    return;
+                }
+            }
+        }
     }
 
     @Record(RUNTIME_INIT)

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/CompletionManager.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/CompletionManager.java
@@ -13,12 +13,27 @@ public interface CompletionManager extends FeatureManager<CompletionInfo> {
      *
      * @param name
      * @param argumentName
+     * @param serverName
+     * @return the completion for the given name reference, argument name, and server
+     * @see McpServer
+     */
+    CompletionInfo getCompletion(String name, String argumentName, String serverName);
+
+    /**
+     * For backwards compatibility, this method does not default to the {@link McpServer#DEFAULT} server configuration.
+     * Instead, it searches across all servers and throws an exception if the name and argument combination is ambiguous.
+     *
+     * @param name
+     * @param argumentName
      * @return the completion for the given name reference and argument name
+     * @throws IllegalStateException if multiple completions with the given name and argument exist on different servers
+     * @see #getCompletion(String, String, String)
      */
     CompletionInfo getCompletion(String name, String argumentName);
 
     /**
-     * The combination of the name reference and argument name must be unique.
+     * The combination of the name reference and argument name must be unique within a server configuration. A completion with
+     * the same name reference and argument name can exist on different servers.
      *
      * @param nameReference
      * @return a new definition builder
@@ -68,7 +83,8 @@ public interface CompletionManager extends FeatureManager<CompletionInfo> {
 
         /**
          * @return the completion info
-         * @throws IllegalArgumentException if a completion for the given name reference and argument already exists
+         * @throws IllegalArgumentException if a completion for the given name reference and argument already exists for the
+         *         same server configuration
          */
         @Override
         CompletionInfo register();

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/FeatureManager.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/FeatureManager.java
@@ -20,9 +20,10 @@ public interface FeatureManager<INFO extends FeatureInfo> extends Iterable<INFO>
     interface FeatureInfo extends Comparable<FeatureInfo> {
 
         /**
-         * It is guaranteed that the name is unique for a specific feature.
+         * It is guaranteed that the name is unique for a specific feature within a server configuration.
          *
          * @return the name
+         * @see #serverNames()
          */
         String name();
 

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/NotificationManager.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/NotificationManager.java
@@ -13,13 +13,28 @@ public interface NotificationManager extends FeatureManager<NotificationInfo> {
      *
      * @param type
      * @param name
+     * @param serverName
+     * @return the notification callback of the given type with the given name bound to the given server, or {@code null}
+     * @see McpServer
+     */
+    NotificationInfo getNotification(Notification.Type type, String name, String serverName);
+
+    /**
+     * For backwards compatibility, this method does not default to the {@link McpServer#DEFAULT} server configuration.
+     * Instead, it searches across all servers and throws an exception if the type and name combination is ambiguous.
+     *
+     * @param type
+     * @param name
      * @return the notification callback of the given type with the given name, or {@code null}
+     * @throws IllegalStateException if multiple notifications with the given type and name exist on different servers
+     * @see #getNotification(Notification.Type, String, String)
      */
     NotificationInfo getNotification(Notification.Type type, String name);
 
     /**
+     * The name must be unique within a server configuration. A notification with the same name can exist on different servers.
      *
-     * @param name The name must be unique
+     * @param name
      * @return a new definition builder
      * @see NotificationDefinition#register()
      */
@@ -63,7 +78,8 @@ public interface NotificationManager extends FeatureManager<NotificationInfo> {
         /**
          *
          * @return the notification info
-         * @throws IllegalArgumentException if a notification with the given name and type already exists
+         * @throws IllegalArgumentException if a notification with the given name and type already exists for the same server
+         *         configuration
          */
         @Override
         NotificationInfo register();

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/PromptManager.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/PromptManager.java
@@ -13,23 +13,50 @@ public interface PromptManager extends FeatureManager<PromptInfo> {
     /**
      *
      * @param name
+     * @param serverName
+     * @return the prompt with the given name bound to the given server, or {@code null}
+     * @see McpServer
+     */
+    PromptInfo getPrompt(String name, String serverName);
+
+    /**
+     * For backwards compatibility, this method does not default to the {@link McpServer#DEFAULT} server configuration.
+     * Instead, it searches across all servers and throws an exception if the name is ambiguous.
+     *
+     * @param name
      * @return the prompt with the given name, or {@code null}
+     * @throws IllegalStateException if multiple prompts with the given name exist on different servers
+     * @see #getPrompt(String, String)
      */
     PromptInfo getPrompt(String name);
 
     /**
+     * The name must be unique within a server configuration. A prompt with the same name can exist on different servers.
      *
-     * @param name The name must be unique
+     * @param name
      * @return a new definition builder
-     * @throws IllegalArgumentException if a prompt with the given name already exists
      * @see PromptDefinition#register()
      */
     PromptDefinition newPrompt(String name);
 
     /**
-     * Removes a prompt previously added with {@link #newPrompt(String)}.
+     * Removes a prompt previously added with {@link #newPrompt(String)} from the given server configuration only.
      *
+     * @param name
+     * @param serverName
      * @return the removed prompt or {@code null} if no such prompt existed
+     */
+    PromptInfo removePrompt(String name, String serverName);
+
+    /**
+     * Removes all prompts previously added with {@link #newPrompt(String)} with the given name from all server configurations.
+     * <p>
+     * For backwards compatibility, this method does not default to the {@link McpServer#DEFAULT} server configuration.
+     * Instead, it removes matching prompts across all servers.
+     *
+     * @param name
+     * @return one of the removed prompts or {@code null} if no such prompt existed
+     * @see #removePrompt(String, String)
      */
     PromptInfo removePrompt(String name);
 
@@ -103,7 +130,7 @@ public interface PromptManager extends FeatureManager<PromptInfo> {
 
         /**
          * @return the prompt info
-         * @throws IllegalArgumentException if a prompt with the given name already exists
+         * @throws IllegalArgumentException if a prompt with the given name already exists for the same server configuration
          */
         @Override
         PromptInfo register();

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/ResourceManager.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/ResourceManager.java
@@ -14,23 +14,52 @@ public interface ResourceManager extends FeatureManager<ResourceInfo> {
     /**
      *
      * @param uri
+     * @param serverName
+     * @return the resource with the given URI bound to the given server, or {@code null}
+     * @see McpServer
+     */
+    ResourceInfo getResource(String uri, String serverName);
+
+    /**
+     * For backwards compatibility, this method does not default to the {@link McpServer#DEFAULT} server configuration.
+     * Instead, it searches across all servers and throws an exception if the URI is ambiguous.
+     *
+     * @param uri
      * @return the resource with the given URI or {@code null}
+     * @throws IllegalStateException if multiple resources with the given URI exist on different servers
+     * @see #getResource(String, String)
      */
     ResourceInfo getResource(String uri);
 
     /**
+     * The name and URI must be unique within a server configuration. A resource with the same name can exist on different
+     * servers.
      *
-     * @param name The name must be unique
+     * @param name
      * @return a new definition builder
-     * @throws IllegalArgumentException if a resource with the given name already exists
      * @see ResourceDefinition#register()
      */
     ResourceDefinition newResource(String name);
 
     /**
-     * Removes a resource previously added with {@link #newResource(String)}.
+     * Removes a resource previously added with {@link #newResource(String)} from the given server configuration only.
      *
+     * @param uri
+     * @param serverName
      * @return the removed resource or {@code null} if no such resource existed
+     */
+    ResourceInfo removeResource(String uri, String serverName);
+
+    /**
+     * Removes all resources previously added with {@link #newResource(String)} with the given URI from all server
+     * configurations.
+     * <p>
+     * For backwards compatibility, this method does not default to the {@link McpServer#DEFAULT} server configuration.
+     * Instead, it removes matching resources across all servers.
+     *
+     * @param uri
+     * @return one of the removed resources or {@code null} if no such resource existed
+     * @see #removeResource(String, String)
      */
     ResourceInfo removeResource(String uri);
 
@@ -77,7 +106,6 @@ public interface ResourceManager extends FeatureManager<ResourceInfo> {
         /**
          * @param uri
          * @return self
-         * @throws IllegalArgumentException if a resource with the given URI already exists
          * @see Resource#uri()
          */
         ResourceDefinition setUri(String uri);
@@ -110,7 +138,8 @@ public interface ResourceManager extends FeatureManager<ResourceInfo> {
 
         /**
          * @return the resource info
-         * @throws IllegalArgumentException if a resource with the given name or URI already exists
+         * @throws IllegalArgumentException if a resource with the given name or URI already exists for the same server
+         *         configuration
          */
         @Override
         ResourceInfo register();

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/ResourceTemplateManager.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/ResourceTemplateManager.java
@@ -13,23 +13,53 @@ public interface ResourceTemplateManager extends FeatureManager<ResourceTemplate
     /**
      *
      * @param name
+     * @param serverName
+     * @return the resource template with the given name bound to the given server, or {@code null}
+     * @see McpServer
+     */
+    ResourceTemplateInfo getResourceTemplate(String name, String serverName);
+
+    /**
+     * For backwards compatibility, this method does not default to the {@link McpServer#DEFAULT} server configuration.
+     * Instead, it searches across all servers and throws an exception if the name is ambiguous.
+     *
+     * @param name
      * @return the resource template with the given name or {@code null}
+     * @throws IllegalStateException if multiple resource templates with the given name exist on different servers
+     * @see #getResourceTemplate(String, String)
      */
     ResourceTemplateInfo getResourceTemplate(String name);
 
     /**
+     * The name must be unique within a server configuration. A resource template with the same name can exist on different
+     * servers.
      *
-     * @param name The name must be unique
+     * @param name
      * @return a new definition builder
-     * @throws IllegalArgumentException if a resource template with the given name already exists
      * @see ResourceTemplateDefinition#register()
      */
     ResourceTemplateDefinition newResourceTemplate(String name);
 
     /**
-     * Removes a resource template previously added with {@link #newResourceTemplate(String)}.
+     * Removes a resource template previously added with {@link #newResourceTemplate(String)} from the given server
+     * configuration only.
      *
-     * @return the removed resource template or {@code null} if no such resource existed
+     * @param name
+     * @param serverName
+     * @return the removed resource template or {@code null} if no such resource template existed
+     */
+    ResourceTemplateInfo removeResourceTemplate(String name, String serverName);
+
+    /**
+     * Removes all resource templates previously added with {@link #newResourceTemplate(String)} with the given name from all
+     * server configurations.
+     * <p>
+     * For backwards compatibility, this method does not default to the {@link McpServer#DEFAULT} server configuration.
+     * Instead, it removes matching resource templates across all servers.
+     *
+     * @param name
+     * @return one of the removed resource templates or {@code null} if no such resource template existed
+     * @see #removeResourceTemplate(String, String)
      */
     ResourceTemplateInfo removeResourceTemplate(String name);
 
@@ -93,8 +123,9 @@ public interface ResourceTemplateManager extends FeatureManager<ResourceTemplate
         ResourceTemplateDefinition setMetadata(Map<MetaKey, Object> metadata);
 
         /**
-         * @throws IllegalArgumentException if a resource template with the given name already exists
          * @return the resource template info
+         * @throws IllegalArgumentException if a resource template with the given name already exists for the same server
+         *         configuration
          */
         @Override
         ResourceTemplateInfo register();

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/ToolManager.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/ToolManager.java
@@ -14,23 +14,50 @@ public interface ToolManager extends FeatureManager<ToolInfo> {
     /**
      *
      * @param name
+     * @param serverName
+     * @return the tool with the given name bound to the given server, or {@code null}
+     * @see McpServer
+     */
+    ToolInfo getTool(String name, String serverName);
+
+    /**
+     * For backwards compatibility, this method does not default to the {@link McpServer#DEFAULT} server configuration.
+     * Instead, it searches across all servers and throws an exception if the name is ambiguous.
+     *
+     * @param name
      * @return the tool with the given name, or {@code null}
+     * @throws IllegalStateException if multiple tools with the given name exist on different servers
+     * @see #getTool(String, String)
      */
     ToolInfo getTool(String name);
 
     /**
+     * The name must be unique within a server configuration. A tool with the same name can exist on different servers.
      *
-     * @param name The name must be unique
+     * @param name
      * @return a new definition builder
-     * @throws IllegalArgumentException if a tool with the given name already exists
      * @see ToolDefinition#register()
      */
     ToolDefinition newTool(String name);
 
     /**
-     * Removes a tool previously added with {@link #newTool(String)}.
+     * Removes a tool previously added with {@link #newTool(String)} from the given server configuration only.
      *
+     * @param name
+     * @param serverName
      * @return the removed tool or {@code null} if no such tool existed
+     */
+    ToolInfo removeTool(String name, String serverName);
+
+    /**
+     * Removes all tools previously added with {@link #newTool(String)} with the given name from all server configurations.
+     * <p>
+     * For backwards compatibility, this method does not default to the {@link McpServer#DEFAULT} server configuration.
+     * Instead, it removes matching tools across all servers.
+     *
+     * @param name
+     * @return one of the removed tools or {@code null} if no such tool existed
+     * @see #removeTool(String, String)
      */
     ToolInfo removeTool(String name);
 
@@ -136,7 +163,7 @@ public interface ToolManager extends FeatureManager<ToolInfo> {
 
         /**
          * @return the tool info
-         * @throws IllegalArgumentException if a tool with the given name already exists
+         * @throws IllegalArgumentException if a tool with the given name already exists for the same server configuration
          */
         @Override
         ToolInfo register();

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/CompletionManagerBase.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/CompletionManagerBase.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.mcp.server.runtime;
 
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -25,8 +26,7 @@ import io.vertx.core.json.JsonObject;
 public abstract class CompletionManagerBase extends FeatureManagerBase<CompletionResponse, CompletionInfo>
         implements CompletionManager {
 
-    // key = reference name + "_" + argument name
-    protected final ConcurrentMap<String, CompletionInfo> completions;
+    protected final ConcurrentMap<FeatureKey, CompletionInfo> completions;
 
     protected CompletionManagerBase(Vertx vertx,
             ObjectMapper mapper,
@@ -42,8 +42,13 @@ public abstract class CompletionManagerBase extends FeatureManagerBase<Completio
     }
 
     @Override
+    public CompletionInfo getCompletion(String name, String argumentName, String serverName) {
+        return completions.get(new FeatureKey(compositeName(name, argumentName), serverName));
+    }
+
+    @Override
     public CompletionInfo getCompletion(String name, String argumentName) {
-        return completions.get(name + "_" + argumentName);
+        return findUniqueByName(completions, compositeName(name, argumentName), Feature.PROMPT_COMPLETE);
     }
 
     @Override
@@ -58,18 +63,21 @@ public abstract class CompletionManagerBase extends FeatureManagerBase<Completio
 
     @Override
     Stream<CompletionInfo> infos() {
-        return completions.values().stream();
+        return completions.values().stream().distinct();
     }
 
     @SuppressWarnings("unchecked")
     @Override
     protected FeatureInvoker<CompletionResponse> getInvoker(String id, McpRequest mcpRequest, JsonObject message) {
-        CompletionInfo completion = completions.get(id);
-        if (completion instanceof FeatureInvoker fi
-                && matchesServer(completion, mcpRequest)) {
+        CompletionInfo completion = completions.get(new FeatureKey(id, mcpRequest.serverName()));
+        if (completion instanceof FeatureInvoker fi) {
             return fi;
         }
         return null;
+    }
+
+    private static String compositeName(String name, String argumentName) {
+        return name + "_" + argumentName;
     }
 
     protected abstract Feature feature();
@@ -78,8 +86,9 @@ public abstract class CompletionManagerBase extends FeatureManagerBase<Completio
 
     protected abstract String refName(String refName);
 
-    IllegalArgumentException completionAlreadyExists(String refName, String argName) {
-        return new IllegalArgumentException("A completion for [" + refName + "] with agument [" + argName + "] already exits");
+    IllegalArgumentException completionAlreadyExists(String refName, String argName, String serverName) {
+        return new IllegalArgumentException("A completion for [" + refName + "] with argument [" + argName
+                + "] already exists for server configuration [" + serverName + "]");
     }
 
     class CompletionMethod extends FeatureMetadataInvoker<CompletionResponse> implements CompletionManager.CompletionInfo {
@@ -144,10 +153,19 @@ public abstract class CompletionManagerBase extends FeatureManagerBase<Completio
             validateReference(name, argumentName);
             CompletionDefinitionInfo ret = new CompletionDefinitionInfo(refName(name), description, serverNames, fun, asyncFun,
                     runOnVirtualThread, argumentName);
-            String key = ret.name() + "_" + ret.argumentName();
-            CompletionInfo existing = completions.putIfAbsent(key, ret);
-            if (existing != null) {
-                throw completionAlreadyExists(name, argumentName);
+            List<FeatureKey> keys = FeatureKey.list(compositeName(ret.name(), ret.argumentName()), serverNames);
+            registrationLock.lock();
+            try {
+                for (FeatureKey key : keys) {
+                    if (completions.containsKey(key)) {
+                        throw completionAlreadyExists(name, argumentName, key.serverName());
+                    }
+                }
+                for (FeatureKey key : keys) {
+                    completions.put(key, ret);
+                }
+            } finally {
+                registrationLock.unlock();
             }
             return ret;
         }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/FeatureKey.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/FeatureKey.java
@@ -1,0 +1,28 @@
+package io.quarkiverse.mcp.server.runtime;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Composite key for feature storage, consisting of a feature name (or URI for resources) and a server name.
+ * <p>
+ * A feature bound to multiple servers is stored under multiple keys, one per server, all pointing to the same info instance.
+ */
+public record FeatureKey(String name, String serverName) {
+
+    public FeatureKey {
+        Objects.requireNonNull(name);
+        Objects.requireNonNull(serverName);
+    }
+
+    static List<FeatureKey> list(String name, Set<String> serverNames) {
+        List<FeatureKey> keys = new ArrayList<>(serverNames.size());
+        for (String sn : serverNames) {
+            keys.add(new FeatureKey(name, sn));
+        }
+        return keys;
+    }
+
+}

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/FeatureManagerBase.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/FeatureManagerBase.java
@@ -15,6 +15,8 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
@@ -75,6 +77,9 @@ public abstract class FeatureManagerBase<RESULT, INFO extends FeatureManager.Fea
 
     // used to validate server name if InvalidServerNameStrategy.FAIL is set
     protected final Set<String> serverNames;
+
+    // used to ensure atomic registration of features across multiple server keys
+    protected final Lock registrationLock = new ReentrantLock();
 
     final ResponseHandlers responseHandlers;
 
@@ -621,6 +626,28 @@ public abstract class FeatureManagerBase<RESULT, INFO extends FeatureManager.Fea
             return ret;
         }
 
+    }
+
+    /**
+     * Finds a unique info by name across all servers. Throws {@link IllegalStateException} if multiple distinct infos with the
+     * given name exist on different servers.
+     *
+     * @return the info or {@code null}
+     */
+    protected static <INFO extends FeatureInfo> INFO findUniqueByName(ConcurrentMap<FeatureKey, INFO> map, String name,
+            Feature feature) {
+        Objects.requireNonNull(name);
+        List<INFO> matches = map.entrySet().stream()
+                .filter(e -> e.getKey().name().equals(name))
+                .map(Map.Entry::getValue)
+                .distinct()
+                .toList();
+        if (matches.size() > 1) {
+            throw new IllegalStateException(
+                    "Multiple %s definitions with name [%s] found on different servers; use the method variant that accepts a server name"
+                            .formatted(feature, name));
+        }
+        return matches.isEmpty() ? null : matches.get(0);
     }
 
     protected Map<Type, DefaultValueConverter<?>> defaultValueConverters() {

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpMetadata.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpMetadata.java
@@ -41,8 +41,9 @@ public interface McpMetadata {
 
     Map<String, Class<?>> toolArgumentHolders();
 
-    static <T> FeatureMetadata<T> findFeatureByName(List<FeatureMetadata<T>> features, String name) {
-        return features.stream().filter(fm -> fm.info().name().equals(name)).findFirst().orElse(null);
+    static <T> FeatureMetadata<T> findFeature(List<FeatureMetadata<T>> features, String name, String serverName) {
+        return features.stream().filter(fm -> fm.info().name().equals(name) && fm.info().serverNames().contains(serverName))
+                .findFirst().orElse(null);
     }
 
 }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/NotificationManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/NotificationManagerImpl.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.mcp.server.runtime;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
@@ -31,8 +32,7 @@ import io.vertx.core.json.JsonObject;
 @Singleton
 public class NotificationManagerImpl extends FeatureManagerBase<Void, NotificationInfo> implements NotificationManager {
 
-    // key = notification type + "::" + name
-    final ConcurrentMap<String, NotificationInfo> notifications;
+    final ConcurrentMap<FeatureKey, NotificationInfo> notifications;
 
     NotificationManagerImpl(McpMetadata metadata,
             Vertx vertx,
@@ -47,21 +47,23 @@ public class NotificationManagerImpl extends FeatureManagerBase<Void, Notificati
         this.notifications = new ConcurrentHashMap<>();
         for (FeatureMetadata<Void> notification : metadata.notifications()) {
             NotificationMethod notificationMethod = new NotificationMethod(notification);
-            this.notifications.put(key(notificationMethod), notificationMethod);
+            String compositeKey = key(notificationMethod);
+            for (String server : notification.info().serverNames()) {
+                this.notifications.put(new FeatureKey(compositeKey, server), notificationMethod);
+            }
         }
     }
 
     @Override
     Stream<NotificationInfo> infos() {
-        return notifications.values().stream();
+        return notifications.values().stream().distinct();
     }
 
     @SuppressWarnings("unchecked")
     @Override
     protected FeatureInvoker<Void> getInvoker(String id, McpRequest mcpRequest, JsonObject message) {
-        NotificationInfo init = notifications.get(id);
-        if (init instanceof FeatureInvoker fi
-                && matchesServer(init, mcpRequest)) {
+        NotificationInfo init = notifications.get(new FeatureKey(id, mcpRequest.serverName()));
+        if (init instanceof FeatureInvoker fi) {
             return fi;
         }
         return null;
@@ -80,8 +82,13 @@ public class NotificationManagerImpl extends FeatureManagerBase<Void, Notificati
     }
 
     @Override
+    public NotificationInfo getNotification(Type type, String name, String serverName) {
+        return notifications.get(new FeatureKey(key(type, name), serverName));
+    }
+
+    @Override
     public NotificationInfo getNotification(Type type, String name) {
-        return notifications.get(key(type, name));
+        return findUniqueByName(notifications, key(type, name), Feature.NOTIFICATION);
     }
 
     @Override
@@ -94,8 +101,10 @@ public class NotificationManagerImpl extends FeatureManagerBase<Void, Notificati
         return notifications.entrySet().removeIf(e -> filter.test(e.getValue()));
     }
 
-    IllegalArgumentException notificationAlreadyExists(Type type, String name) {
-        return new IllegalArgumentException("A " + type + " notification with name [" + name + "] already exits");
+    IllegalArgumentException notificationAlreadyExists(Type type, String name, String serverName) {
+        return new IllegalArgumentException(
+                "A " + type + " notification with name [" + name + "] already exists for server configuration [" + serverName
+                        + "]");
     }
 
     @Override
@@ -170,11 +179,20 @@ public class NotificationManagerImpl extends FeatureManagerBase<Void, Notificati
             }
             NotificationDefinitionInfo ret = new NotificationDefinitionInfo(name, description, serverNames, fun, asyncFun,
                     runOnVirtualThread, type);
-            String key = key(ret);
-
-            NotificationInfo existing = notifications.putIfAbsent(key, ret);
-            if (existing != null) {
-                throw notificationAlreadyExists(type, name);
+            String compositeKey = key(ret);
+            List<FeatureKey> keys = FeatureKey.list(compositeKey, serverNames);
+            registrationLock.lock();
+            try {
+                for (FeatureKey key : keys) {
+                    if (notifications.containsKey(key)) {
+                        throw notificationAlreadyExists(type, name, key.serverName());
+                    }
+                }
+                for (FeatureKey key : keys) {
+                    notifications.put(key, ret);
+                }
+            } finally {
+                registrationLock.unlock();
             }
             return ret;
         }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/PromptCompletionManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/PromptCompletionManagerImpl.java
@@ -32,9 +32,12 @@ public class PromptCompletionManagerImpl extends CompletionManagerBase implement
                 metadata);
         this.promptManager = promptManager;
         for (FeatureMetadata<CompletionResponse> c : metadata.promptCompletions()) {
-            String key = c.info().name() + "_"
+            String compositeKey = c.info().name() + "_"
                     + c.info().arguments().stream().filter(FeatureArgument::isParam).findFirst().orElseThrow().name();
-            this.completions.put(key, new CompletionMethod(c));
+            CompletionMethod completionMethod = new CompletionMethod(c);
+            for (String server : c.info().serverNames()) {
+                this.completions.put(new FeatureKey(compositeKey, server), completionMethod);
+            }
         }
     }
 

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/PromptManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/PromptManagerImpl.java
@@ -5,7 +5,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -48,7 +47,7 @@ public class PromptManagerImpl extends FeatureManagerBase<PromptResponse, Prompt
 
     private static final Logger LOG = Logger.getLogger(PromptManagerImpl.class);
 
-    final ConcurrentMap<String, PromptInfo> prompts;
+    final ConcurrentMap<FeatureKey, PromptInfo> prompts;
 
     final List<PromptFilter> filters;
 
@@ -68,7 +67,10 @@ public class PromptManagerImpl extends FeatureManagerBase<PromptResponse, Prompt
                 metadata);
         this.prompts = new ConcurrentHashMap<>();
         for (FeatureMetadata<PromptResponse> f : metadata.prompts()) {
-            this.prompts.put(f.info().name(), new PromptMethod(f, iconsProviders));
+            PromptMethod promptMethod = new PromptMethod(f, iconsProviders);
+            for (String server : f.info().serverNames()) {
+                this.prompts.put(new FeatureKey(f.info().name(), server), promptMethod);
+            }
         }
         this.filters = filters;
         this.iconsProviders = iconsProviders;
@@ -76,7 +78,7 @@ public class PromptManagerImpl extends FeatureManagerBase<PromptResponse, Prompt
 
     @Override
     Stream<PromptInfo> infos() {
-        return prompts.values().stream();
+        return prompts.values().stream().distinct();
     }
 
     @Override
@@ -90,22 +92,25 @@ public class PromptManagerImpl extends FeatureManagerBase<PromptResponse, Prompt
     }
 
     @Override
+    public PromptInfo getPrompt(String name, String serverName) {
+        return prompts.get(new FeatureKey(name, serverName));
+    }
+
+    @Override
     public PromptInfo getPrompt(String name) {
-        return prompts.get(Objects.requireNonNull(name));
+        return findUniqueByName(prompts, name, Feature.PROMPT);
     }
 
     @Override
     public PromptDefinition newPrompt(String name) {
-        if (prompts.containsKey(name)) {
-            throw promptWithNameAlreadyExists(name);
-        }
         return new PromptDefinitionImpl(name);
     }
 
     @Override
-    public PromptInfo removePrompt(String name) {
+    public PromptInfo removePrompt(String name, String serverName) {
+        FeatureKey key = new FeatureKey(name, serverName);
         AtomicReference<PromptInfo> removed = new AtomicReference<>();
-        prompts.computeIfPresent(name, (key, value) -> {
+        prompts.computeIfPresent(key, (k, value) -> {
             if (!value.isMethod()) {
                 removed.set(value);
                 notifyConnections(McpMethod.NOTIFICATIONS_PROMPTS_LIST_CHANGED);
@@ -116,8 +121,25 @@ public class PromptManagerImpl extends FeatureManagerBase<PromptResponse, Prompt
         return removed.get();
     }
 
-    IllegalArgumentException promptWithNameAlreadyExists(String name) {
-        return new IllegalArgumentException("A prompt with name [" + name + "] already exits");
+    @Override
+    public PromptInfo removePrompt(String name) {
+        AtomicReference<PromptInfo> removed = new AtomicReference<>();
+        prompts.entrySet().removeIf(e -> {
+            if (e.getKey().name().equals(name) && !e.getValue().isMethod()) {
+                removed.set(e.getValue());
+                return true;
+            }
+            return false;
+        });
+        if (removed.get() != null) {
+            notifyConnections(McpMethod.NOTIFICATIONS_PROMPTS_LIST_CHANGED);
+        }
+        return removed.get();
+    }
+
+    IllegalArgumentException promptWithNameAlreadyExists(String name, String serverName) {
+        return new IllegalArgumentException(
+                "A prompt with name [" + name + "] already exists for server configuration [" + serverName + "]");
     }
 
     @Override
@@ -128,9 +150,8 @@ public class PromptManagerImpl extends FeatureManagerBase<PromptResponse, Prompt
     @SuppressWarnings("unchecked")
     @Override
     protected FeatureInvoker<PromptResponse> getInvoker(String id, McpRequest mcpRequest, JsonObject message) {
-        PromptInfo prompt = prompts.get(id);
+        PromptInfo prompt = prompts.get(new FeatureKey(id, mcpRequest.serverName()));
         if (prompt instanceof FeatureInvoker fi
-                && matchesServer(prompt, mcpRequest)
                 && test(prompt, FilterContextImpl.of(McpMethod.PROMPTS_GET, message, mcpRequest))) {
             return fi;
         }
@@ -251,12 +272,21 @@ public class PromptManagerImpl extends FeatureManagerBase<PromptResponse, Prompt
             validate();
             PromptDefinitionInfo ret = new PromptDefinitionInfo(name, title, description, serverNames, fun, asyncFun,
                     runOnVirtualThread, arguments, metadata, icons);
-            PromptInfo existing = prompts.putIfAbsent(name, ret);
-            if (existing != null) {
-                throw promptWithNameAlreadyExists(name);
-            } else {
-                notifyConnections(McpMethod.NOTIFICATIONS_PROMPTS_LIST_CHANGED);
+            List<FeatureKey> keys = FeatureKey.list(name, serverNames);
+            registrationLock.lock();
+            try {
+                for (FeatureKey key : keys) {
+                    if (prompts.containsKey(key)) {
+                        throw promptWithNameAlreadyExists(name, key.serverName());
+                    }
+                }
+                for (FeatureKey key : keys) {
+                    prompts.put(key, ret);
+                }
+            } finally {
+                registrationLock.unlock();
             }
+            notifyConnections(McpMethod.NOTIFICATIONS_PROMPTS_LIST_CHANGED);
             return ret;
         }
     }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceManagerImpl.java
@@ -55,8 +55,8 @@ public class ResourceManagerImpl extends FeatureManagerBase<ResourceResponse, Re
 
     final ResourceTemplateManagerImpl resourceTemplateManager;
 
-    final ConcurrentMap<String, ResourceInfo> uriToResource;
-    final Set<String> resourceNames;
+    final ConcurrentMap<FeatureKey, ResourceInfo> uriToResource;
+    final Set<FeatureKey> resourceNames;
 
     // uri -> subscribers (connection ids)
     final ConcurrentMap<String, List<String>> uriToSubscribers;
@@ -83,8 +83,11 @@ public class ResourceManagerImpl extends FeatureManagerBase<ResourceResponse, Re
         this.resourceNames = Collections.synchronizedSet(new HashSet<>());
         this.uriToSubscribers = new ConcurrentHashMap<>();
         for (FeatureMetadata<ResourceResponse> f : metadata.resources()) {
-            this.uriToResource.put(f.info().uri(), new ResourceMethod(f, iconsProviders));
-            this.resourceNames.add(f.info().name());
+            ResourceMethod resourceMethod = new ResourceMethod(f, iconsProviders);
+            for (String server : f.info().serverNames()) {
+                this.uriToResource.put(new FeatureKey(f.info().uri(), server), resourceMethod);
+                this.resourceNames.add(new FeatureKey(f.info().name(), server));
+            }
         }
         this.filters = filters;
         this.iconsProviders = iconsProviders;
@@ -92,7 +95,7 @@ public class ResourceManagerImpl extends FeatureManagerBase<ResourceResponse, Re
 
     @Override
     Stream<ResourceInfo> infos() {
-        return uriToResource.values().stream();
+        return uriToResource.values().stream().distinct();
     }
 
     @Override
@@ -106,13 +109,18 @@ public class ResourceManagerImpl extends FeatureManagerBase<ResourceResponse, Re
     }
 
     @Override
+    public ResourceInfo getResource(String uri, String serverName) {
+        return uriToResource.get(new FeatureKey(uri, serverName));
+    }
+
+    @Override
     public ResourceInfo getResource(String uri) {
-        return uriToResource.get(Objects.requireNonNull(uri));
+        return findUniqueByName(uriToResource, uri, Feature.RESOURCE);
     }
 
     void subscribe(String uri, McpRequest mcpRequest) {
-        ResourceInfo info = getResource(uri);
-        if (info == null || !matchesServer(info, mcpRequest)) {
+        ResourceInfo info = getResource(uri, mcpRequest.serverName());
+        if (info == null) {
             throw notFound(uri);
         }
         List<String> ids = new CopyOnWriteArrayList<>();
@@ -130,11 +138,6 @@ public class ResourceManagerImpl extends FeatureManagerBase<ResourceResponse, Re
 
     @Override
     public ResourceDefinition newResource(String name) {
-        for (ResourceInfo resource : uriToResource.values()) {
-            if (resource.name().equals(name)) {
-                resourceWithNameAlreadyExists(name);
-            }
-        }
         return new ResourceDefinitionImpl(name);
     }
 
@@ -153,21 +156,24 @@ public class ResourceManagerImpl extends FeatureManagerBase<ResourceResponse, Re
         }
     }
 
-    IllegalArgumentException resourceWithNameAlreadyExists(String name) {
-        return new IllegalArgumentException("A resource with name [" + name + "] already exits");
+    IllegalArgumentException resourceWithNameAlreadyExists(String name, String serverName) {
+        return new IllegalArgumentException(
+                "A resource with name [" + name + "] already exists for server configuration [" + serverName + "]");
     }
 
-    IllegalArgumentException resourceWithUriAlreadyExists(String uri) {
-        return new IllegalArgumentException("A resource with uri [" + uri + "] already exits");
+    IllegalArgumentException resourceWithUriAlreadyExists(String uri, String serverName) {
+        return new IllegalArgumentException(
+                "A resource with uri [" + uri + "] already exists for server configuration [" + serverName + "]");
     }
 
     @Override
-    public ResourceInfo removeResource(String uri) {
+    public ResourceInfo removeResource(String uri, String serverName) {
+        FeatureKey key = new FeatureKey(uri, serverName);
         AtomicReference<ResourceInfo> removed = new AtomicReference<>();
-        uriToResource.computeIfPresent(uri, (key, value) -> {
+        uriToResource.computeIfPresent(key, (k, value) -> {
             if (!value.isMethod()) {
                 removed.set(value);
-                resourceNames.remove(value.name());
+                resourceNames.remove(new FeatureKey(value.name(), serverName));
                 notifyConnections(McpMethod.NOTIFICATIONS_RESOURCES_LIST_CHANGED);
                 return null;
             }
@@ -176,12 +182,28 @@ public class ResourceManagerImpl extends FeatureManagerBase<ResourceResponse, Re
         return removed.get();
     }
 
+    @Override
+    public ResourceInfo removeResource(String uri) {
+        AtomicReference<ResourceInfo> removed = new AtomicReference<>();
+        uriToResource.entrySet().removeIf(e -> {
+            if (e.getKey().name().equals(uri) && !e.getValue().isMethod()) {
+                removed.set(e.getValue());
+                resourceNames.remove(new FeatureKey(e.getValue().name(), e.getKey().serverName()));
+                return true;
+            }
+            return false;
+        });
+        if (removed.get() != null) {
+            notifyConnections(McpMethod.NOTIFICATIONS_RESOURCES_LIST_CHANGED);
+        }
+        return removed.get();
+    }
+
     @SuppressWarnings("unchecked")
     @Override
     protected FeatureInvoker<ResourceResponse> getInvoker(String id, McpRequest mcpRequest, JsonObject message) {
-        ResourceInfo resource = uriToResource.get(id);
+        ResourceInfo resource = uriToResource.get(new FeatureKey(id, mcpRequest.serverName()));
         if (resource instanceof FeatureInvoker fi
-                && matchesServer(resource, mcpRequest)
                 && test(resource, FilterContextImpl.of(McpMethod.RESOURCES_READ, message, mcpRequest))) {
             return fi;
         }
@@ -457,9 +479,6 @@ public class ResourceManagerImpl extends FeatureManagerBase<ResourceResponse, Re
 
         @Override
         public ResourceDefinition setUri(String uri) {
-            if (uriToResource.containsKey(uri)) {
-                throw resourceWithUriAlreadyExists(uri);
-            }
             this.uri = Objects.requireNonNull(uri);
             return this;
         }
@@ -494,21 +513,31 @@ public class ResourceManagerImpl extends FeatureManagerBase<ResourceResponse, Re
             if (uri == null) {
                 throw new IllegalStateException("uri must be set");
             }
-            ResourceInfo newValue = uriToResource.compute(uri, (uri, old) -> {
-                if (old != null) {
-                    throw resourceWithUriAlreadyExists(uri);
+            ResourceDefinitionInfo ret = new ResourceDefinitionInfo(name, title, description, serverNames, fun, asyncFun,
+                    runOnVirtualThread, uri, mimeType, size, annotations, metadata, icons);
+            List<FeatureKey> nameKeys = FeatureKey.list(name, serverNames);
+            List<FeatureKey> uriKeys = FeatureKey.list(uri, serverNames);
+            registrationLock.lock();
+            try {
+                for (FeatureKey nameKey : nameKeys) {
+                    if (resourceNames.contains(nameKey)) {
+                        throw resourceWithNameAlreadyExists(name, nameKey.serverName());
+                    }
                 }
-                if (resourceNames.contains(name)) {
-                    throw resourceWithNameAlreadyExists(name);
+                for (FeatureKey uriKey : uriKeys) {
+                    if (uriToResource.containsKey(uriKey)) {
+                        throw resourceWithUriAlreadyExists(uri, uriKey.serverName());
+                    }
                 }
-                resourceNames.add(name);
-                return new ResourceDefinitionInfo(name, title, description, serverNames, fun, asyncFun,
-                        runOnVirtualThread, uri, mimeType, size, annotations, metadata, icons);
-            });
-            if (newValue != null) {
-                notifyConnections(McpMethod.NOTIFICATIONS_RESOURCES_LIST_CHANGED);
+                for (int i = 0; i < nameKeys.size(); i++) {
+                    resourceNames.add(nameKeys.get(i));
+                    uriToResource.put(uriKeys.get(i), ret);
+                }
+            } finally {
+                registrationLock.unlock();
             }
-            return newValue;
+            notifyConnections(McpMethod.NOTIFICATIONS_RESOURCES_LIST_CHANGED);
+            return ret;
         }
     }
 

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceTemplateCompletionManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceTemplateCompletionManagerImpl.java
@@ -39,13 +39,16 @@ public class ResourceTemplateCompletionManagerImpl extends CompletionManagerBase
                 .stream().map(FeatureMetadata::info).collect(Collectors.toMap(FeatureMethodInfo::name, FeatureMethodInfo::uri));
         for (FeatureMetadata<CompletionResponse> c : metadata.resourceTemplateCompletions()) {
             // Find the corresponding resource template
-            String key = nameToUriTemplate.get(c.info().name()) + "_"
+            String compositeKey = nameToUriTemplate.get(c.info().name()) + "_"
                     + c.info().arguments().stream()
                             .filter(FeatureArgument::isParam)
                             .findFirst()
                             .orElseThrow()
                             .name();
-            this.completions.put(key, new CompletionMethod(c));
+            CompletionMethod completionMethod = new CompletionMethod(c);
+            for (String server : c.info().serverNames()) {
+                this.completions.put(new FeatureKey(compositeKey, server), completionMethod);
+            }
         }
         this.resourceTemplateManager = resourceTemplateManager;
     }
@@ -62,7 +65,12 @@ public class ResourceTemplateCompletionManagerImpl extends CompletionManagerBase
 
     @Override
     protected void validateReference(String refName, String argumentName) {
-        ResourceTemplateMetadata templateMeta = resourceTemplateManager.templates.get(refName);
+        // Find any template with the given name (across all servers)
+        ResourceTemplateMetadata templateMeta = resourceTemplateManager.templates.entrySet().stream()
+                .filter(e -> e.getKey().name().equals(refName))
+                .map(java.util.Map.Entry::getValue)
+                .findFirst()
+                .orElse(null);
         if (templateMeta == null) {
             throw new IllegalStateException("Resource template does not exist: " + refName);
         }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceTemplateManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceTemplateManagerImpl.java
@@ -55,7 +55,7 @@ public class ResourceTemplateManagerImpl extends FeatureManagerBase<ResourceResp
 
     private static final Logger LOG = Logger.getLogger(ResourceTemplateManagerImpl.class);
 
-    final ConcurrentMap<String, ResourceTemplateMetadata> templates;
+    final ConcurrentMap<FeatureKey, ResourceTemplateMetadata> templates;
 
     final List<ResourceTemplateFilter> filters;
 
@@ -75,8 +75,12 @@ public class ResourceTemplateManagerImpl extends FeatureManagerBase<ResourceResp
                 metadata);
         this.templates = new ConcurrentHashMap<>();
         for (FeatureMetadata<ResourceResponse> fm : metadata.resourceTemplates()) {
-            this.templates.put(fm.info().name(), new ResourceTemplateMetadata(createMatcherFromUriTemplate(fm.info().uri()),
-                    new ResourceTemplateMethod(fm, iconsProviders)));
+            ResourceTemplateMethod templateMethod = new ResourceTemplateMethod(fm, iconsProviders);
+            ResourceTemplateMetadata templateMetadata = new ResourceTemplateMetadata(
+                    createMatcherFromUriTemplate(fm.info().uri()), templateMethod);
+            for (String server : fm.info().serverNames()) {
+                this.templates.put(new FeatureKey(fm.info().name(), server), templateMetadata);
+            }
         }
         this.filters = filters;
         this.iconsProviders = iconsProviders;
@@ -84,7 +88,7 @@ public class ResourceTemplateManagerImpl extends FeatureManagerBase<ResourceResp
 
     @Override
     Stream<ResourceTemplateInfo> infos() {
-        return templates.values().stream().map(ResourceTemplateMetadata::info);
+        return templates.values().stream().map(ResourceTemplateMetadata::info).distinct();
     }
 
     @Override
@@ -98,25 +102,40 @@ public class ResourceTemplateManagerImpl extends FeatureManagerBase<ResourceResp
     }
 
     @Override
-    public ResourceTemplateInfo getResourceTemplate(String name) {
-        ResourceTemplateMetadata metadata = templates.get(Objects.requireNonNull(name));
+    public ResourceTemplateInfo getResourceTemplate(String name, String serverName) {
+        ResourceTemplateMetadata metadata = templates
+                .get(new FeatureKey(name, serverName));
         return metadata != null ? metadata.info() : null;
     }
 
     @Override
-    public ResourceTemplateDefinition newResourceTemplate(String name) {
-        if (templates.containsKey(name)) {
-            throw resourceTemplateWithNameAlreadyExists(name);
+    public ResourceTemplateInfo getResourceTemplate(String name) {
+        Objects.requireNonNull(name);
+        List<ResourceTemplateInfo> matches = templates.entrySet().stream()
+                .filter(e -> e.getKey().name().equals(name))
+                .map(e -> e.getValue().info())
+                .distinct()
+                .toList();
+        if (matches.size() > 1) {
+            throw new IllegalStateException(
+                    "Multiple resource templates with name [%s] found on different servers; use the variant that accepts a server name"
+                            .formatted(name));
         }
+        return matches.isEmpty() ? null : matches.get(0);
+    }
+
+    @Override
+    public ResourceTemplateDefinition newResourceTemplate(String name) {
         return new ResourceTemplateDefinitionImpl(name);
     }
 
     @Override
-    public ResourceTemplateInfo removeResourceTemplate(String name) {
+    public ResourceTemplateInfo removeResourceTemplate(String name, String serverName) {
+        FeatureKey key = new FeatureKey(name, serverName);
         AtomicReference<ResourceTemplateInfo> removed = new AtomicReference<>();
-        templates.computeIfPresent(name, (key, value) -> {
+        templates.computeIfPresent(key, (k, value) -> {
             if (!value.info().isMethod()) {
-                removed.set(value.info);
+                removed.set(value.info());
                 return null;
             }
             return value;
@@ -124,29 +143,63 @@ public class ResourceTemplateManagerImpl extends FeatureManagerBase<ResourceResp
         return removed.get();
     }
 
-    private VariableMatcher getVariableMatcher(String name) {
-        return templates.get(name).variableMatcher();
+    @Override
+    public ResourceTemplateInfo removeResourceTemplate(String name) {
+        AtomicReference<ResourceTemplateInfo> removed = new AtomicReference<>();
+        templates.entrySet().removeIf(e -> {
+            if (e.getKey().name().equals(name) && !e.getValue().info().isMethod()) {
+                removed.set(e.getValue().info());
+                return true;
+            }
+            return false;
+        });
+        return removed.get();
+    }
+
+    private VariableMatcher getVariableMatcher(String name, String serverName) {
+        return templates.get(new FeatureKey(name, serverName)).variableMatcher();
     }
 
     @SuppressWarnings("unchecked")
     @Override
     protected FeatureInvoker<ResourceResponse> getInvoker(String id, McpRequest mcpRequest, JsonObject message) {
         // This method is used by ResourceManager during "resources/read" - the id is a URI
-        // We need to iterate over all templates and find the matching URI template
-        ResourceTemplateInfo found = findMatching(id);
+        // We need to iterate over all templates and find the matching URI template for the given server
+        ResourceTemplateInfo found = findMatching(id, mcpRequest.serverName());
         if (found instanceof FeatureInvoker fi
-                && matchesServer(found, mcpRequest)
                 && test(found, FilterContextImpl.of(McpMethod.RESOURCES_READ, message, mcpRequest))) {
             return fi;
         }
         return null;
     }
 
+    /**
+     * Finds a matching template across all servers. Used by transport-level logic that does not have server context.
+     */
     public ResourceTemplateInfo findMatching(String uri) {
         List<ResourceTemplateInfo> matching = new ArrayList<>();
-        for (ResourceTemplateMetadata t : templates.values()) {
-            if (t.variableMatcher().matches(uri)) {
-                matching.add(t.info());
+        for (Map.Entry<FeatureKey, ResourceTemplateMetadata> e : templates.entrySet()) {
+            if (e.getValue().variableMatcher().matches(uri)) {
+                matching.add(e.getValue().info());
+            }
+        }
+        // Deduplicate (same info may appear under multiple server keys)
+        matching = matching.stream().distinct().toList();
+        if (matching.isEmpty()) {
+            return null;
+        } else if (matching.size() > 1) {
+            throw new McpException("Multiple resource templates match uri %s [%s]".formatted(uri,
+                    matching.stream().map(ResourceTemplateInfo::name).toList()), JsonRpcErrorCodes.INTERNAL_ERROR);
+        } else {
+            return matching.get(0);
+        }
+    }
+
+    public ResourceTemplateInfo findMatching(String uri, String serverName) {
+        List<ResourceTemplateInfo> matching = new ArrayList<>();
+        for (Map.Entry<FeatureKey, ResourceTemplateMetadata> e : templates.entrySet()) {
+            if (e.getKey().serverName().equals(serverName) && e.getValue().variableMatcher().matches(uri)) {
+                matching.add(e.getValue().info());
             }
         }
         if (matching.isEmpty()) {
@@ -157,7 +210,6 @@ public class ResourceTemplateManagerImpl extends FeatureManagerBase<ResourceResp
         } else {
             return matching.get(0);
         }
-
     }
 
     private boolean test(ResourceTemplateInfo resourceTemplate, FilterContext filterContext) {
@@ -179,8 +231,9 @@ public class ResourceTemplateManagerImpl extends FeatureManagerBase<ResourceResp
     record ResourceTemplateMetadata(VariableMatcher variableMatcher, ResourceTemplateInfo info) {
     }
 
-    IllegalArgumentException resourceTemplateWithNameAlreadyExists(String name) {
-        return new IllegalArgumentException("A resource template with name [" + name + "] already exits");
+    IllegalArgumentException resourceTemplateWithNameAlreadyExists(String name, String serverName) {
+        return new IllegalArgumentException(
+                "A resource template with name [" + name + "] already exists for server configuration [" + serverName + "]");
     }
 
     @Override
@@ -191,7 +244,7 @@ public class ResourceTemplateManagerImpl extends FeatureManagerBase<ResourceResp
     @Override
     protected Object[] prepareArguments(FeatureMetadata<?> metadata, ArgumentProviders argProviders) throws McpException {
         // Use variable matching to extract method arguments
-        Map<String, Object> matchedVariables = getVariableMatcher(metadata.info().name())
+        Map<String, Object> matchedVariables = getVariableMatcher(metadata.info().name(), argProviders.serverName())
                 .matchVariables(argProviders.uri()).entrySet().stream()
                 .collect(Collectors.toMap(Entry::getKey, e -> e.getValue().toString()));
         argProviders = new ArgumentProviders(argProviders.rawMessage(),
@@ -407,7 +460,7 @@ public class ResourceTemplateManagerImpl extends FeatureManagerBase<ResourceResp
         @Override
         protected ResourceTemplateArguments createArguments(ArgumentProviders argumentProviders) {
             // Use variable matching to extract method arguments
-            Map<String, String> matchedVariables = getVariableMatcher(name)
+            Map<String, String> matchedVariables = getVariableMatcher(name, argumentProviders.serverName())
                     .matchVariables(argumentProviders.uri());
             return new ResourceTemplateArgumentsImpl(argumentProviders,
                     matchedVariables,
@@ -501,9 +554,20 @@ public class ResourceTemplateManagerImpl extends FeatureManagerBase<ResourceResp
             ResourceTemplateDefinitionInfo ret = new ResourceTemplateDefinitionInfo(name, title, description, serverNames,
                     fun, asyncFun, runOnVirtualThread, uriTemplate, mimeType, annotations, metadata, icons);
             VariableMatcher variableMatcher = createMatcherFromUriTemplate(uriTemplate);
-            ResourceTemplateMetadata existing = templates.putIfAbsent(name, new ResourceTemplateMetadata(variableMatcher, ret));
-            if (existing != null) {
-                throw resourceTemplateWithNameAlreadyExists(name);
+            ResourceTemplateMetadata templateMetadata = new ResourceTemplateMetadata(variableMatcher, ret);
+            List<FeatureKey> keys = FeatureKey.list(name, serverNames);
+            registrationLock.lock();
+            try {
+                for (FeatureKey key : keys) {
+                    if (templates.containsKey(key)) {
+                        throw resourceTemplateWithNameAlreadyExists(name, key.serverName());
+                    }
+                }
+                for (FeatureKey key : keys) {
+                    templates.put(key, templateMetadata);
+                }
+            } finally {
+                registrationLock.unlock();
             }
             return ret;
         }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ToolManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ToolManagerImpl.java
@@ -7,7 +7,6 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.Set;
@@ -76,7 +75,7 @@ public class ToolManagerImpl extends FeatureManagerBase<ToolResponse, ToolInfo> 
     final Instance<InputSchemaGenerator<?>> inputSchemaGenerator;
     final Instance<OutputSchemaGenerator> outputSchemaGenerator;
 
-    final ConcurrentMap<String, ToolInfo> tools;
+    final ConcurrentMap<FeatureKey, ToolInfo> tools;
 
     final Map<Type, DefaultValueConverter<?>> defaultValueConverters;
 
@@ -120,13 +119,16 @@ public class ToolManagerImpl extends FeatureManagerBase<ToolResponse, ToolInfo> 
         this.buildTimeConfig = buildTimeConfig;
         this.config = config;
         for (FeatureMetadata<ToolResponse> f : metadata.tools()) {
-            this.tools.put(f.info().name(), new ToolMethod(f, iconsProviders));
+            ToolMethod toolMethod = new ToolMethod(f, iconsProviders);
+            for (String server : f.info().serverNames()) {
+                this.tools.put(new FeatureKey(f.info().name(), server), toolMethod);
+            }
         }
     }
 
     @Override
     Stream<ToolInfo> infos() {
-        return tools.values().stream();
+        return tools.values().stream().distinct();
     }
 
     @Override
@@ -140,26 +142,30 @@ public class ToolManagerImpl extends FeatureManagerBase<ToolResponse, ToolInfo> 
     }
 
     @Override
+    public ToolInfo getTool(String name, String serverName) {
+        return tools.get(new FeatureKey(name, serverName));
+    }
+
+    @Override
     public ToolInfo getTool(String name) {
-        return tools.get(Objects.requireNonNull(name));
+        return findUniqueByName(tools, name, Feature.TOOL);
     }
 
     @Override
     public ToolDefinition newTool(String name) {
-        if (tools.containsKey(name)) {
-            throw toolAlreadyExists(name);
-        }
         return new ToolDefinitionImpl(name);
     }
 
-    IllegalArgumentException toolAlreadyExists(String name) {
-        return new IllegalArgumentException("A tool with name [" + name + "] already exits");
+    IllegalArgumentException toolAlreadyExists(String name, String serverName) {
+        return new IllegalArgumentException(
+                "A tool with name [" + name + "] already exists for server configuration [" + serverName + "]");
     }
 
     @Override
-    public ToolInfo removeTool(String name) {
+    public ToolInfo removeTool(String name, String serverName) {
+        FeatureKey key = new FeatureKey(name, serverName);
         AtomicReference<ToolInfo> removed = new AtomicReference<>();
-        tools.computeIfPresent(name, (key, value) -> {
+        tools.computeIfPresent(key, (k, value) -> {
             if (!value.isMethod()) {
                 removed.set(value);
                 notifyConnections(McpMethod.NOTIFICATIONS_TOOLS_LIST_CHANGED);
@@ -170,12 +176,27 @@ public class ToolManagerImpl extends FeatureManagerBase<ToolResponse, ToolInfo> 
         return removed.get();
     }
 
+    @Override
+    public ToolInfo removeTool(String name) {
+        AtomicReference<ToolInfo> removed = new AtomicReference<>();
+        tools.entrySet().removeIf(e -> {
+            if (e.getKey().name().equals(name) && !e.getValue().isMethod()) {
+                removed.set(e.getValue());
+                return true;
+            }
+            return false;
+        });
+        if (removed.get() != null) {
+            notifyConnections(McpMethod.NOTIFICATIONS_TOOLS_LIST_CHANGED);
+        }
+        return removed.get();
+    }
+
     @SuppressWarnings("unchecked")
     @Override
     protected FeatureInvoker<ToolResponse> getInvoker(String id, McpRequest mcpRequest, JsonObject message) {
-        ToolInfo tool = tools.get(id);
+        ToolInfo tool = tools.get(new FeatureKey(id, mcpRequest.serverName()));
         if (tool instanceof FeatureInvoker fi
-                && matchesServer(tool, mcpRequest)
                 && test(tool, FilterContextImpl.of(McpMethod.TOOLS_CALL, message, mcpRequest))) {
             return fi;
         }
@@ -628,12 +649,21 @@ public class ToolManagerImpl extends FeatureManagerBase<ToolResponse, ToolInfo> 
             ToolDefinitionInfo ret = new ToolDefinitionInfo(name, title, description, serverNames, fun, asyncFun,
                     runOnVirtualThread, arguments, annotations, outputSchema, inputSchema, metadata,
                     initInputGuardrails(inputGuardrails), initOutputGuardrails(outputGuardrails), icons);
-            ToolInfo existing = tools.putIfAbsent(name, ret);
-            if (existing != null) {
-                throw toolAlreadyExists(name);
-            } else {
-                notifyConnections(McpMethod.NOTIFICATIONS_TOOLS_LIST_CHANGED);
+            List<FeatureKey> keys = FeatureKey.list(name, serverNames);
+            registrationLock.lock();
+            try {
+                for (FeatureKey key : keys) {
+                    if (tools.containsKey(key)) {
+                        throw toolAlreadyExists(name, key.serverName());
+                    }
+                }
+                for (FeatureKey key : keys) {
+                    tools.put(key, ret);
+                }
+            } finally {
+                registrationLock.unlock();
             }
+            notifyConnections(McpMethod.NOTIFICATIONS_TOOLS_LIST_CHANGED);
             return ret;
         }
 

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/mcpservers/MultipleServersMultiBindingTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/mcpservers/MultipleServersMultiBindingTest.java
@@ -53,51 +53,51 @@ public class MultipleServersMultiBindingTest extends McpServerTest {
 
     @Test
     public void testServerNames() {
-        ToolManager.ToolInfo alpha = toolManager.getTool("alpha");
+        ToolManager.ToolInfo alpha = toolManager.getTool("alpha", DEFAULT);
         assertNotNull(alpha);
         assertThat(alpha.serverNames()).containsExactly(DEFAULT);
 
-        ToolManager.ToolInfo bravo = toolManager.getTool("bravo");
+        ToolManager.ToolInfo bravo = toolManager.getTool("bravo", "bravo");
         assertNotNull(bravo);
         assertThat(bravo.serverNames()).containsExactly("bravo");
 
-        ToolManager.ToolInfo shared = toolManager.getTool("shared");
+        ToolManager.ToolInfo shared = toolManager.getTool("shared", DEFAULT);
         assertNotNull(shared);
         assertThat(shared.serverNames()).containsExactlyInAnyOrder(DEFAULT, "bravo");
 
-        ToolManager.ToolInfo charlie = toolManager.getTool("charlie");
+        ToolManager.ToolInfo charlie = toolManager.getTool("charlie", "charlie");
         assertNotNull(charlie);
         assertThat(charlie.serverNames()).containsExactly("charlie");
 
-        ToolManager.ToolInfo delta = toolManager.getTool("delta");
+        ToolManager.ToolInfo delta = toolManager.getTool("delta", DEFAULT);
         assertNotNull(delta);
         assertThat(delta.serverNames()).containsExactlyInAnyOrder("charlie", DEFAULT);
 
-        ToolManager.ToolInfo golf = toolManager.getTool("golf");
+        ToolManager.ToolInfo golf = toolManager.getTool("golf", "bravo");
         assertNotNull(golf);
         assertThat(golf.serverNames()).containsExactlyInAnyOrder("charlie", "bravo");
 
-        PromptManager.PromptInfo sharedPrompt = promptManager.getPrompt("sharedPrompt");
+        PromptManager.PromptInfo sharedPrompt = promptManager.getPrompt("sharedPrompt", DEFAULT);
         assertNotNull(sharedPrompt);
         assertThat(sharedPrompt.serverNames()).containsExactlyInAnyOrder(DEFAULT, "bravo");
 
-        PromptManager.PromptInfo deltaPrompt = promptManager.getPrompt("deltaPrompt");
+        PromptManager.PromptInfo deltaPrompt = promptManager.getPrompt("deltaPrompt", DEFAULT);
         assertNotNull(deltaPrompt);
         assertThat(deltaPrompt.serverNames()).containsExactlyInAnyOrder("charlie", DEFAULT);
 
-        ResourceManager.ResourceInfo sharedResource = resourceManager.getResource("file://shared");
+        ResourceManager.ResourceInfo sharedResource = resourceManager.getResource("file://shared", DEFAULT);
         assertNotNull(sharedResource);
         assertThat(sharedResource.serverNames()).containsExactlyInAnyOrder(DEFAULT, "bravo");
 
-        ResourceManager.ResourceInfo deltaResource = resourceManager.getResource("file://delta");
+        ResourceManager.ResourceInfo deltaResource = resourceManager.getResource("file://delta", DEFAULT);
         assertNotNull(deltaResource);
         assertThat(deltaResource.serverNames()).containsExactlyInAnyOrder("charlie", DEFAULT);
 
-        ToolManager.ToolInfo echo = toolManager.getTool("echo");
+        ToolManager.ToolInfo echo = toolManager.getTool("echo", DEFAULT);
         assertNotNull(echo);
         assertThat(echo.serverNames()).containsExactly(DEFAULT);
 
-        ToolManager.ToolInfo foxtrot = toolManager.getTool("foxtrot");
+        ToolManager.ToolInfo foxtrot = toolManager.getTool("foxtrot", "bravo");
         assertNotNull(foxtrot);
         assertThat(foxtrot.serverNames()).containsExactly("bravo");
     }

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/mcpservers/MutipleServersTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/mcpservers/MutipleServersTest.java
@@ -63,16 +63,16 @@ public class MutipleServersTest extends McpServerTest {
                 .register());
         assertEquals("Invalid server name: nonexistent", ise.getMessage());
 
-        ToolManager.ToolInfo bravo = toolManager.getTool("bravo");
+        ToolManager.ToolInfo bravo = toolManager.getTool("bravo", "bravo");
         assertNotNull(bravo);
         assertThat(bravo.serverNames()).containsExactly("bravo");
-        ToolManager.ToolInfo echo = toolManager.getTool("echo");
+        ToolManager.ToolInfo echo = toolManager.getTool("echo", McpServer.DEFAULT);
         assertNotNull(echo);
         assertThat(echo.serverNames()).containsExactly(McpServer.DEFAULT);
-        PromptManager.PromptInfo bravoPrompt = promptManager.getPrompt("bravoPrompt");
+        PromptManager.PromptInfo bravoPrompt = promptManager.getPrompt("bravoPrompt", "bravo");
         assertNotNull(bravoPrompt);
         assertThat(bravoPrompt.serverNames()).containsExactly("bravo");
-        ResourceManager.ResourceInfo bravoResource = resourceManager.getResource("file://2");
+        ResourceManager.ResourceInfo bravoResource = resourceManager.getResource("file://2", "bravo");
         assertNotNull(bravoResource);
         assertThat(bravoResource.serverNames()).containsExactly("bravo");
 

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/mcpservers/PerServerProgrammaticTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/mcpservers/PerServerProgrammaticTest.java
@@ -1,0 +1,297 @@
+package io.quarkiverse.mcp.server.test.mcpservers;
+
+import static io.quarkiverse.mcp.server.McpServer.DEFAULT;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.PromptManager;
+import io.quarkiverse.mcp.server.PromptMessage;
+import io.quarkiverse.mcp.server.PromptResponse;
+import io.quarkiverse.mcp.server.ResourceManager;
+import io.quarkiverse.mcp.server.ResourceResponse;
+import io.quarkiverse.mcp.server.TextResourceContents;
+import io.quarkiverse.mcp.server.ToolManager;
+import io.quarkiverse.mcp.server.ToolResponse;
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkiverse.mcp.server.test.McpAssured.McpStreamableTestClient;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Tests programmatic registration of features with the same name on different servers,
+ * and verifies per-server get/remove and deprecated API behavior.
+ */
+public class PerServerProgrammaticTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .withApplicationRoot(
+                    root -> root.addClasses(PerServerProgrammaticTest.class))
+            .overrideConfigKey("quarkus.mcp.server.support-multi-server-bindings", "true")
+            .overrideConfigKey("quarkus.mcp.server.http.root-path", "/alpha/mcp")
+            .overrideConfigKey("quarkus.mcp.server.bravo.http.root-path", "/bravo/mcp");
+
+    @Inject
+    ToolManager toolManager;
+
+    @Inject
+    PromptManager promptManager;
+
+    @Inject
+    ResourceManager resourceManager;
+
+    @BeforeEach
+    void cleanup() {
+        // Remove all programmatically registered features
+        for (String server : List.of(DEFAULT, "bravo")) {
+            for (String name : List.of("query", "duplicate", "shared", "summarize", "data", "ambiguous")) {
+                toolManager.removeTool(name, server);
+                promptManager.removePrompt(name, server);
+                resourceManager.removeResource(name, server);
+                resourceManager.removeResource("file://" + name, server);
+            }
+        }
+    }
+
+    @Test
+    public void testSameToolNameDifferentServers() {
+        // Register tool "query" on default server
+        toolManager.newTool("query")
+                .setServerName(DEFAULT)
+                .setDescription("alpha query")
+                .setHandler(ta -> ToolResponse.success("alpha"))
+                .register();
+
+        // Register tool "query" on bravo server — same name, different server
+        toolManager.newTool("query")
+                .setServerName("bravo")
+                .setDescription("bravo query")
+                .setHandler(ta -> ToolResponse.success("bravo"))
+                .register();
+
+        // Server-aware get returns the correct tool
+        ToolManager.ToolInfo alphaQuery = toolManager.getTool("query", DEFAULT);
+        assertNotNull(alphaQuery);
+        assertThat(alphaQuery.serverNames()).containsExactly(DEFAULT);
+        assertEquals("alpha query", alphaQuery.description());
+
+        ToolManager.ToolInfo bravoQuery = toolManager.getTool("query", "bravo");
+        assertNotNull(bravoQuery);
+        assertThat(bravoQuery.serverNames()).containsExactly("bravo");
+        assertEquals("bravo query", bravoQuery.description());
+
+        // Each server sees its own tool
+        McpStreamableTestClient alphaClient = McpAssured.newStreamableClient()
+                .setMcpPath("/alpha/mcp")
+                .build()
+                .connect();
+
+        alphaClient.when()
+                .toolsList(page -> {
+                    assertEquals(1, page.size());
+                    assertEquals("query", page.tools().get(0).name());
+                })
+                .toolsCall("query", r -> assertEquals("alpha", r.firstContent().asText().text()))
+                .thenAssertResults();
+
+        McpStreamableTestClient bravoClient = McpAssured.newStreamableClient()
+                .setMcpPath("/bravo/mcp")
+                .build()
+                .connect();
+
+        bravoClient.when()
+                .toolsList(page -> {
+                    assertEquals(1, page.size());
+                    assertEquals("query", page.tools().get(0).name());
+                })
+                .toolsCall("query", r -> assertEquals("bravo", r.firstContent().asText().text()))
+                .thenAssertResults();
+
+        // Remove tool only from bravo — alpha should still work
+        ToolManager.ToolInfo removed = toolManager.removeTool("query", "bravo");
+        assertNotNull(removed);
+        assertEquals("bravo query", removed.description());
+
+        assertNull(toolManager.getTool("query", "bravo"));
+        assertNotNull(toolManager.getTool("query", DEFAULT));
+    }
+
+    @Test
+    public void testSameToolNameSameServerFails() {
+        toolManager.newTool("duplicate")
+                .setServerName(DEFAULT)
+                .setDescription("first")
+                .setHandler(ta -> ToolResponse.success("1"))
+                .register();
+
+        // Same name, same server — should fail
+        assertThrows(IllegalArgumentException.class, () -> toolManager.newTool("duplicate")
+                .setServerName(DEFAULT)
+                .setDescription("second")
+                .setHandler(ta -> ToolResponse.success("2"))
+                .register());
+    }
+
+    @Test
+    public void testSamePromptNameDifferentServers() {
+        promptManager.newPrompt("summarize")
+                .setServerName(DEFAULT)
+                .setDescription("alpha summarize")
+                .setHandler(pa -> PromptResponse.withMessages(PromptMessage.withUserRole("alpha")))
+                .register();
+
+        promptManager.newPrompt("summarize")
+                .setServerName("bravo")
+                .setDescription("bravo summarize")
+                .setHandler(pa -> PromptResponse.withMessages(PromptMessage.withUserRole("bravo")))
+                .register();
+
+        assertNotNull(promptManager.getPrompt("summarize", DEFAULT));
+        assertNotNull(promptManager.getPrompt("summarize", "bravo"));
+
+        McpStreamableTestClient alphaClient = McpAssured.newStreamableClient()
+                .setMcpPath("/alpha/mcp")
+                .build()
+                .connect();
+
+        alphaClient.when()
+                .promptsGet("summarize", r -> assertEquals("alpha", r.messages().get(0).content().asText().text()))
+                .thenAssertResults();
+
+        McpStreamableTestClient bravoClient = McpAssured.newStreamableClient()
+                .setMcpPath("/bravo/mcp")
+                .build()
+                .connect();
+
+        bravoClient.when()
+                .promptsGet("summarize", r -> assertEquals("bravo", r.messages().get(0).content().asText().text()))
+                .thenAssertResults();
+
+        // Remove from alpha only
+        PromptManager.PromptInfo removed = promptManager.removePrompt("summarize", DEFAULT);
+        assertNotNull(removed);
+        assertNull(promptManager.getPrompt("summarize", DEFAULT));
+        assertNotNull(promptManager.getPrompt("summarize", "bravo"));
+    }
+
+    @Test
+    public void testSameResourceUriDifferentServers() {
+        resourceManager.newResource("data")
+                .setServerName(DEFAULT)
+                .setUri("file://data")
+                .setDescription("alpha data")
+                .setHandler(ra -> new ResourceResponse(
+                        List.of(TextResourceContents.create(ra.requestUri().value(), "alpha"))))
+                .register();
+
+        resourceManager.newResource("data")
+                .setServerName("bravo")
+                .setUri("file://data")
+                .setDescription("bravo data")
+                .setHandler(ra -> new ResourceResponse(
+                        List.of(TextResourceContents.create(ra.requestUri().value(), "bravo"))))
+                .register();
+
+        assertNotNull(resourceManager.getResource("file://data", DEFAULT));
+        assertNotNull(resourceManager.getResource("file://data", "bravo"));
+
+        McpStreamableTestClient alphaClient = McpAssured.newStreamableClient()
+                .setMcpPath("/alpha/mcp")
+                .build()
+                .connect();
+
+        alphaClient.when()
+                .resourcesRead("file://data", r -> assertEquals("alpha", r.contents().get(0).asText().text()))
+                .thenAssertResults();
+
+        McpStreamableTestClient bravoClient = McpAssured.newStreamableClient()
+                .setMcpPath("/bravo/mcp")
+                .build()
+                .connect();
+
+        bravoClient.when()
+                .resourcesRead("file://data", r -> assertEquals("bravo", r.contents().get(0).asText().text()))
+                .thenAssertResults();
+
+        // Remove from bravo only
+        ResourceManager.ResourceInfo removed = resourceManager.removeResource("file://data", "bravo");
+        assertNotNull(removed);
+        assertNull(resourceManager.getResource("file://data", "bravo"));
+        assertNotNull(resourceManager.getResource("file://data", DEFAULT));
+    }
+
+    @Test
+    public void testGetWithoutServerThrowsIseWhenAmbiguous() {
+        // Register same name on two servers
+        toolManager.newTool("ambiguous")
+                .setServerName(DEFAULT)
+                .setDescription("alpha")
+                .setHandler(ta -> ToolResponse.success("alpha"))
+                .register();
+        toolManager.newTool("ambiguous")
+                .setServerName("bravo")
+                .setDescription("bravo")
+                .setHandler(ta -> ToolResponse.success("bravo"))
+                .register();
+
+        promptManager.newPrompt("ambiguous")
+                .setServerName(DEFAULT)
+                .setDescription("alpha")
+                .setHandler(pa -> PromptResponse.withMessages(PromptMessage.withUserRole("alpha")))
+                .register();
+        promptManager.newPrompt("ambiguous")
+                .setServerName("bravo")
+                .setDescription("bravo")
+                .setHandler(pa -> PromptResponse.withMessages(PromptMessage.withUserRole("bravo")))
+                .register();
+
+        resourceManager.newResource("ambiguous")
+                .setServerName(DEFAULT)
+                .setUri("file://ambiguous")
+                .setDescription("alpha")
+                .setHandler(ra -> new ResourceResponse(
+                        List.of(TextResourceContents.create(ra.requestUri().value(), "alpha"))))
+                .register();
+        resourceManager.newResource("ambiguous")
+                .setServerName("bravo")
+                .setUri("file://ambiguous")
+                .setDescription("bravo")
+                .setHandler(ra -> new ResourceResponse(
+                        List.of(TextResourceContents.create(ra.requestUri().value(), "bravo"))))
+                .register();
+
+        // Single-arg get throws ISE when ambiguous
+        assertThrows(IllegalStateException.class, () -> toolManager.getTool("ambiguous"));
+        assertThrows(IllegalStateException.class, () -> promptManager.getPrompt("ambiguous"));
+        assertThrows(IllegalStateException.class, () -> resourceManager.getResource("file://ambiguous"));
+    }
+
+    @SuppressWarnings("null")
+    @Test
+    public void testMultiServerToolSharedInstance() {
+        // Register a tool bound to both servers
+        ToolManager.ToolInfo info = toolManager.newTool("shared")
+                .setServerNames(DEFAULT, "bravo")
+                .setDescription("shared tool")
+                .setHandler(ta -> ToolResponse.success("shared"))
+                .register();
+
+        // Both server-aware lookups return the same instance
+        ToolManager.ToolInfo fromAlpha = toolManager.getTool("shared", DEFAULT);
+        assertNotNull(fromAlpha);
+        ToolManager.ToolInfo fromBravo = toolManager.getTool("shared", "bravo");
+        assertNotNull(fromBravo);
+        assertThat(fromAlpha).isSameAs(fromBravo).isSameAs(info);
+    }
+}

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/mcpservers/SameNameDifferentServersTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/mcpservers/SameNameDifferentServersTest.java
@@ -1,0 +1,108 @@
+package io.quarkiverse.mcp.server.test.mcpservers;
+
+import static io.quarkiverse.mcp.server.McpServer.DEFAULT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.McpServer;
+import io.quarkiverse.mcp.server.Prompt;
+import io.quarkiverse.mcp.server.PromptMessage;
+import io.quarkiverse.mcp.server.RequestUri;
+import io.quarkiverse.mcp.server.Resource;
+import io.quarkiverse.mcp.server.TextResourceContents;
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolResponse;
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkiverse.mcp.server.test.McpAssured.McpStreamableTestClient;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Tests that the same feature name can be used on different servers.
+ */
+public class SameNameDifferentServersTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .withApplicationRoot(
+                    root -> root.addClasses(AlphaFeatures.class, BravoFeatures.class))
+            .overrideConfigKey("quarkus.mcp.server.support-multi-server-bindings", "false")
+            .overrideConfigKey("quarkus.mcp.server.http.root-path", "/alpha/mcp")
+            .overrideConfigKey("quarkus.mcp.server.bravo.http.root-path", "/bravo/mcp");
+
+    @Test
+    public void testAlpha() {
+        McpStreamableTestClient client = McpAssured.newStreamableClient()
+                .setMcpPath("/alpha/mcp")
+                .build()
+                .connect();
+
+        client.when()
+                .toolsList(page -> {
+                    assertEquals(1, page.size());
+                    assertEquals("query", page.tools().get(0).name());
+                })
+                .toolsCall("query", r -> assertEquals("alpha_result", r.firstContent().asText().text()))
+                .promptsGet("summarize", r -> assertEquals("alpha_prompt", r.messages().get(0).content().asText().text()))
+                .resourcesRead("file://data", r -> assertEquals("alpha_data", r.contents().get(0).asText().text()))
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testBravo() {
+        McpStreamableTestClient client = McpAssured.newStreamableClient()
+                .setMcpPath("/bravo/mcp")
+                .build()
+                .connect();
+
+        client.when()
+                .toolsList(page -> {
+                    assertEquals(1, page.size());
+                    assertEquals("query", page.tools().get(0).name());
+                })
+                .toolsCall("query", r -> assertEquals("bravo_result", r.firstContent().asText().text()))
+                .promptsGet("summarize", r -> assertEquals("bravo_prompt", r.messages().get(0).content().asText().text()))
+                .resourcesRead("file://data", r -> assertEquals("bravo_data", r.contents().get(0).asText().text()))
+                .thenAssertResults();
+    }
+
+    @McpServer(DEFAULT)
+    public static class AlphaFeatures {
+
+        @Tool
+        ToolResponse query() {
+            return ToolResponse.success("alpha_result");
+        }
+
+        @Prompt
+        PromptMessage summarize() {
+            return PromptMessage.withUserRole("alpha_prompt");
+        }
+
+        @Resource(uri = "file://data")
+        TextResourceContents data(RequestUri uri) {
+            return TextResourceContents.create(uri.value(), "alpha_data");
+        }
+    }
+
+    @McpServer("bravo")
+    public static class BravoFeatures {
+
+        @Tool
+        ToolResponse query() {
+            return ToolResponse.success("bravo_result");
+        }
+
+        @Prompt
+        PromptMessage summarize() {
+            return PromptMessage.withUserRole("bravo_prompt");
+        }
+
+        @Resource(uri = "file://data")
+        TextResourceContents data(RequestUri uri) {
+            return TextResourceContents.create(uri.value(), "bravo_data");
+        }
+    }
+}

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/resources/ProgrammaticResourceTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/resources/ProgrammaticResourceTest.java
@@ -104,7 +104,7 @@ public class ProgrammaticResourceTest extends McpServerTest {
                 .thenAssertResults();
 
         IllegalArgumentException iae = assertThrows(IllegalArgumentException.class, () -> myResources.registerFailure());
-        assertEquals("A resource with name [dummy] already exits", iae.getMessage());
+        assertEquals("A resource with name [dummy] already exists for server configuration [<default>]", iae.getMessage());
     }
 
     @Singleton

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/resources/templates/ResourceTemplatesTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/resources/templates/ResourceTemplatesTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkiverse.mcp.server.JsonRpcErrorCodes;
+import io.quarkiverse.mcp.server.McpServer;
 import io.quarkiverse.mcp.server.MetaKey;
 import io.quarkiverse.mcp.server.ResourceTemplateManager;
 import io.quarkiverse.mcp.server.Role;
@@ -33,13 +34,14 @@ public class ResourceTemplatesTest extends McpServerTest {
 
     @Test
     public void testResourceTemplates() {
-        ResourceTemplateManager.ResourceTemplateInfo foxtrotTemplate = manager.getResourceTemplate("foxtrot_custom_name");
+        ResourceTemplateManager.ResourceTemplateInfo foxtrotTemplate = manager.getResourceTemplate("foxtrot_custom_name",
+                McpServer.DEFAULT);
         assertNotNull(foxtrotTemplate);
         assertEquals("Foxtrot Resource", foxtrotTemplate.title());
         assertEquals("file:///foxtrot/{path}", foxtrotTemplate.uriTemplate());
         assertEquals("application/json", foxtrotTemplate.mimeType());
         assertEquals("customValue", foxtrotTemplate.metadata().get(MetaKey.of("customField")));
-        ResourceTemplateManager.ResourceTemplateInfo golfTemplate = manager.getResourceTemplate("golf");
+        ResourceTemplateManager.ResourceTemplateInfo golfTemplate = manager.getResourceTemplate("golf", McpServer.DEFAULT);
         assertNotNull(golfTemplate);
         assertEquals(Role.ASSISTANT, golfTemplate.annotations().orElseThrow().audience());
         assertEquals(0.7, golfTemplate.annotations().orElseThrow().priority());

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/streamablehttp/SimpleStreamableTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/streamablehttp/SimpleStreamableTest.java
@@ -12,6 +12,7 @@ import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkiverse.mcp.server.McpServer;
 import io.quarkiverse.mcp.server.ToolManager;
 import io.quarkiverse.mcp.server.test.Checks;
 import io.quarkiverse.mcp.server.test.FooService;
@@ -42,7 +43,7 @@ public class SimpleStreamableTest extends McpServerTest {
                 .setDescription("foofoo")
                 .setHandler(atgs -> null)
                 .register();
-        assertNotNull(toolManager.getTool("foofoo"));
+        assertNotNull(toolManager.getTool("foofoo", McpServer.DEFAULT));
         assertNotNull(toolManager.removeTool("foofoo"));
 
         client.when()

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/annotations/ToolAnnotationsTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/annotations/ToolAnnotationsTest.java
@@ -11,6 +11,7 @@ import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkiverse.mcp.server.McpServer;
 import io.quarkiverse.mcp.server.Tool;
 import io.quarkiverse.mcp.server.Tool.Annotations;
 import io.quarkiverse.mcp.server.ToolManager;
@@ -35,7 +36,7 @@ public class ToolAnnotationsTest extends McpServerTest {
 
     @Test
     public void testAnnotations() {
-        ToolManager.ToolInfo alpha = manager.getTool("alpha");
+        ToolManager.ToolInfo alpha = manager.getTool("alpha", McpServer.DEFAULT);
         assertTrue(alpha.annotations().isPresent());
         assertEquals("Alpha tool", alpha.annotations().get().title());
         assertTrue(alpha.annotations().get().readOnlyHint());
@@ -43,7 +44,7 @@ public class ToolAnnotationsTest extends McpServerTest {
         assertFalse(alpha.annotations().get().idempotentHint());
         assertTrue(alpha.annotations().get().openWorldHint());
 
-        ToolManager.ToolInfo bravo = manager.getTool("bravo");
+        ToolManager.ToolInfo bravo = manager.getTool("bravo", McpServer.DEFAULT);
         assertTrue(bravo.annotations().isPresent());
         assertEquals("Bravo tool", bravo.annotations().get().title());
         assertFalse(bravo.annotations().get().readOnlyHint());
@@ -51,7 +52,7 @@ public class ToolAnnotationsTest extends McpServerTest {
         assertFalse(bravo.annotations().get().idempotentHint());
         assertFalse(bravo.annotations().get().openWorldHint());
 
-        ToolManager.ToolInfo charlie = manager.getTool("charlie");
+        ToolManager.ToolInfo charlie = manager.getTool("charlie", McpServer.DEFAULT);
         assertTrue(charlie.annotations().isEmpty());
 
         McpSseTestClient client = McpAssured.newSseClient()

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/validation/DuplicateToolNameOverlappingServersTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/validation/DuplicateToolNameOverlappingServersTest.java
@@ -1,0 +1,50 @@
+package io.quarkiverse.mcp.server.test.validation;
+
+import static io.quarkiverse.mcp.server.McpServer.DEFAULT;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.McpServer;
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolResponse;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Tests that two tools with the same name on overlapping servers are rejected at build time.
+ */
+public class DuplicateToolNameOverlappingServersTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> {
+                root.addClasses(AlphaFeatures.class, BravoFeatures.class);
+            })
+            .overrideConfigKey("quarkus.mcp.server.support-multi-server-bindings", "true")
+            .setExpectedException(IllegalStateException.class, true);
+
+    @Test
+    public void test() {
+        fail();
+    }
+
+    public static class AlphaFeatures {
+
+        @Tool
+        @McpServer(DEFAULT)
+        @McpServer("bravo")
+        ToolResponse query() {
+            return null;
+        }
+    }
+
+    @McpServer("bravo")
+    public static class BravoFeatures {
+
+        @Tool
+        ToolResponse query() {
+            return null;
+        }
+    }
+}

--- a/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/StreamableHttpMcpMessageHandler.java
+++ b/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/StreamableHttpMcpMessageHandler.java
@@ -442,12 +442,13 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
                 && Messages.isRequest(message)
                 && FORCE_SSE_REQUESTS.contains(method)) {
             JsonObject params = Messages.getParams(message);
+            String serverName = mcpRequest.serverName();
             if (params != null) {
                 return switch (method) {
-                    case TOOLS_CALL -> forceSseTool(params);
-                    case PROMPTS_GET -> forceSsePrompt(params);
-                    case RESOURCES_READ -> forceSseResource(params);
-                    case COMPLETION_COMPLETE -> forceSseCompletion(params);
+                    case TOOLS_CALL -> forceSseTool(serverName, params);
+                    case PROMPTS_GET -> forceSsePrompt(serverName, params);
+                    case RESOURCES_READ -> forceSseResource(serverName, params);
+                    case COMPLETION_COMPLETE -> forceSseCompletion(serverName, params);
                     default -> throw new IllegalArgumentException("Unexpected value: " + method);
                 };
             }
@@ -455,10 +456,10 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
         return false;
     }
 
-    private boolean forceSseTool(JsonObject params) {
+    private boolean forceSseTool(String serverName, JsonObject params) {
         String name = params.getString("name");
         if (name != null) {
-            var fm = McpMetadata.findFeatureByName(metadata.tools(), name);
+            var fm = McpMetadata.findFeature(metadata.tools(), name, serverName);
             if (fm != null) {
                 for (FeatureArgument a : fm.info().arguments()) {
                     if (FORCE_SSE_PROVIDERS.contains(a.provider())) {
@@ -466,7 +467,7 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
                     }
                 }
             } else {
-                ToolInfo info = toolManager.getTool(name);
+                ToolInfo info = toolManager.getTool(name, serverName);
                 if (info != null && !info.isMethod()) {
                     // Always force SSE init for a tool added programatically
                     return true;
@@ -476,10 +477,10 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
         return false;
     }
 
-    private boolean forceSsePrompt(JsonObject params) {
+    private boolean forceSsePrompt(String serverName, JsonObject params) {
         String name = params.getString("name");
         if (name != null) {
-            var fm = McpMetadata.findFeatureByName(metadata.prompts(), name);
+            var fm = McpMetadata.findFeature(metadata.prompts(), name, serverName);
             if (fm != null) {
                 for (FeatureArgument a : fm.info().arguments()) {
                     if (FORCE_SSE_PROVIDERS.contains(a.provider())) {
@@ -487,7 +488,7 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
                     }
                 }
             } else {
-                PromptInfo info = promptManager.getPrompt(name);
+                PromptInfo info = promptManager.getPrompt(name, serverName);
                 if (info != null && !info.isMethod()) {
                     // Always force SSE init for a prompt added programatically
                     return true;
@@ -497,7 +498,7 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
         return false;
     }
 
-    private boolean forceSseResource(JsonObject params) {
+    private boolean forceSseResource(String serverName, JsonObject params) {
         String resourceUri = params.getString("uri");
         if (resourceUri != null) {
             FeatureMetadata<?> fm = metadata.resources().stream().filter(m -> m.info().uri().equals(resourceUri))
@@ -506,7 +507,7 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
                 // Also try resource templates
                 ResourceTemplateManager.ResourceTemplateInfo rti = resourceTemplateManager.findMatching(resourceUri);
                 if (rti != null && rti.isMethod()) {
-                    fm = McpMetadata.findFeatureByName(metadata.resourceTemplates(), rti.name());
+                    fm = McpMetadata.findFeature(metadata.resourceTemplates(), rti.name(), serverName);
                 }
             }
             if (fm != null) {
@@ -516,7 +517,7 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
                     }
                 }
             } else {
-                ResourceManager.ResourceInfo info = resourceManager.getResource(resourceUri);
+                ResourceManager.ResourceInfo info = resourceManager.getResource(resourceUri, serverName);
                 if (info != null) {
                     if (!info.isMethod()) {
                         // Always force SSE init for a resource added programatically
@@ -534,7 +535,7 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
         return false;
     }
 
-    private boolean forceSseCompletion(JsonObject params) {
+    private boolean forceSseCompletion(String serverName, JsonObject params) {
         JsonObject ref = params.getJsonObject("ref");
         if (ref != null) {
             String referenceType = ref.getString("type");
@@ -543,10 +544,10 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
             String argumentName = argument != null ? argument.getString("name") : null;
             if (referenceName != null && argumentName != null) {
                 if ("ref/prompt".equals(referenceType)) {
-                    return forceSseCompletion(referenceName, argumentName, metadata.promptCompletions(),
+                    return forceSseCompletion(serverName, referenceName, argumentName, metadata.promptCompletions(),
                             promptCompletionManager);
                 } else if ("ref/resource".equals(referenceType)) {
-                    return forceSseCompletion(referenceName, argumentName, metadata.resourceTemplateCompletions(),
+                    return forceSseCompletion(serverName, referenceName, argumentName, metadata.resourceTemplateCompletions(),
                             resourceTemplateCompletionManager);
                 }
             }
@@ -555,10 +556,11 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
 
     }
 
-    private boolean forceSseCompletion(String referenceName, String argumentName,
+    private boolean forceSseCompletion(String serverName, String referenceName, String argumentName,
             List<FeatureMetadata<CompletionResponse>> completions, CompletionManager completionManager) {
         FeatureMetadata<?> fm = completions.stream().filter(m -> {
             return m.info().name().equals(referenceName)
+                    && m.info().serverNames().contains(serverName)
                     && argumentName.equals(m.info().arguments().stream().filter(FeatureArgument::isParam).findFirst()
                             .orElseThrow().name());
         })
@@ -570,7 +572,7 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
                 }
             }
         } else {
-            CompletionManager.CompletionInfo info = completionManager.getCompletion(referenceName, argumentName);
+            CompletionManager.CompletionInfo info = completionManager.getCompletion(referenceName, argumentName, serverName);
             if (info != null && !info.isMethod()) {
                 // Always force SSE init for a completion added programatically
                 return true;

--- a/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/devui/SseMcpJsonRPCService.java
+++ b/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/devui/SseMcpJsonRPCService.java
@@ -273,7 +273,9 @@ public class SseMcpJsonRPCService {
 
     public JsonObject callTool(String name, String serverName, JsonObject args, String bearerToken, boolean forceNewSession)
             throws IOException, InterruptedException {
-        ToolManager.ToolInfo info = toolManager.getTool(name);
+        ToolManager.ToolInfo info = serverName != null && !serverName.isBlank()
+                ? toolManager.getTool(name, serverName)
+                : toolManager.getTool(name);
         if (info == null) {
             return new JsonObject().put("error", "Tool not found: " + name);
         }
@@ -294,7 +296,9 @@ public class SseMcpJsonRPCService {
 
     public JsonObject getPrompt(String name, String serverName, JsonObject args, String bearerToken, boolean forceNewSession)
             throws IOException, InterruptedException {
-        PromptManager.PromptInfo info = promptManager.getPrompt(name);
+        PromptManager.PromptInfo info = serverName != null && !serverName.isBlank()
+                ? promptManager.getPrompt(name, serverName)
+                : promptManager.getPrompt(name);
         if (info == null) {
             return new JsonObject().put("error", "Prompt not found: " + name);
         }
@@ -316,7 +320,9 @@ public class SseMcpJsonRPCService {
     public JsonObject completePrompt(String name, String serverName, String argumentName, String argumentValue,
             String bearerToken, boolean forceNewSession)
             throws IOException, InterruptedException {
-        CompletionManager.CompletionInfo info = promptCompletionManager.getCompletion(name, argumentName);
+        CompletionManager.CompletionInfo info = serverName != null && !serverName.isBlank()
+                ? promptCompletionManager.getCompletion(name, argumentName, serverName)
+                : promptCompletionManager.getCompletion(name, argumentName);
         if (info == null) {
             return new JsonObject().put("error", "Prompt completion not found: " + name);
         }
@@ -361,7 +367,9 @@ public class SseMcpJsonRPCService {
     public JsonObject completeResourceTemplate(String name, String serverName, String argumentName, String argumentValue,
             String bearerToken, boolean forceNewSession)
             throws IOException, InterruptedException {
-        CompletionManager.CompletionInfo info = resourceTemplateCompletionManager.getCompletion(name, argumentName);
+        CompletionManager.CompletionInfo info = serverName != null && !serverName.isBlank()
+                ? resourceTemplateCompletionManager.getCompletion(name, argumentName, serverName)
+                : resourceTemplateCompletionManager.getCompletion(name, argumentName);
         if (info == null) {
             return new JsonObject().put("error", "Resource template completion not found: " + name);
         }

--- a/transports/websocket/deployment/src/test/java/io/quarkiverse/mcp/server/websocket/test/mcpservers/MultipleServersMultiBindingTest.java
+++ b/transports/websocket/deployment/src/test/java/io/quarkiverse/mcp/server/websocket/test/mcpservers/MultipleServersMultiBindingTest.java
@@ -53,35 +53,35 @@ public class MultipleServersMultiBindingTest extends McpServerTest {
 
     @Test
     public void testServerNames() {
-        ToolManager.ToolInfo alpha = toolManager.getTool("alpha");
+        ToolManager.ToolInfo alpha = toolManager.getTool("alpha", DEFAULT);
         assertNotNull(alpha);
         assertThat(alpha.serverNames()).containsExactly(DEFAULT);
 
-        ToolManager.ToolInfo bravo = toolManager.getTool("bravo");
+        ToolManager.ToolInfo bravo = toolManager.getTool("bravo", "bravo");
         assertNotNull(bravo);
         assertThat(bravo.serverNames()).containsExactly("bravo");
 
-        ToolManager.ToolInfo shared = toolManager.getTool("shared");
+        ToolManager.ToolInfo shared = toolManager.getTool("shared", DEFAULT);
         assertNotNull(shared);
         assertThat(shared.serverNames()).containsExactlyInAnyOrder(DEFAULT, "bravo");
 
-        ToolManager.ToolInfo charlie = toolManager.getTool("charlie");
+        ToolManager.ToolInfo charlie = toolManager.getTool("charlie", "charlie");
         assertNotNull(charlie);
         assertThat(charlie.serverNames()).containsExactly("charlie");
 
-        ToolManager.ToolInfo delta = toolManager.getTool("delta");
+        ToolManager.ToolInfo delta = toolManager.getTool("delta", DEFAULT);
         assertNotNull(delta);
         assertThat(delta.serverNames()).containsExactlyInAnyOrder("charlie", DEFAULT);
 
-        ToolManager.ToolInfo golf = toolManager.getTool("golf");
+        ToolManager.ToolInfo golf = toolManager.getTool("golf", "bravo");
         assertNotNull(golf);
         assertThat(golf.serverNames()).containsExactlyInAnyOrder("charlie", "bravo");
 
-        PromptManager.PromptInfo sharedPrompt = promptManager.getPrompt("sharedPrompt");
+        PromptManager.PromptInfo sharedPrompt = promptManager.getPrompt("sharedPrompt", DEFAULT);
         assertNotNull(sharedPrompt);
         assertThat(sharedPrompt.serverNames()).containsExactlyInAnyOrder(DEFAULT, "bravo");
 
-        ResourceManager.ResourceInfo sharedResource = resourceManager.getResource("file://shared");
+        ResourceManager.ResourceInfo sharedResource = resourceManager.getResource("file://shared", DEFAULT);
         assertNotNull(sharedResource);
         assertThat(sharedResource.serverNames()).containsExactlyInAnyOrder(DEFAULT, "bravo");
     }

--- a/transports/websocket/deployment/src/test/java/io/quarkiverse/mcp/server/websocket/test/mcpservers/MutipleServersTest.java
+++ b/transports/websocket/deployment/src/test/java/io/quarkiverse/mcp/server/websocket/test/mcpservers/MutipleServersTest.java
@@ -53,16 +53,16 @@ public class MutipleServersTest extends McpServerTest {
 
     @Test
     public void testDefaultServer() {
-        ToolManager.ToolInfo bravo = toolManager.getTool("bravo");
+        ToolManager.ToolInfo bravo = toolManager.getTool("bravo", "bravo");
         assertNotNull(bravo);
         assertThat(bravo.serverNames()).containsExactly("bravo");
-        ToolManager.ToolInfo echo = toolManager.getTool("echo");
+        ToolManager.ToolInfo echo = toolManager.getTool("echo", McpServer.DEFAULT);
         assertNotNull(echo);
         assertThat(echo.serverNames()).containsExactly(McpServer.DEFAULT);
-        PromptManager.PromptInfo bravoPrompt = promptManager.getPrompt("bravoPrompt");
+        PromptManager.PromptInfo bravoPrompt = promptManager.getPrompt("bravoPrompt", "bravo");
         assertNotNull(bravoPrompt);
         assertThat(bravoPrompt.serverNames()).containsExactly("bravo");
-        ResourceManager.ResourceInfo bravoResource = resourceManager.getResource("file://2");
+        ResourceManager.ResourceInfo bravoResource = resourceManager.getResource("file://2", "bravo");
         assertNotNull(bravoResource);
         assertThat(bravoResource.serverNames()).containsExactly("bravo");
 


### PR DESCRIPTION
- enforce feature name uniqueness per server configuration instead of globally
- resolves #627