### PR TITLE
docs(server): add intro before per-server tools example

### DIFF
--- a/docs/modules/ROOT/pages/guides-multiple-servers.adoc
+++ b/docs/modules/ROOT/pages/guides-multiple-servers.adoc
@@ -303,6 +303,8 @@ quarkus.http.auth.permission.public.paths=/public/mcp/*
 quarkus.http.auth.permission.public.policy=permit
 ----
 
+Define the per-server tools:
+
 [source,java]
 ----
 public class MyFeatures {


### PR DESCRIPTION
> **🔁 Backport request: `triage/backport-1.11`.** Maintainers — please apply the `triage/backport-1.11` label so this is picked up by the backport workflow. (I tried to self-label and got `does not have the correct permissions to execute AddLabelsToLabelable`.)

## Summary

The "Public and Secured Servers" section had two adjacent `[source,...]` blocks (the `application.properties` config and the `MyFeatures` Java class) with no introducing sentence between them. Add an imperative-voice intro so the reader knows the second block defines the per-server `@Tool` / `@McpServer` pattern.

Mirrors the imperative-voice pattern accepted in PR #2430 of `quarkus-langchain4j`.

Content-only change; no behavior change.

## Files

- `docs/modules/ROOT/pages/guides-multiple-servers.adoc` (1 line inserted)
