### PR TITLE
docs: fix copyedit issues across mcp-server pages

### DIFF
--- a/docs/modules/ROOT/pages/concepts-architecture.adoc
+++ b/docs/modules/ROOT/pages/concepts-architecture.adoc
@@ -25,7 +25,7 @@ All MCP features are CDI beans, enabling dependency injection, interceptors, and
 
 **Reactive Foundation**::
 Built on SmallRye Mutiny and Eclipse Vert.x for non-blocking I/O, supporting both imperative and reactive programming models. Async operations don't block threads.
-The MCP server also support virtual threads when running on Java 21+, allowing for a more traditional blocking programming style without sacrificing scalability.
+The MCP server also supports virtual threads when running on Java 21+, allowing for a more traditional blocking programming style without sacrificing scalability.
 
 == CDI Integration
 
@@ -291,7 +291,7 @@ However, if the HTTP transport is used then all MCP requests will have the same 
 
 == Schema Generation
 
-JSON schemas for tools are generated at **runtime**  using the https://github.com/victools/jsonschema-generator[Victools JSON Schema Generator].
+JSON schemas for tools are generated at **runtime** using the https://github.com/victools/jsonschema-generator[Victools JSON Schema Generator].
 
 
 === Caching schemas

--- a/docs/modules/ROOT/pages/concepts-transports.adoc
+++ b/docs/modules/ROOT/pages/concepts-transports.adoc
@@ -9,7 +9,7 @@ This page explains the transport mechanisms available for MCP communication.
 
 The MCP specification currently defines two standard transports for client-server communication.
 The `stdio` transport starts an MCP server as a subprocess and communicates over standard `in` and `out`.
-The `HTTP` transports connects to a running HTTP server.
+The `HTTP` transport connects to a running HTTP server.
 The `HTTP` transport is defined in two variants: the "Streamable HTTP" variant (introduced in the protocol version 2025-03-26) replaces the "HTTP/SSE" transport (introduced in protocol version 2024-11-05).
 The "HTTP/SSE" transport is considered deprecated, but it's still supported by most clients and servers.
 

--- a/docs/modules/ROOT/pages/guides-hibernate-validator.adoc
+++ b/docs/modules/ROOT/pages/guides-hibernate-validator.adoc
@@ -5,8 +5,8 @@ include::./includes/attributes.adoc[]
 
 The extension provides integration with Hibernate Validator, a Jakarta Validation implementation.
 First, it adds the `quarkus-hibernate-validator` dependency so that all `@Tool` methods with constraint annotations are validated when executed.
-The resulting constraint violations are transformed in a procotol error message.
-Additionaly, the extension adds a transitive dependency on `com.github.victools:jsonschema-module-jakarta-validation` which means that Jakarta Validation annotations will be considered when generating the input schema for `@Tool` methods.
+The resulting constraint violations are transformed in a protocol error message.
+Additionally, the extension adds a transitive dependency on `com.github.victools:jsonschema-module-jakarta-validation` which means that Jakarta Validation annotations will be considered when generating the input schema for `@Tool` methods.
 
 If you want to use the Hibernate Validator integration in your application you'll need to add the `io.quarkiverse.mcp:quarkus-mcp-server-hibernate-validator` extension to your build file first.
 For instance, with Maven, add the following dependency to your POM file:
@@ -105,7 +105,7 @@ By default, a `ConstraintViolationException` is converted into:
 
 The message contains `ConstraintViolation#getPropertyPath()` and `ConstraintViolation#getMessage()` for each violation.
 
-However, it possible to implement a custom CDI bean that implements the `io.quarkiverse.mcp.server.hibernate.validator.ConstraintViolationConverter` interface and supply some custom logic.
+However, it is possible to implement a custom CDI bean that implements the `io.quarkiverse.mcp.server.hibernate.validator.ConstraintViolationConverter` interface and supply some custom logic.
 
 [source,java]
 ----


### PR DESCRIPTION
> **🔁 Backport request: `triage/backport-1.11`.** Maintainers — please apply the `triage/backport-1.11` label so this is picked up by the backport workflow. (I tried to self-label and got `does not have the correct permissions to execute AddLabelsToLabelable`.)
>
> Context: RHBQ 3.33 ships MCP Server `1.10.x`; there is no `triage/backport-1.10` label. We will keep a downstream bandaid in place for 1.10 until RHBQ moves to 1.11.

## Summary

Six small copyedit fixes across three pages, surfaced by an automated LanguageTool run over `docs/modules/ROOT/pages/`. All are content-only; no behavior change.

## Files

- `docs/modules/ROOT/pages/concepts-architecture.adoc`
    - L28: `also support virtual threads` → `also supports`
    - L294: `are generated at **runtime**  using` → single space
- `docs/modules/ROOT/pages/concepts-transports.adoc`
    - L12: `The \`HTTP\` transports connects` → `transport connects` (the next sentence already uses the singular form)
- `docs/modules/ROOT/pages/guides-hibernate-validator.adoc`
    - L8: `procotol` → `protocol`
    - L9: `Additionaly` → `Additionally`
    - L108: `However, it possible to implement` → `it is possible`
