### PR TITLE
docs: stop auto-linking file:/// URI example in Resources bullet

### DIFF
--- a/docs/modules/ROOT/pages/concepts-mcp-protocol.adoc
+++ b/docs/modules/ROOT/pages/concepts-mcp-protocol.adoc
@@ -278,7 +278,7 @@ See: https://modelcontextprotocol.io/specification/{spec-version}/server/tools[T
 
 **Resources** are data sources that clients can read and optionally subscribe to for updates.
 
-* Identified by URI (e.g., `file:///path/to/file`, `database://table/row`)
+* Identified by URI (e.g., `+file:///path/to/file+`, `database://table/row`)
 * Support static URIs and URI templates with variables
 * Can be text or binary content
 * Clients can subscribe to receive update notifications


### PR DESCRIPTION
## Summary

The Resources bullet under Connection Lifecycle in [concepts-mcp-protocol.adoc](docs/modules/ROOT/pages/concepts-mcp-protocol.adoc#L281) uses \`file:///path/to/file\` as an example URI. Even though the URI is wrapped in monospace backticks, AsciiDoc recognizes \`file://\` as a known URI scheme and renders it as a clickable link — backticks alone don't suppress the link macro for recognized schemes (http, https, ftp, irc, mailto, file).

Before:
\`\`\`
* Identified by URI (e.g., \`file:///path/to/file\`, \`database://table/row\`)
\`\`\`

After:
\`\`\`
* Identified by URI (e.g., \`+file:///path/to/file+\`, \`database://table/row\`)
\`\`\`

The \`+...+\` inline passthrough disables macro and attribute substitution on its content; the surrounding backticks keep the monospace rendering. The example now renders as literal monospace text rather than a clickable \`file://\` link.

The sibling example \`database://table/row\` uses an unrecognized scheme, so it already renders as literal text and needs no change.

## Test plan

- [ ] Rendered page shows the URI as monospace literal text, not a clickable link.
- [ ] No regressions on the rest of the Resources bullet list.