### PR TITLE
Clarify McpLog placeholder syntax in Javadoc

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/McpLog.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/McpLog.java
@@ -7,6 +7,14 @@ import org.jboss.logging.Logger;
  * <p>
  * The MCP logger name is derived from the method. For example, if there is a method {@code myTool()} annotated with
  * {@code @Tool} then the logger name will be {@code tool:myTool}.
+ * <p>
+ * The {@code format} and {@code params} arguments of the logging methods use {@link java.util.Formatter} syntax
+ * (for example {@code %s}, {@code %d}, {@code %%}). SLF4J-style <code>{}</code> placeholders are <em>not</em>
+ * supported and will appear verbatim in the output. For example:
+ *
+ * <pre>{@code
+ * log.info("Processed %d of %d items", processed, total);
+ * }</pre>
  */
 public interface McpLog {
 
@@ -28,16 +36,16 @@ public interface McpLog {
      * Sends a log message notification to the client if the specified level is higher or equal to the current level.
      *
      * @param level
-     * @param format
-     * @param params
+     * @param format a format string in {@link java.util.Formatter} syntax
+     * @param params arguments referenced by the format specifiers
      */
     void send(LogLevel level, String format, Object... params);
 
     /**
      * Logs a message and sends a {@link LogLevel#DEBUG} log message notification to the client.
      *
-     * @param format
-     * @param params
+     * @param format a format string in {@link java.util.Formatter} syntax
+     * @param params arguments referenced by the format specifiers
      * @see Logger#debugf(String, Object...)
      */
     void debug(String format, Object... params);
@@ -45,8 +53,8 @@ public interface McpLog {
     /**
      * Logs a message and sends a {@link LogLevel#INFO} log message notification to the client.
      *
-     * @param format
-     * @param params
+     * @param format a format string in {@link java.util.Formatter} syntax
+     * @param params arguments referenced by the format specifiers
      * @see Logger#infof(String, Object...)
      */
     void info(String format, Object... params);
@@ -54,8 +62,8 @@ public interface McpLog {
     /**
      * Logs a message and sends a {@link LogLevel#ERROR} log message notification to the client.
      *
-     * @param format
-     * @param params
+     * @param format a format string in {@link java.util.Formatter} syntax
+     * @param params arguments referenced by the format specifiers
      * @see Logger#errorf(String, Object...)
      */
     void error(String format, Object... params);
@@ -64,8 +72,8 @@ public interface McpLog {
      * Logs a message and sends a {@link LogLevel#ERROR} log message notification to the client.
      *
      * @param t
-     * @param format
-     * @param params
+     * @param format a format string in {@link java.util.Formatter} syntax
+     * @param params arguments referenced by the format specifiers
      * @see Logger#errorf(Throwable, String, Object...)
      */
     void error(Throwable t, String format, Object... params);


### PR DESCRIPTION
Follow-up to #738 addressing @mkouba's review comment:
https://github.com/quarkiverse/quarkus-mcp-server/pull/738#issuecomment-4241428686

PR #738 fixed doc *examples* that used SLF4J-style `{}` placeholders.
This PR makes the placeholder syntax explicit in the `McpLog` Javadoc
itself — a class-level paragraph plus one-line descriptions on each
`@param format` / `@param params` — so the contract is visible in IDE
hover tooltips and generated Javadoc, not just via `@see Logger#infof`.

Please backport to `1.10.x` and `1.11.x` for downstream IBM builds.
