### PR TITLE
Avoid NPE for guarded no-argument tool calls

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ToolManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ToolManagerImpl.java
@@ -439,6 +439,9 @@ public class ToolManagerImpl extends FeatureManagerBase<ToolResponse, ToolInfo> 
 
         @Override
         public void setArguments(JsonObject arguments) {
+            if (arguments == null) {
+                arguments = new JsonObject();
+            }
             JsonObject newArgs = new JsonObject(Map.copyOf(arguments.getMap()));
             this.arguments.set(newArgs);
         }


### PR DESCRIPTION
This fixes a `NullPointerException` when a no-argument tool has an input guardrail and a client omits the `arguments` field from a `tools/call` request. I first reproduced this with `McpStreamableTestClient`, when it sends no `arguments` field for no-argument tool calls.

Input guardrails are not only used for argument validation. They can also be used for cross-cutting pre-call checks such as rate limiting. For example, a no-argument read tool may still need a rate-limit guardrail even though it has no arguments to validate.

Without this fix, attaching any input guardrail to a no-argument tool is unsafe for clients that omit `arguments`. The framework throws an NPE while building the guardrail input context, before the guardrail logic can run. As a result, the request fails with an internal error instead of being handled by the guardrail or the tool.