### PR TITLE
Fix callout rendering in custom encoders guide

### DIFF
--- a/docs/modules/ROOT/pages/guides-custom-encoders.adoc
+++ b/docs/modules/ROOT/pages/guides-custom-encoders.adoc
@@ -394,7 +394,6 @@ For tool methods, encoders are selected in this order:
 1. `ToolResponseEncoder` - If one exists and supports the type
 2. `ContentEncoder` - If no `ToolResponseEncoder` matches
 3. Default JSON encoder - If no custom encoders match
-
 [source,java]
 ----
 // With ToolResponseEncoder<MyObject> and ContentEncoder<MyObject> defined:


### PR DESCRIPTION
## Summary

- Remove blank line between numbered list and code block in `guides-custom-encoders.adoc` so the code block stays attached to the list and the callout renders correctly

## Test plan

- [ ] Verify the callout `<1>` renders correctly in the "Encoder Selection for Tools" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)