### PR TITLE
fix: downgrade client-error (4xx) log level from ERROR to WARN

### DIFF
--- a/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/SseMcpMessageHandler.java
+++ b/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/SseMcpMessageHandler.java
@@ -94,19 +94,19 @@ public class SseMcpMessageHandler extends McpMessageHandler<SseMcpRequest> imple
         HttpServerRequest request = ctx.request();
         String connectionId = ctx.pathParam("id");
         if (connectionId == null) {
-            LOG.errorf("Connection id is missing: %s", ctx.normalizedPath());
+            LOG.warnf("Connection id is missing: %s", ctx.normalizedPath());
             ctx.fail(400);
             return;
         }
         if (request.method() != HttpMethod.POST) {
             ctx.response().putHeader(HttpHeaders.ALLOW, "POST");
-            LOG.errorf("Invalid HTTP method %s [connectionId: %s]", ctx.request().method(), connectionId);
+            LOG.warnf("Invalid HTTP method %s [connectionId: %s]", ctx.request().method(), connectionId);
             ctx.fail(405);
             return;
         }
         McpConnectionBase conn = connectionManager.get(connectionId);
         if (conn == null) {
-            LOG.errorf("Connection not found: %s", connectionId);
+            LOG.warnf("Connection not found: %s", connectionId);
             ctx.fail(404);
             return;
         }
@@ -122,7 +122,7 @@ public class SseMcpMessageHandler extends McpMessageHandler<SseMcpRequest> imple
             json = Json.decodeValue(ctx.body().buffer());
         } catch (Exception e) {
             String msg = "Unable to parse the JSON message";
-            LOG.errorf(e, msg);
+            LOG.warnf(e, msg);
             connection.sendError(null, JsonRpcErrorCodes.PARSE_ERROR, msg);
             ctx.end();
             return;

--- a/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/StreamableHttpMcpMessageHandler.java
+++ b/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/StreamableHttpMcpMessageHandler.java
@@ -178,7 +178,7 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
         List<String> accepts = ctx.request().headers().getAll(HttpHeaders.ACCEPT);
         if (!accepts(accepts, "application/json")
                 || !accepts(accepts, "text/event-stream")) {
-            LOG.errorf("Invalid Accept header: %s", accepts);
+            LOG.warnf("Invalid Accept header: %s", accepts);
             ctx.fail(400);
             return;
         }
@@ -194,7 +194,7 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
                     // We don't care about non-existent session when auto-init is enabled
                     connection = initConnection(serverName);
                 } else {
-                    LOG.errorf("Mcp session not found: %s", mcpSessionId);
+                    LOG.warnf("Mcp session not found: %s", mcpSessionId);
                     ctx.fail(404);
                     return;
                 }
@@ -210,7 +210,7 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
             json = Json.decodeValue(ctx.body().buffer());
         } catch (Exception e) {
             String msg = "Unable to parse the JSON message";
-            LOG.errorf(e, msg);
+            LOG.warnf(e, msg);
             ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, "application/json");
             ctx.end(newError(null, JsonRpcErrorCodes.PARSE_ERROR, msg).toBuffer());
             return;
@@ -237,7 +237,7 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
         String mcpProtocolVersion = request.getHeader(MCP_PROTOCOL_VERSION_HEADER);
         if (mcpProtocolVersion != null
                 && !SUPPORTED_PROTOCOL_VERSIONS.contains(mcpProtocolVersion)) {
-            LOG.errorf("Invalid MCP protocol header: %s", mcpProtocolVersion);
+            LOG.warnf("Invalid MCP protocol header: %s", mcpProtocolVersion);
             ctx.fail(400);
             return;
         }
@@ -285,13 +285,13 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
         HttpServerRequest request = ctx.request();
         String mcpSessionId = request.getHeader(MCP_SESSION_ID_HEADER);
         if (mcpSessionId == null) {
-            LOG.errorf("%s header not found", MCP_SESSION_ID_HEADER);
+            LOG.warnf("%s header not found", MCP_SESSION_ID_HEADER);
             ctx.fail(405);
             return;
         }
         McpConnectionBase connection = connectionManager.get(mcpSessionId);
         if (connection == null) {
-            LOG.errorf("Mcp session not found: %s", mcpSessionId);
+            LOG.warnf("Mcp session not found: %s", mcpSessionId);
             ctx.fail(404);
             return;
         }
@@ -365,13 +365,13 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
         HttpServerRequest request = ctx.request();
         String mcpSessionId = request.getHeader(MCP_SESSION_ID_HEADER);
         if (mcpSessionId == null) {
-            LOG.errorf("Mcp session id header is missing: %s", ctx.normalizedPath());
+            LOG.warnf("Mcp session id header is missing: %s", ctx.normalizedPath());
             ctx.fail(404);
             return;
         }
         McpConnectionBase connection = connectionManager.get(mcpSessionId);
         if (connection == null) {
-            LOG.errorf("Mcp session not found: %s", mcpSessionId);
+            LOG.warnf("Mcp session not found: %s", mcpSessionId);
             ctx.fail(404);
             return;
         }

--- a/transports/stdio/runtime/src/main/java/io/quarkiverse/mcp/server/stdio/runtime/StdioMcpMessageHandler.java
+++ b/transports/stdio/runtime/src/main/java/io/quarkiverse/mcp/server/stdio/runtime/StdioMcpMessageHandler.java
@@ -115,7 +115,7 @@ public class StdioMcpMessageHandler extends McpMessageHandler<StdioMcpRequest> {
                                 json = Json.decodeValue(line);
                             } catch (Exception e) {
                                 String msg = "Unable to parse the JSON message";
-                                LOG.errorf(e, msg);
+                                LOG.warnf(e, msg);
                                 connection.sendError(null, JsonRpcErrorCodes.PARSE_ERROR, msg);
                                 return;
                             }


### PR DESCRIPTION
## Summary

All `LOG.errorf()` calls in transport message handlers that correspond to **client-side errors** (4xx status codes, malformed JSON, missing/invalid headers, unknown sessions) are changed to `LOG.warnf()`.

These are expected client behaviors — not server errors — and logging them at ERROR level causes false alerts in production monitoring systems (e.g., OpsGenie via Datadog).

## Changes

### `StreamableHttpMcpMessageHandler.java` (8 changes)
- `"Invalid Accept header"` (400) → WARN
- `"Mcp session not found"` (404, 3 occurrences) → WARN
- `"Unable to parse the JSON message"` (JSON-RPC error) → WARN
- `"Invalid MCP protocol header"` (400) → WARN
- `"Mcp-Session-Id header not found"` (405) → WARN
- `"Mcp session id header is missing"` (404) → WARN

### `SseMcpMessageHandler.java` (4 changes)
- `"Connection id is missing"` (400) → WARN
- `"Invalid HTTP method"` (405) → WARN
- `"Connection not found"` (404) → WARN
- `"Unable to parse the JSON message"` (JSON-RPC error) → WARN

### `StdioMcpMessageHandler.java` (1 change)
- `"Unable to parse the JSON message"` (JSON-RPC error) → WARN
- Note: `"Error reading stdio"` (genuine I/O failure) intentionally **kept at ERROR**

Fixes #760