### PR TITLE
core: fix Content.Annotations/Resource#annotations()

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/McpServerProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/McpServerProcessor.java
@@ -772,10 +772,16 @@ class McpServerProcessor {
         if (annotationsValue != null) {
             AnnotationInstance annotationsAnnotation = annotationsValue.asNested();
             AnnotationValue audienceValue = annotationsAnnotation.value("audience");
+            List<Role> audience = List.of();
+            if (audienceValue != null) {
+                audience = new ArrayList<>();
+                for (String r : audienceValue.asEnumArray()) {
+                    audience.add(Role.valueOf(r));
+                }
+            }
             AnnotationValue lastModifiedValue = annotationsAnnotation.value("lastModified");
             AnnotationValue priorityValue = annotationsAnnotation.value("priority");
-            return new Content.Annotations(audienceValue != null ? Role.valueOf(audienceValue.asEnum()) : null,
-                    lastModifiedValue != null ? lastModifiedValue.asString() : null,
+            return new Content.Annotations(audience, lastModifiedValue != null ? lastModifiedValue.asString() : null,
                     priorityValue != null ? priorityValue.asDouble() : null);
         }
         return null;
@@ -1577,11 +1583,12 @@ class McpServerProcessor {
                 LocalVar resourceAnnotations;
                 if ((featureMethod.isResource() || featureMethod.isResourceTemplate())
                         && featureMethod.getResourceAnnotations() != null) {
-                    // new Annotations(Role audience, String lastModified, Double priority)
+                    // new Annotations(List<Role> audience, String lastModified, Double priority)
                     Content.Annotations annotations = featureMethod.getResourceAnnotations();
                     resourceAnnotations = bc.localVar("resourceAnnotations", bc.new_(
-                            ConstructorDesc.of(Content.Annotations.class, Role.class, String.class, Double.class),
-                            annotations.audience() == null ? Const.ofNull(Role.class) : Const.of(annotations.audience()),
+                            ConstructorDesc.of(Content.Annotations.class, List.class, String.class, Double.class),
+                            annotations.audience() == null ? Const.ofNull(List.class)
+                                    : bc.listOf(annotations.audience(), Const::of),
                             annotations.lastModified() == null ? Const.ofNull(String.class)
                                     : Const.of(annotations.lastModified()),
                             annotations.priority() == null ? Const.ofNull(Double.class) : Const.of(annotations.priority())));

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/Content.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/Content.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.mcp.server;
 
+import java.util.List;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -85,7 +86,11 @@ public sealed interface Content
      * @param lastModified (may be {@code null})
      * @param priority (may be {@code null})
      */
-    public record Annotations(Role audience, String lastModified, Double priority) {
+    public record Annotations(List<Role> audience, String lastModified, Double priority) {
+
+        public Annotations(Role audience, String lastModified, Double priority) {
+            this(List.of(audience), lastModified, priority);
+        }
     }
 
     public enum Type {

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/Resource.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/Resource.java
@@ -93,7 +93,7 @@ public @interface Resource {
     @Target(ElementType.ANNOTATION_TYPE)
     public @interface Annotations {
 
-        Role audience();
+        Role[] audience();
 
         String lastModified() default "";
 

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/Contents.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/Contents.java
@@ -1,6 +1,8 @@
 package io.quarkiverse.mcp.server.runtime;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -15,6 +17,7 @@ import io.quarkiverse.mcp.server.ResourceLink;
 import io.quarkiverse.mcp.server.Role;
 import io.quarkiverse.mcp.server.TextContent;
 import io.quarkiverse.mcp.server.TextResourceContents;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 public final class Contents {
@@ -65,9 +68,16 @@ public final class Contents {
         if (annotations == null) {
             return null;
         }
-        return new Content.Annotations(
-                annotations.containsKey("audience") ? Role.valueOf(annotations.getString("audience").toUpperCase()) : null,
-                annotations.getString("lastModified"), annotations.getDouble("priority"));
+        List<Role> audience = List.of();
+        JsonArray audienceValue = annotations.getJsonArray("audience");
+        if (audienceValue != null) {
+            audience = new ArrayList<Role>(audienceValue.size());
+            for (int i = 0; i < audienceValue.size(); i++) {
+                audience.add(Role.valueOf(audienceValue.getString(i).toUpperCase()));
+            }
+        }
+        return new Content.Annotations(List.copyOf(audience), annotations.getString("lastModified"),
+                annotations.getDouble("priority"));
     }
 
 }

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/resources/MultiRoleAudienceResources.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/resources/MultiRoleAudienceResources.java
@@ -1,0 +1,62 @@
+package io.quarkiverse.mcp.server.test.resources;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import io.quarkiverse.mcp.server.Content;
+import io.quarkiverse.mcp.server.RequestUri;
+import io.quarkiverse.mcp.server.Resource;
+import io.quarkiverse.mcp.server.Resource.Annotations;
+import io.quarkiverse.mcp.server.ResourceManager;
+import io.quarkiverse.mcp.server.ResourceResponse;
+import io.quarkiverse.mcp.server.ResourceTemplate;
+import io.quarkiverse.mcp.server.ResourceTemplateManager;
+import io.quarkiverse.mcp.server.Role;
+import io.quarkiverse.mcp.server.TextResourceContents;
+
+public class MultiRoleAudienceResources {
+
+    @Resource(uri = "file:///multi/alpha", annotations = @Annotations(audience = { Role.USER,
+            Role.ASSISTANT }, priority = 0.6))
+    TextResourceContents alpha(RequestUri uri) {
+        return TextResourceContents.create(uri.value(), "alpha");
+    }
+
+    @ResourceTemplate(uriTemplate = "file:///multi/template/{id}", annotations = @Annotations(audience = { Role.ASSISTANT,
+            Role.USER }, priority = 0.7))
+    TextResourceContents template(String id) {
+        return TextResourceContents.create("file:///multi/template/" + id, "template-" + id);
+    }
+
+    @Singleton
+    public static class ProgrammaticRegistrar {
+
+        @Inject
+        ResourceManager resourceManager;
+
+        @Inject
+        ResourceTemplateManager resourceTemplateManager;
+
+        void registerResource() {
+            resourceManager.newResource("programmatic_multi")
+                    .setUri("file:///multi/programmatic")
+                    .setDescription("Programmatic multi-role resource")
+                    .setAnnotations(new Content.Annotations(List.of(Role.ASSISTANT, Role.USER), null, 0.8))
+                    .setHandler(args -> new ResourceResponse(
+                            List.of(TextResourceContents.create(args.requestUri().value(), "programmatic"))))
+                    .register();
+        }
+
+        void registerResourceTemplate() {
+            resourceTemplateManager.newResourceTemplate("programmatic_template_multi")
+                    .setUriTemplate("file:///multi/programmatic_template/{name}")
+                    .setDescription("Programmatic multi-role resource template")
+                    .setAnnotations(new Content.Annotations(List.of(Role.USER, Role.ASSISTANT), null, 0.9))
+                    .setHandler(args -> new ResourceResponse(
+                            List.of(TextResourceContents.create(args.requestUri().value(), args.args().get("name")))))
+                    .register();
+        }
+    }
+}

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/resources/MultiRoleAudienceTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/resources/MultiRoleAudienceTest.java
@@ -1,0 +1,135 @@
+package io.quarkiverse.mcp.server.test.resources;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.Content;
+import io.quarkiverse.mcp.server.McpServer;
+import io.quarkiverse.mcp.server.ResourceManager;
+import io.quarkiverse.mcp.server.ResourceTemplateManager;
+import io.quarkiverse.mcp.server.Role;
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkiverse.mcp.server.test.McpAssured.McpStreamableTestClient;
+import io.quarkiverse.mcp.server.test.McpAssured.ResourceInfo;
+import io.quarkiverse.mcp.server.test.McpAssured.ResourceTemplateInfo;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+public class MultiRoleAudienceTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .withApplicationRoot(
+                    root -> root.addClasses(MultiRoleAudienceResources.class,
+                            MultiRoleAudienceResources.ProgrammaticRegistrar.class));
+
+    @Inject
+    ResourceManager resourceManager;
+
+    @Inject
+    ResourceTemplateManager resourceTemplateManager;
+
+    @Inject
+    MultiRoleAudienceResources.ProgrammaticRegistrar registrar;
+
+    @Test
+    public void testMultiRoleResource() {
+        // Verify via ResourceManager API
+        ResourceManager.ResourceInfo alphaInfo = resourceManager.getResource("file:///multi/alpha", McpServer.DEFAULT);
+        assertNotNull(alphaInfo);
+        Content.Annotations annotations = alphaInfo.annotations().orElseThrow();
+        assertEquals(List.of(Role.USER, Role.ASSISTANT), annotations.audience());
+        assertEquals(0.6, annotations.priority());
+
+        // Verify JSON serialization
+        JsonObject json = alphaInfo.asJson();
+        JsonObject decoded = new JsonObject(json.encode());
+        JsonObject annJson = decoded.getJsonObject("annotations");
+        assertNotNull(annJson);
+        JsonArray audience = annJson.getJsonArray("audience");
+        assertEquals(2, audience.size());
+        assertEquals("user", audience.getString(0));
+        assertEquals("assistant", audience.getString(1));
+        assertEquals(0.6, annJson.getDouble("priority"));
+
+        // Verify via MCP client
+        McpStreamableTestClient client = McpAssured.newConnectedStreamableClient();
+        client.when()
+                .resourcesList(p -> {
+                    ResourceInfo alpha = p.findByUri("file:///multi/alpha");
+                    assertNotNull(alpha.annotations());
+                    assertEquals(List.of(Role.USER, Role.ASSISTANT), alpha.annotations().audience());
+                    assertEquals(0.6, alpha.annotations().priority());
+                })
+                .resourcesRead("file:///multi/alpha", r -> assertEquals("alpha", r.contents().get(0).asText().text()))
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testMultiRoleResourceTemplate() {
+        // Verify via ResourceTemplateManager API
+        ResourceTemplateManager.ResourceTemplateInfo templateInfo = resourceTemplateManager
+                .getResourceTemplate("template", McpServer.DEFAULT);
+        assertNotNull(templateInfo);
+        Content.Annotations annotations = templateInfo.annotations().orElseThrow();
+        assertEquals(List.of(Role.ASSISTANT, Role.USER), annotations.audience());
+        assertEquals(0.7, annotations.priority());
+
+        // Verify via MCP client
+        McpStreamableTestClient client = McpAssured.newConnectedStreamableClient();
+        client.when()
+                .resourcesTemplatesList(p -> {
+                    ResourceTemplateInfo template = p.findByUriTemplate("file:///multi/template/{id}");
+                    assertNotNull(template.annotations());
+                    assertEquals(List.of(Role.ASSISTANT, Role.USER), template.annotations().audience());
+                    assertEquals(0.7, template.annotations().priority());
+                })
+                .resourcesRead("file:///multi/template/42",
+                        r -> assertEquals("template-42", r.contents().get(0).asText().text()))
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testMultiRoleProgrammaticResource() {
+        registrar.registerResource();
+
+        McpStreamableTestClient client = McpAssured.newConnectedStreamableClient();
+        client.when()
+                .resourcesList(p -> {
+                    ResourceInfo programmatic = p.findByUri("file:///multi/programmatic");
+                    assertNotNull(programmatic.annotations());
+                    assertEquals(List.of(Role.ASSISTANT, Role.USER), programmatic.annotations().audience());
+                    assertEquals(0.8, programmatic.annotations().priority());
+                })
+                .resourcesRead("file:///multi/programmatic",
+                        r -> assertEquals("programmatic", r.contents().get(0).asText().text()))
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testMultiRoleProgrammaticResourceTemplate() {
+        registrar.registerResourceTemplate();
+
+        McpStreamableTestClient client = McpAssured.newConnectedStreamableClient();
+        client.when()
+                .resourcesTemplatesList(p -> {
+                    ResourceTemplateInfo template = p
+                            .findByUriTemplate("file:///multi/programmatic_template/{name}");
+                    assertNotNull(template.annotations());
+                    assertEquals(List.of(Role.USER, Role.ASSISTANT), template.annotations().audience());
+                    assertEquals(0.9, template.annotations().priority());
+                })
+                .resourcesRead("file:///multi/programmatic_template/hello",
+                        r -> assertEquals("hello", r.contents().get(0).asText().text()))
+                .thenAssertResults();
+    }
+}

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/resources/ProgrammaticResourceTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/resources/ProgrammaticResourceTest.java
@@ -65,7 +65,7 @@ public class ProgrammaticResourceTest extends McpServerTest {
                     assertNotNull(alpha);
                     assertEquals(1, alpha.size());
                     assertNotNull(alpha.annotations());
-                    assertEquals(Role.ASSISTANT, alpha.annotations().audience());
+                    assertEquals(Role.ASSISTANT, alpha.annotations().audience().get(0));
                     assertEquals(0.9, alpha.annotations().priority());
                 })
                 .resourcesRead("file:///alpha", r -> assertEquals("2", r.contents().get(0).asText().text()))

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/resources/ResourcesTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/resources/ResourcesTest.java
@@ -43,7 +43,7 @@ public class ResourcesTest extends McpServerTest {
         assertNotNull(annotations);
         assertFalse(annotations.containsKey("lastModified"),
                 "annotations must not contain 'lastModified' key when lastModified is not set");
-        assertEquals("user", annotations.getString("audience"));
+        assertEquals("user", annotations.getJsonArray("audience").getString(0));
         assertEquals(0.5, annotations.getDouble("priority"));
     }
 
@@ -59,7 +59,7 @@ public class ResourcesTest extends McpServerTest {
                     assertEquals("Alpha...", alpha.title());
                     assertEquals(15, alpha.size());
                     assertNotNull(alpha.annotations());
-                    assertEquals(Role.USER, alpha.annotations().audience());
+                    assertEquals(Role.USER, alpha.annotations().audience().get(0));
                     assertEquals(0.5, alpha.annotations().priority());
                     assertEquals("bravo", p.findByUri("file:///project/bravo").name());
                     assertEquals("uni_alpha", p.findByUri("file:///project/uni_alpha").name());

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/resources/templates/ProgrammaticResourceTemplateTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/resources/templates/ProgrammaticResourceTemplateTest.java
@@ -58,7 +58,7 @@ public class ProgrammaticResourceTemplateTest extends McpServerTest {
                     assertEquals(1, p.size());
                     ResourceTemplateInfo alpha = p.findByUriTemplate("file:///alpha/{foo}");
                     assertNotNull(alpha.annotations());
-                    assertEquals(Role.ASSISTANT, alpha.annotations().audience());
+                    assertEquals(Role.ASSISTANT, alpha.annotations().audience().get(0));
                     assertEquals(0.9, alpha.annotations().priority());
                 })
                 .resourcesRead("file:///alpha/ok", r -> assertEquals("ok", r.contents().get(0).asText().text()))

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/resources/templates/ResourceTemplatesTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/resources/templates/ResourceTemplatesTest.java
@@ -43,7 +43,7 @@ public class ResourceTemplatesTest extends McpServerTest {
         assertEquals("customValue", foxtrotTemplate.metadata().get(MetaKey.of("customField")));
         ResourceTemplateManager.ResourceTemplateInfo golfTemplate = manager.getResourceTemplate("golf", McpServer.DEFAULT);
         assertNotNull(golfTemplate);
-        assertEquals(Role.ASSISTANT, golfTemplate.annotations().orElseThrow().audience());
+        assertEquals(Role.ASSISTANT, golfTemplate.annotations().orElseThrow().audience().get(0));
         assertEquals(0.7, golfTemplate.annotations().orElseThrow().priority());
         assertEquals("2024-01-15T10:30:00Z", golfTemplate.annotations().orElseThrow().lastModified());
 
@@ -55,7 +55,7 @@ public class ResourceTemplatesTest extends McpServerTest {
                     ResourceTemplateInfo alpha = p.findByUriTemplate("file:///{path}");
                     assertEquals("Alpha...", alpha.title());
                     assertNotNull(alpha.annotations());
-                    assertEquals(Role.USER, alpha.annotations().audience());
+                    assertEquals(Role.USER, alpha.annotations().audience().get(0));
                     assertEquals(0.5, alpha.annotations().priority());
 
                     ResourceTemplateInfo foxtrot = p.findByUriTemplate("file:///foxtrot/{path}");
@@ -76,7 +76,7 @@ public class ResourceTemplatesTest extends McpServerTest {
                     assertEquals("Resource with lastModified annotation", golf.description());
                     assertEquals("text/plain", golf.mimeType());
                     assertNotNull(golf.annotations());
-                    assertEquals(Role.ASSISTANT, golf.annotations().audience());
+                    assertEquals(Role.ASSISTANT, golf.annotations().audience().get(0));
                     assertEquals("2024-01-15T10:30:00Z", golf.annotations().lastModified());
                     assertEquals(0.7, golf.annotations().priority());
                 })

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/ToolsTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/ToolsTest.java
@@ -83,7 +83,7 @@ public class ToolsTest extends McpServerTest {
                     assertEquals(10, t._meta().entrySet().iterator().next().getValue());
                     // content annotations
                     assertNotNull(t.annotations());
-                    assertEquals(Role.ASSISTANT, t.annotations().audience());
+                    assertEquals(Role.ASSISTANT, t.annotations().audience().get(0));
                     assertEquals("2025-08-26T08:40:00Z", t.annotations().lastModified());
                     assertEquals(0.5, t.annotations().priority());
                     // result _meta


### PR DESCRIPTION
- the MCP spec defines the audience as an array of strings; current API only supports a single Role
- fixes #788

### Compatibility

This is a breaking change, because:

1. We change the canonical constructor of the `io.quarkiverse.mcp.server.Content.Annotations` record class; and that can break [record patterns](https://docs.oracle.com/en/java/javase/21/language/record-patterns.html) in JDK 21+, because record patterns deconstruct using the canonical constructor's component types.
2. We change the type of `io.quarkiverse.mcp.server.Resource.Annotations.audience()` from `Role` to `Role[]`.

The annotation change is source-compatible (recompile works). The record change is not fully source-compatible if anyone uses record patterns, regular construction via the convenience constructor is fine.