### PR TITLE
docs: update Compliance and Testing note to reflect MCP conformance suite

### DIFF
--- a/docs/modules/ROOT/pages/concepts-mcp-protocol.adoc
+++ b/docs/modules/ROOT/pages/concepts-mcp-protocol.adoc
@@ -36,8 +36,8 @@ See the https://modelcontextprotocol.io/specification/{spec-version}[official MC
 
 === Compliance and Testing
 
-NOTE: The absence of an official "Compliance Test Suite" (similar to Java's TCK) makes it challenging to verify full specification compliance.
-The `quarkus-mcp-server` implementation is tested against real MCP clients and aims for maximum compatibility.
+The `quarkus-mcp-server` implementation is tested against the official https://github.com/modelcontextprotocol/conformance[MCP Conformance Test Suite] and against real MCP clients to maximize specification compliance.
+Conformance test integration lives in the `conformance/` module of the project.
 If you encounter any issues or discrepancies with the specification, please open an issue on https://github.com/quarkiverse/quarkus-mcp-server/issues.
 
 == Known Limitations


### PR DESCRIPTION
## Summary

The **Compliance and Testing** note in [concepts-mcp-protocol.adoc](docs/modules/ROOT/pages/concepts-mcp-protocol.adoc) currently claims that no official compliance test suite exists and that this project is tested only against real MCP clients. Both claims are now outdated:

1. An official [MCP Conformance Test Suite](https://github.com/modelcontextprotocol/conformance) exists and is actively maintained by the modelcontextprotocol organization — **v0.1.16** (March 2026), 142 commits, 17 releases.
2. This project already integrates with it via the [conformance/](conformance/) module, added in commit [\`59e07cf3\` "MCP conformance tests"](../../commit/59e07cf3).

Rewrite the paragraph to describe the actual testing approach and link to the official suite. Drop the \`NOTE\` admonition since the content is now informational rather than a caveat.

Before:
\`\`\`
NOTE: The absence of an official "Compliance Test Suite" (similar to Java's TCK) makes it challenging to verify full specification compliance.
The \`quarkus-mcp-server\` implementation is tested against real MCP clients and aims for maximum compatibility.
If you encounter any issues or discrepancies with the specification, please open an issue on https://github.com/quarkiverse/quarkus-mcp-server/issues.
\`\`\`

After:
\`\`\`
The \`quarkus-mcp-server\` implementation is tested against the official https://github.com/modelcontextprotocol/conformance[MCP Conformance Test Suite] and against real MCP clients to maximize specification compliance.
Conformance test integration lives in the \`conformance/\` module of the project.
If you encounter any issues or discrepancies with the specification, please open an issue on https://github.com/quarkiverse/quarkus-mcp-server/issues.
\`\`\`

## Test plan

- [ ] Verify the rendered page shows the updated paragraph (no \`NOTE\` block) at docs.quarkiverse.io.
- [ ] No other pages duplicate the outdated TCK-absence claim (verified by grep: only this one location).