### PR TITLE
Add a handler to intercept security failures after a Streamable HTTP is established

### DIFF
--- a/transports/http/authorization-integration-tests/src/test/java/io/quarkiverse/mcp/server/authorization/it/ServerFeaturesTest.java
+++ b/transports/http/authorization-integration-tests/src/test/java/io/quarkiverse/mcp/server/authorization/it/ServerFeaturesTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 import org.awaitility.Awaitility;
 import org.htmlunit.TextPage;
@@ -83,8 +84,8 @@ class ServerFeaturesTest {
     void testToolExpiredToken() throws Exception {
         String accessToken = getAccessToken();
 
-        Awaitility.await().atMost(6, java.util.concurrent.TimeUnit.SECONDS)
-                .pollInterval(1, java.util.concurrent.TimeUnit.SECONDS)
+        Awaitility.await().atMost(6, TimeUnit.SECONDS)
+                .pollInterval(1, TimeUnit.SECONDS)
                 .untilAsserted(() -> {
                     McpAssured.newStreamableClient()
                             .setAdditionalHeaders(msg -> MultiMap.caseInsensitiveMultiMap()
@@ -110,6 +111,29 @@ class ServerFeaturesTest {
                 })
                 .build()
                 .connect();
+    }
+
+    @Test
+    void testExpiredTokenAfterConnect() throws Exception {
+        String accessToken = getAccessToken();
+
+        McpStreamableTestClient client = McpAssured.newStreamableClient()
+                .setAdditionalHeaders(msg -> MultiMap.caseInsensitiveMultiMap()
+                        .add("Authorization", "Bearer " + accessToken))
+                .build()
+                .connect();
+
+        Awaitility.await().atMost(6, TimeUnit.SECONDS)
+                .pollInterval(1, TimeUnit.SECONDS)
+                .untilAsserted(() -> {
+                    client.when()
+                            .toolsCall("alpha-user-name-provider")
+                            .withErrorAssert(error -> {
+                                assertTrue(error.message().contains("AuthenticationFailedException"));
+                            })
+                            .send()
+                            .thenAssertResults();
+                });
     }
 
     @Test

--- a/transports/http/deployment/src/main/java/io/quarkiverse/mcp/server/http/deployment/HttpMcpServerProcessor.java
+++ b/transports/http/deployment/src/main/java/io/quarkiverse/mcp/server/http/deployment/HttpMcpServerProcessor.java
@@ -75,6 +75,10 @@ public class HttpMcpServerProcessor {
                     .withRouteCustomizer(recorder.addBodyHandler(bodyHandler.getHandler()))
                     .withRequestHandler(recorder.createMcpEndpointHandler(endpoint.serverName))
                     .build());
+            routes.produce(RouteBuildItem.newFrameworkRoute(endpoint.mcpPath)
+                    .withRequestHandler(recorder.createAuthFailureHandler())
+                    .asFailureRoute()
+                    .build());
             // SSE/HTTP transport
             routes.produce(RouteBuildItem.newFrameworkRoute(endpoint.ssePath)
                     .withRequestHandler(recorder.createSseEndpointHandler(endpoint.mcpPath, endpoint.serverName))

--- a/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/HttpMcpServerRecorder.java
+++ b/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/HttpMcpServerRecorder.java
@@ -15,6 +15,7 @@ import java.util.function.Function;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
 
+import io.quarkiverse.mcp.server.JsonRpcErrorCodes;
 import io.quarkiverse.mcp.server.http.runtime.config.McpHttpServersBuildTimeConfig;
 import io.quarkiverse.mcp.server.http.runtime.config.McpHttpServersRuntimeConfig;
 import io.quarkiverse.mcp.server.runtime.ConnectionManager;
@@ -25,6 +26,9 @@ import io.quarkus.arc.ArcContainer;
 import io.quarkus.arc.SyntheticCreationalContext;
 import io.quarkus.runtime.RuntimeValue;
 import io.quarkus.runtime.annotations.Recorder;
+import io.quarkus.security.AuthenticationException;
+import io.quarkus.security.ForbiddenException;
+import io.quarkus.security.UnauthorizedException;
 import io.smallrye.config.SmallRyeConfig;
 import io.vertx.core.Handler;
 import io.vertx.core.MultiMap;
@@ -33,6 +37,7 @@ import io.vertx.core.http.HttpHeaders;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.http.HttpServerRequest;
 import io.vertx.core.http.HttpServerResponse;
+import io.vertx.core.json.JsonObject;
 import io.vertx.core.net.impl.ConnectionBase;
 import io.vertx.ext.web.Route;
 import io.vertx.ext.web.RoutingContext;
@@ -98,6 +103,37 @@ public class HttpMcpServerRecorder {
                     LOG.debugf("Invalid HTTP method %s [server: %s]", method, serverName);
                     ctx.response().putHeader(HttpHeaders.ALLOW, "GET, POST, DELETE");
                     ctx.fail(405);
+                }
+            }
+        };
+    }
+
+    public Handler<RoutingContext> createAuthFailureHandler() {
+        return new Handler<RoutingContext>() {
+            @Override
+            public void handle(RoutingContext ctx) {
+                Throwable failure = ctx.failure();
+                if (failure instanceof AuthenticationException
+                        || failure instanceof UnauthorizedException
+                        || failure instanceof ForbiddenException) {
+                    ctx.response().setStatusCode(failure instanceof ForbiddenException ? 403 : 401);
+                    if (!ctx.request().isEnded()) {
+                        ctx.request().resume();
+                    }
+                    ctx.request().body().onComplete(ar -> {
+                        if (ar.succeeded() && ar.result() != null) {
+                            Integer id = new JsonObject(ar.result()).getInteger("id");
+                            JsonObject error = new JsonObject()
+                                    .put("jsonrpc", "2.0")
+                                    .put("id", id)
+                                    .put("error", new JsonObject()
+                                            .put("code", JsonRpcErrorCodes.SECURITY_ERROR)
+                                            .put("message", failure.toString()));
+                            ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, "application/json").end(error.toBuffer());
+                        }
+                    });
+                } else {
+                    ctx.next();
                 }
             }
         };


### PR DESCRIPTION
Myself and Claude tried many things :-), this one looks not bad to me - the security exception may be thrown at the OIDC level for various reasons after a successful connection, so the proposed handler would correctly convert such failures to JSON-RPC responses, thus avoiding MCP clients hanging.

The proposed test was nearly working even before the PR, I just did not realize the MCP client was hanging - no security issue at all - all works as expected at the security level with respect to this test. CC @cescoffier 