### PR TITLE
docs: clarify SSE transport deprecation in index overview

### DIFF
--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -42,7 +42,7 @@ Quarkus analyzes your code at build time, not runtime. Tools, resources, and pro
 
 === Production Ready, Out of the Box
 
-* **Multiple transports** : STDIO, HTTP, SSE, WebSocket all supported
+* **Multiple transports** : STDIO, Streamable HTTP (preferred), SSE (deprecated in MCP 2025-03-26), and WebSocket all supported
 * **Enterprise integration** : Full CDI support with dependency injection, interceptors, and decorators
 * **Security built-in** : Integrate with Quarkus Security for authentication and authorization
 * **Reactive by default** : Built on Eclipse Vert.x for non-blocking I/O, also supports virtual threads


### PR DESCRIPTION
## Summary

The **Multiple transports** feature bullet on the overview page listed `STDIO, HTTP, SSE, WebSocket all supported` without indicating that SSE is deprecated in the MCP specification. MCP protocol version 2025-03-26 deprecated HTTP/SSE and introduced Streamable HTTP as its replacement — this is already documented in [concepts-transports.adoc](docs/modules/ROOT/pages/concepts-transports.adoc) but was not reflected in the overview page readers see first.

Before:
\`\`\`
* **Multiple transports** : STDIO, HTTP, SSE, WebSocket all supported
\`\`\`

After:
\`\`\`
* **Multiple transports** : STDIO, Streamable HTTP (preferred), SSE (deprecated in MCP 2025-03-26), and WebSocket all supported
\`\`\`

## Rationale

- Names **Streamable HTTP** explicitly (the 2025-03-26 replacement for HTTP/SSE) so readers don't confuse the two "HTTP" variants.
- Flags SSE as deprecated with the specific MCP spec version, matching the wording already in concepts-transports.adoc.
- Leaves WebSocket unchanged — still supported as an unofficial transport.
- Keeps the bullet concise (feature-list context).

## Test plan

- [ ] Verify the overview page at docs.quarkiverse.io renders the bullet correctly.
- [ ] No other pages use the exact string `STDIO, HTTP, SSE, WebSocket all supported`, so no follow-on edits needed.