### PR TITLE
cli: derive MCP tool parameter names from CLI option names

### DIFF
--- a/cli-adapter/deployment/src/main/java/io/quarkiverse/mcp/server/cli/adapter/deployment/CommandUtil.java
+++ b/cli-adapter/deployment/src/main/java/io/quarkiverse/mcp/server/cli/adapter/deployment/CommandUtil.java
@@ -96,7 +96,13 @@ class CommandUtil {
             a.annotations(DotNames.OPTION).forEach(o -> {
                 String[] names = o.value("names").asStringArray();
                 if (names.length != 0) {
-                    options.put(names[0], a);
+                    String longest = names[0];
+                    for (int i = 1; i < names.length; i++) {
+                        if (names[i].length() > longest.length()) {
+                            longest = names[i];
+                        }
+                    }
+                    options.put(longest, a);
                 }
             });
         });

--- a/cli-adapter/deployment/src/main/java/io/quarkiverse/mcp/server/cli/adapter/deployment/McpServerCliAdapterProcessor.java
+++ b/cli-adapter/deployment/src/main/java/io/quarkiverse/mcp/server/cli/adapter/deployment/McpServerCliAdapterProcessor.java
@@ -91,7 +91,7 @@ class McpServerCliAdapterProcessor {
 
         Optional<DotName> topCommand = CommandUtil.findTopCommand(index);
         topCommand.ifPresentOrElse(dotName -> {
-            // Top command has been found, then collect all subcommanS
+            // Top command has been found, then collect all subcommands
             ClassInfo classInfo = index.getClassByName(dotName);
             if (classInfo != null) {
                 commandClasses.putAll(collectCommandClassNames(index, classInfo));
@@ -313,7 +313,7 @@ class McpServerCliAdapterProcessor {
 
             for (Entry<String, FieldInfo> entry : options.entrySet()) {
                 FieldInfo option = entry.getValue();
-                String optionName = option.name().toString();
+                String optionName = entry.getKey();
                 String optionDescription = String.join("\n",
                         option.annotation(DotNames.OPTION).value("description").asStringArray());
 

--- a/cli-adapter/deployment/src/test/java/io/quarkiverse/mcp/server/cli/adapter/deployment/CommandUtilTest.java
+++ b/cli-adapter/deployment/src/test/java/io/quarkiverse/mcp/server/cli/adapter/deployment/CommandUtilTest.java
@@ -2,16 +2,31 @@ package io.quarkiverse.mcp.server.cli.adapter.deployment;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.util.Map;
 import java.util.Set;
 
 import jakarta.inject.Inject;
 
 import org.jboss.jandex.ClassInfo;
 import org.jboss.jandex.DotName;
+import org.jboss.jandex.FieldInfo;
 import org.jboss.jandex.Index;
 import org.junit.jupiter.api.Test;
 
+import picocli.CommandLine.Option;
+
 public class CommandUtilTest {
+
+    public static class CommandWithOptions {
+        @Option(names = "--json", description = "Output in JSON format.")
+        boolean jsonOutput;
+
+        @Option(names = { "-c", "--cluster" }, description = "The cluster name.")
+        String clusterNameOrId;
+
+        @Option(names = "-v", description = "Verbose output.")
+        boolean verbose;
+    }
 
     public static class Simple {
     }
@@ -71,6 +86,24 @@ public class CommandUtilTest {
                 "io.quarkiverse.mcp.server.cli.adapter.deployment.CommandUtilTest",
                 "io.quarkiverse.mcp.server.cli.adapter.deployment.CommandUtil",
                 "org.acme.MyCommand")));
+    }
+
+    @Test
+    public void testListOptionsShouldUseLongestName() throws Exception {
+        Index index = Index.of(CommandWithOptions.class);
+        ClassInfo classInfo = index.getClassByName(DotName.createSimple(CommandWithOptions.class.getName()));
+        Map<String, FieldInfo> options = CommandUtil.listOptions(classInfo, index);
+        assertEquals(3, options.size());
+        // Short + long: longest name should be the key
+        assertTrue(options.containsKey("--cluster"));
+        assertFalse(options.containsKey("-c"));
+        assertEquals("clusterNameOrId", options.get("--cluster").name());
+        // Single long name
+        assertTrue(options.containsKey("--json"));
+        assertEquals("jsonOutput", options.get("--json").name());
+        // Single short name
+        assertTrue(options.containsKey("-v"));
+        assertEquals("verbose", options.get("-v").name());
     }
 
 }

--- a/cli-adapter/integration-tests/src/main/java/io/quarkiverse/mcp/server/cli/adapter/it/CodeServiceCommand.java
+++ b/cli-adapter/integration-tests/src/main/java/io/quarkiverse/mcp/server/cli/adapter/it/CodeServiceCommand.java
@@ -7,6 +7,7 @@ import jakarta.inject.Inject;
 import io.quarkus.picocli.runtime.annotations.TopCommand;
 import picocli.CommandLine.Command;
 import picocli.CommandLine.ExitCode;
+import picocli.CommandLine.Option;
 import picocli.CommandLine.Parameters;
 
 @TopCommand
@@ -16,11 +17,17 @@ public class CodeServiceCommand implements Callable<Integer> {
     @Inject
     CodeService codeService;
 
+    @Option(names = { "-s", "--style" }, defaultValue = "plain", description = "The code style.")
+    String codeStyle;
+
     @Parameters(defaultValue = "java", description = "The lanugage.")
     String language;
 
     @Override
     public Integer call() {
+        if (codeStyle == null || codeStyle.isBlank()) {
+            throw new IllegalStateException("Code style is required");
+        }
         System.out.println(codeService.assist(language));
         return ExitCode.OK;
     }

--- a/cli-adapter/integration-tests/src/test/java/io/quarkiverse/mcp/server/cli/adapter/it/ServerFeaturesIT.java
+++ b/cli-adapter/integration-tests/src/test/java/io/quarkiverse/mcp/server/cli/adapter/it/ServerFeaturesIT.java
@@ -31,11 +31,16 @@ public class ServerFeaturesIT {
                         assertNotNull(tool);
                         assertNotNull(tool.inputSchema());
                         var properties = tool.inputSchema().getJsonObject("properties");
-                        assertEquals(1, properties.size());
+                        assertEquals(2, properties.size());
                         assertNotNull(properties.getJsonObject("language"));
                         assertEquals("string", properties.getJsonObject("language").getString("type"));
+                        // Verify the @Option parameter name derives from the longest CLI option name,
+                        // not the Java field name ("codeStyle") or the short form ("s")
+                        assertNotNull(properties.getJsonObject("style"),
+                                "Option parameter should be named 'style' (from --style), not 'codeStyle' (field name)");
+                        assertEquals("string", properties.getJsonObject("style").getString("type"));
                     })
-                    .toolsCall("codeservicecommand", Map.of("language", "java"), response -> {
+                    .toolsCall("codeservicecommand", Map.of("language", "java", "style", "plain"), response -> {
                         assertFalse(response.isError());
                         assertEquals(1, response.content().size());
                         assertEquals("System.out.println(\"Hello world!\");",

--- a/cli-adapter/runtime/src/main/java/io/quarkiverse/mcp/server/cli/adapter/runtime/McpAdapter.java
+++ b/cli-adapter/runtime/src/main/java/io/quarkiverse/mcp/server/cli/adapter/runtime/McpAdapter.java
@@ -19,7 +19,7 @@ public class McpAdapter {
     public static Integer startMcp() {
         PrintStream stdout = System.out;
         try {
-            StdioMcpMessageHandler mcpMessageHandler = Arc.container().instance(StdioMcpMessageHandler.class).get();
+            StdioMcpMessageHandler mcpMessageHandler = Arc.requireContainer().instance(StdioMcpMessageHandler.class).get();
             System.setOut(new PrintStream(OutputStream.nullOutputStream()));
             mcpMessageHandler.initialize(stdout);
             Quarkus.waitForExit();

--- a/docs/modules/ROOT/pages/guides-cli-adapter.adoc
+++ b/docs/modules/ROOT/pages/guides-cli-adapter.adoc
@@ -16,6 +16,7 @@ The CLI adapter bridges Quarkus CLI commands and MCP by:
 * Handling standard input/output for MCP communication
 
 This means your CLI application can run in two modes:
+
 - Normal CLI mode: Traditional command-line interface (script, manual invocation)
 - MCP mode: Exposes commands as tools to MCP clients (with `--mcp` flag)
 
@@ -206,8 +207,8 @@ The command becomes available as an MCP tool:
 |`String language` → `"language": {"type": "string"}`
 
 |`@Option`
-|Tool argument
-|`@Option(names = "-f") String format` → `"format": {...}`
+|Tool argument (named after the longest option name)
+|`@Option(names = {"-f", "--format"}) String fmt` → `"format": {...}`
 
 |Default value
 |Argument default
@@ -266,6 +267,7 @@ class LintCommand implements Callable<Integer> {
 ----
 
 Each subcommand becomes an MCP tool:
+
 - `formatcommand` - Format source code
 - `lintcommand` - Lint source code
 - `testcommand` - Run tests
@@ -307,17 +309,23 @@ Commands will be discovered by AI based on their descriptions:
 
 === Use Meaningful Parameter Names
 
-Parameter names become argument names in the tool schema:
+`@Parameters` field names become argument names in the tool schema:
 
 [source,java]
 ----
 @Parameters(description = "Source file to analyze")
 String sourceFile; // <1>
-
-// Not as clear:
-// String file;
 ----
-<1> Descriptive names make the tool easier to use.
+<1> Descriptive field names make the tool easier to use.
+
+For `@Option`, the MCP argument name is derived from the longest option name (with leading dashes stripped), not from the Java field name:
+
+[source,java]
+----
+@Option(names = {"-f", "--format"}, description = "Output format")
+String outputFormat; // <1>
+----
+<1> The MCP argument name will be `format` (from `--format`), not `outputFormat`.
 
 === Set Sensible Defaults
 
@@ -358,5 +366,6 @@ public Integer call() {
 * STDIO transport only: The CLI adapter uses standard input/output for MCP communication
 * Synchronous execution: Each tool call blocks until the command completes
 * No streaming: Tool responses are returned only after the command finishes
+* No concurrent tool calls: The CLI adapter redirects `System.out` to capture command output, which is not safe under concurrent execution. MCP clients should not send multiple tool call requests in parallel
 
 For more advanced MCP server features (HTTP transport, streaming, multiple clients), consider implementing tools directly with the standard MCP server annotations.


### PR DESCRIPTION
- also update docs with option naming rule and limitations
- resolves #576