### PR TITLE
core: fix log level in McpLog#error(Throwable) overload

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpLogImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpLogImpl.java
@@ -69,7 +69,7 @@ class McpLogImpl implements McpLog {
 
     @Override
     public void error(Throwable t, String format, Object... params) {
-        logger.infof(t, format, params);
+        logger.errorf(t, format, params);
         send(LogLevel.ERROR, format, params);
     }
 


### PR DESCRIPTION
## Problem

`McpLogImpl.error(Throwable t, String format, Object... params)` calls `logger.infof(t, format, params)` instead of `logger.errorf(...)`. As a result, when an MCP feature logs a throwable via this overload:

- The **local JBoss Logger output** is emitted at **INFO** (and would be suppressed in environments that raise the log threshold above INFO).
- The **MCP notification sent to the client** is correctly at **ERROR**.

The two diverge, and the local error context on the server is silently downgraded — including under the production-default root-level thresholds that filter INFO.

## Fix

One-character change: `logger.infof` → `logger.errorf` in [`McpLogImpl.java:72`](https://github.com/quarkiverse/quarkus-mcp-server/blob/main/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpLogImpl.java#L72).

## Evidence this is a typo, not intent

The other three format-taking methods all align the local logger call with their level:

| Method | Local call | MCP notification |
|---|---|---|
| `info(format, params)` | `logger.infof` | `LogLevel.INFO` |
| `debug(format, params)` | `logger.debugf` | `LogLevel.DEBUG` |
| `error(format, params)` | `logger.errorf` | `LogLevel.ERROR` |
| `error(t, format, params)` **(before)** | `logger.infof` ❌ | `LogLevel.ERROR` |
| `error(t, format, params)` **(after)** | `logger.errorf` ✅ | `LogLevel.ERROR` |

`git blame` shows the line has been `log.infof(t, ...)` / `logger.infof(t, ...)` since before the streamable-transport refactor in #308 — a copy-paste from the `info(String, Object...)` method directly above it.

## Tests

I did not add a test. The existing `LoggingTest` suite asserts MCP notifications sent to the client — not local JBoss Logger output — so a notification-level assertion wouldn't catch this class of bug. Verifying the local level requires wiring a `java.util.logging` / JBoss Logger handler capture, which is more infrastructure than the fix itself. Happy to add one in a follow-up if maintainers prefer.

## Backport

Please backport to `1.10.x` and `1.11.x` for downstream IBM builds.
