### PR TITLE
Add an extension to deal with OIDC specific MCP authorization requirements

### DIFF
--- a/oidc/deployment/pom.xml
+++ b/oidc/deployment/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkiverse.mcp</groupId>
+        <artifactId>quarkus-mcp-server-oidc-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>quarkus-mcp-server-oidc-deployment</artifactId>
+    <name>Quarkus MCP Server - OIDC - Deployment</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-oidc-deployment</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.mcp</groupId>
+            <artifactId>quarkus-mcp-server-http-deployment</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.mcp</groupId>
+            <artifactId>quarkus-mcp-server-oidc</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>io.quarkus</groupId>
+                                    <artifactId>quarkus-extension-processor</artifactId>
+                                    <version>${quarkus.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/oidc/deployment/src/main/java/io/quarkiverse/mcp/server/oidc/deployment/OidcMcpServerProcessor.java
+++ b/oidc/deployment/src/main/java/io/quarkiverse/mcp/server/oidc/deployment/OidcMcpServerProcessor.java
@@ -1,0 +1,49 @@
+package io.quarkiverse.mcp.server.oidc.deployment;
+
+import static io.quarkus.deployment.annotations.ExecutionTime.RUNTIME_INIT;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import io.quarkiverse.mcp.server.http.runtime.config.McpHttpServerBuildTimeConfig;
+import io.quarkiverse.mcp.server.http.runtime.config.McpHttpServersBuildTimeConfig;
+import io.quarkiverse.mcp.server.oidc.runtime.OidcMcpServerRecorder;
+import io.quarkus.deployment.annotations.BuildProducer;
+import io.quarkus.deployment.annotations.BuildStep;
+import io.quarkus.deployment.annotations.Record;
+import io.quarkus.deployment.builditem.FeatureBuildItem;
+import io.quarkus.vertx.http.deployment.HttpRootPathBuildItem;
+import io.quarkus.vertx.http.deployment.spi.RouteBuildItem;
+
+public class OidcMcpServerProcessor {
+
+    @BuildStep
+    FeatureBuildItem feature() {
+        return new FeatureBuildItem("mcp-server-oidc");
+    }
+
+    @Record(RUNTIME_INIT)
+    @BuildStep
+    void registerInsufficientScopeHandler(
+            McpHttpServersBuildTimeConfig config,
+            HttpRootPathBuildItem httpRootPath,
+            OidcMcpServerRecorder recorder,
+            BuildProducer<RouteBuildItem> routes) {
+
+        List<String> mcpPaths = new ArrayList<>();
+        for (Map.Entry<String, McpHttpServerBuildTimeConfig> e : config.servers().entrySet()) {
+            if (e.getValue().http().enabled()) {
+                mcpPaths.add(httpRootPath.relativePath(e.getValue().http().rootPath()));
+            }
+        }
+
+        if (!mcpPaths.isEmpty()) {
+            routes.produce(RouteBuildItem.newAbsoluteRoute("/*")
+                    .asFailureRoute()
+                    .withRequestHandler(
+                            recorder.createInsufficientScopeHandler(mcpPaths, httpRootPath.getRootPath()))
+                    .build());
+        }
+    }
+}

--- a/oidc/pom.xml
+++ b/oidc/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkiverse.mcp</groupId>
+        <artifactId>quarkus-mcp-server-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+	<relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>quarkus-mcp-server-oidc-parent</artifactId>
+    <packaging>pom</packaging>
+    <name>Quarkus MCP Server - OIDC - Parent</name>
+
+    <modules>
+        <module>deployment</module>
+        <module>runtime</module>
+    </modules>
+</project>

--- a/oidc/runtime/pom.xml
+++ b/oidc/runtime/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkiverse.mcp</groupId>
+        <artifactId>quarkus-mcp-server-oidc-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+    <artifactId>quarkus-mcp-server-oidc</artifactId>
+    <name>Quarkus MCP Server - OIDC - Runtime</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>io.quarkiverse.mcp</groupId>
+            <artifactId>quarkus-mcp-server-http</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-oidc</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <version>${quarkus.version}</version>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>extension-descriptor</goal>
+                        </goals>
+                        <configuration>
+                            <deployment>
+                                ${project.groupId}:${project.artifactId}-deployment:${project.version}</deployment>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>default-compile</id>
+                        <configuration>
+                            <annotationProcessorPaths>
+                                <path>
+                                    <groupId>io.quarkus</groupId>
+                                    <artifactId>quarkus-extension-processor</artifactId>
+                                    <version>${quarkus.version}</version>
+                                </path>
+                            </annotationProcessorPaths>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/oidc/runtime/src/main/java/io/quarkiverse/mcp/server/oidc/runtime/InsufficientScopeFailureHandler.java
+++ b/oidc/runtime/src/main/java/io/quarkiverse/mcp/server/oidc/runtime/InsufficientScopeFailureHandler.java
@@ -1,0 +1,99 @@
+package io.quarkiverse.mcp.server.oidc.runtime;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Set;
+
+import org.jboss.logging.Logger;
+
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.quarkus.oidc.OidcTenantConfig;
+import io.quarkus.oidc.common.runtime.OidcCommonUtils;
+import io.quarkus.oidc.common.runtime.OidcConstants;
+import io.quarkus.oidc.runtime.OidcUtils;
+import io.quarkus.security.ForbiddenException;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
+
+public class InsufficientScopeFailureHandler implements Handler<RoutingContext> {
+
+    private static final Logger LOG = Logger.getLogger(InsufficientScopeFailureHandler.class);
+
+    private final List<String> mcpPaths;
+    private final String rootPath;
+
+    public InsufficientScopeFailureHandler(List<String> mcpPaths, String rootPath) {
+        this.mcpPaths = mcpPaths;
+        this.rootPath = rootPath;
+    }
+
+    @Override
+    public void handle(RoutingContext ctx) {
+        if (!(ctx.failure() instanceof ForbiddenException) || !isMcpPath(ctx.normalizedPath())) {
+            ctx.next();
+            return;
+        }
+
+        OidcTenantConfig oidcConfig = ctx.get(OidcTenantConfig.class.getName());
+        if (oidcConfig == null
+                || !oidcConfig.resourceMetadata().enabled()
+                || oidcConfig.resourceMetadata().scopes().isEmpty()) {
+            ctx.next();
+            return;
+        }
+
+        Set<String> scopes = oidcConfig.resourceMetadata().scopes().get();
+        StringBuilder wwwAuth = new StringBuilder(oidcConfig.token().authorizationScheme());
+        wwwAuth.append(" error=\"insufficient_scope\"");
+        wwwAuth.append(", scope=\"").append(String.join(" ", scopes)).append("\"");
+
+        String resourceMetadataUrl = buildResourceMetadataUrl(ctx, oidcConfig);
+        wwwAuth.append(", resource_metadata=\"").append(resourceMetadataUrl).append("\"");
+
+        LOG.debugf("Returning 403 with insufficient_scope challenge for tenant %s",
+                oidcConfig.tenantId().orElse(OidcUtils.DEFAULT_TENANT_ID));
+
+        ctx.response()
+                .putHeader(HttpHeaderNames.WWW_AUTHENTICATE.toString(), wwwAuth.toString())
+                .setStatusCode(403)
+                .end();
+    }
+
+    private boolean isMcpPath(String path) {
+        for (String mcpPath : mcpPaths) {
+            if (path.equals(mcpPath) || path.startsWith(mcpPath + "/")) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String buildResourceMetadataUrl(RoutingContext ctx, OidcTenantConfig oidcConfig) {
+        String metadataPath = getResourceMetadataPath(oidcConfig);
+        String authority = URI.create(ctx.request().absoluteURI()).getAuthority();
+        String scheme = oidcConfig.resourceMetadata().forceHttpsScheme() ? "https" : ctx.request().scheme();
+        return scheme + "://" + authority + metadataPath;
+    }
+
+    private String getResourceMetadataPath(OidcTenantConfig oidcConfig) {
+        String configuredResource = oidcConfig.resourceMetadata().resource().orElse("");
+        String relativePath;
+
+        if (configuredResource.startsWith("http")) {
+            relativePath = URI.create(configuredResource).getRawPath();
+        } else {
+            relativePath = configuredResource;
+        }
+
+        String path = OidcUtils.getRootPath(rootPath) + OidcConstants.RESOURCE_METADATA_WELL_KNOWN_PATH;
+        if (!relativePath.isEmpty()) {
+            if (!"/".equals(relativePath)) {
+                path += OidcCommonUtils.prependSlash(relativePath);
+            }
+        } else if (!OidcUtils.DEFAULT_TENANT_ID.equals(oidcConfig.tenantId().orElse(OidcUtils.DEFAULT_TENANT_ID))) {
+            path += OidcCommonUtils.prependSlash(oidcConfig.tenantId().get().toLowerCase());
+        }
+
+        return path;
+    }
+}

--- a/oidc/runtime/src/main/java/io/quarkiverse/mcp/server/oidc/runtime/OidcMcpServerRecorder.java
+++ b/oidc/runtime/src/main/java/io/quarkiverse/mcp/server/oidc/runtime/OidcMcpServerRecorder.java
@@ -1,0 +1,15 @@
+package io.quarkiverse.mcp.server.oidc.runtime;
+
+import java.util.List;
+
+import io.quarkus.runtime.annotations.Recorder;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
+
+@Recorder
+public class OidcMcpServerRecorder {
+
+    public Handler<RoutingContext> createInsufficientScopeHandler(List<String> mcpPaths, String rootPath) {
+        return new InsufficientScopeFailureHandler(mcpPaths, rootPath);
+    }
+}

--- a/oidc/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/oidc/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -1,0 +1,10 @@
+name: MCP Server - OIDC
+description: OIDC integration for the MCP server.
+metadata:
+  keywords:
+    - mcp, oidc
+  guide: https://docs.quarkiverse.io/quarkus-mcp-server/dev/
+  categories:
+    - "security"
+    - "oidc"
+  status: "experimental"

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
         <module>devtools/stdio-sse-proxy</module>
         <module>cli-adapter</module>
         <module>hibernate-validator</module>
+        <module>oidc</module>
         <module>schema-validator</module>
         <module>relocations/sse/deployment</module>
         <module>relocations/sse/runtime</module>

--- a/transports/http/authorization-integration-tests/pom.xml
+++ b/transports/http/authorization-integration-tests/pom.xml
@@ -45,6 +45,24 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>io.quarkiverse.mcp</groupId>
+            <artifactId>quarkus-mcp-server-oidc</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkiverse.mcp</groupId>
+            <artifactId>quarkus-mcp-server-oidc-deployment</artifactId>
+            <version>${project.version}</version>
+            <type>pom</type>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>*</groupId>
+                    <artifactId>*</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
             <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit</artifactId>
             <scope>test</scope>

--- a/transports/http/authorization-integration-tests/src/main/resources/application.properties
+++ b/transports/http/authorization-integration-tests/src/main/resources/application.properties
@@ -18,6 +18,7 @@ quarkus.oidc.beta.token.audience=quarkus-mcp-alpha
 quarkus.oidc.beta.roles.role-claim-path=scope
 quarkus.oidc.beta.resource-metadata.enabled=true
 quarkus.oidc.beta.resource-metadata.resource=beta/mcp
+quarkus.oidc.beta.resource-metadata.scopes=phone
 quarkus.oidc.beta.resource-metadata.force-https-scheme=false
 
 quarkus.oidc.code-flow.auth-server-url=${quarkus.oidc.auth-server-url}

--- a/transports/http/authorization-integration-tests/src/test/java/io/quarkiverse/mcp/server/authorization/it/ServerFeaturesTest.java
+++ b/transports/http/authorization-integration-tests/src/test/java/io/quarkiverse/mcp/server/authorization/it/ServerFeaturesTest.java
@@ -166,6 +166,7 @@ class ServerFeaturesTest {
     @Test
     void testBetaToolWithoutPhoneScope() throws Exception {
         String accessToken = getAccessToken();
+        String authServerUrl = given().get("/auth-server-url").then().statusCode(200).extract().asString();
 
         McpAssured.newStreamableClient()
                 .setMcpPath("/beta/mcp")
@@ -173,6 +174,24 @@ class ServerFeaturesTest {
                         .add("Authorization", "Bearer " + accessToken))
                 .setExpectConnectFailure(r -> {
                     assertEquals(403, r.statusCode());
+
+                    String wwwAuthenticate = r.firstHeader("www-authenticate");
+                    assertNotNull(wwwAuthenticate, "WWW-Authenticate header missing from 403 response");
+
+                    assertTrue(wwwAuthenticate.contains("error=\"insufficient_scope\""),
+                            "Expected error=\"insufficient_scope\" in: " + wwwAuthenticate);
+                    assertTrue(wwwAuthenticate.contains("scope=\"phone\""),
+                            "Expected scope=\"phone\" in: " + wwwAuthenticate);
+
+                    String resourceMetadataUrl = extractResourceMetadata(wwwAuthenticate);
+                    assertNotNull(resourceMetadataUrl,
+                            "Expected resource_metadata in: " + wwwAuthenticate);
+
+                    String metadata = given().get(resourceMetadataUrl).then().statusCode(200).extract().asString();
+                    JsonObject metadataJson = new JsonObject(metadata);
+                    JsonArray authServers = metadataJson.getJsonArray("authorization_servers");
+                    assertEquals(1, authServers.size());
+                    assertEquals(authServerUrl, authServers.getString(0));
                 })
                 .build()
                 .connect();


### PR DESCRIPTION
To address a `SHOULD` recommendation at https://modelcontextprotocol.io/specification/draft/basic/authorization#runtime-insufficient-scope-errors, where `403` is accompanied by `WWW-Authenticate` with a list of expected scopes and a link to the OAuth2 resource metadata handler (that would typically be done only for `401`), an OIDC specific `ForbiddenException` handler has to be provided. This handler can't really be shipped directly with the `transports/http`.

Therefore, a `quarkus-mcp-server-oidc` extension is proposed, similarly to how it is done with the hibernate validator.

Please note that even though this extension only holds a Vert.x failure handler for now, we can definitely make it more feature-rich going forward.

For example, one thing I've been thinking about is, instead of asking users to add OIDC configuration manually, this extension might be able to listen to Streambale MCP route registration events and register an OIDC handler automatically.

I hope we will be able to do something interesting in this extension in the future.