### PR TITLE
Improve McpAssured test performance and disable OTel by default in HTTP transport tests

### DIFF
--- a/test/src/main/java/io/quarkiverse/mcp/server/test/HttpClients.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/HttpClients.java
@@ -1,0 +1,16 @@
+package io.quarkiverse.mcp.server.test;
+
+import java.net.http.HttpClient;
+
+final class HttpClients {
+
+    private static final HttpClient INSTANCE = HttpClient.newHttpClient();
+
+    static HttpClient getDefault() {
+        return INSTANCE;
+    }
+
+    private HttpClients() {
+    }
+
+}

--- a/test/src/main/java/io/quarkiverse/mcp/server/test/McpClientState.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/McpClientState.java
@@ -1,6 +1,9 @@
 package io.quarkiverse.mcp.server.test;
 
+import java.time.Duration;
 import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -11,16 +14,28 @@ import io.vertx.core.json.JsonObject;
 
 final class McpClientState {
 
+    static final Duration POLL_INTERVAL = Duration.ofMillis(50);
+
     final AtomicInteger requestIdGenerator;
     final List<JsonObject> requests;
     final List<JsonObject> responses;
+    final ConcurrentMap<Integer, JsonObject> responseMap;
     final List<JsonObject> notifications;
 
     McpClientState() {
         this.requestIdGenerator = new AtomicInteger();
         this.requests = new CopyOnWriteArrayList<>();
         this.responses = new CopyOnWriteArrayList<>();
+        this.responseMap = new ConcurrentHashMap<>();
         this.notifications = new CopyOnWriteArrayList<>();
+    }
+
+    void addResponse(JsonObject response) {
+        responses.add(response);
+        Integer id = response.getInteger("id");
+        if (id != null) {
+            responseMap.put(id, response);
+        }
     }
 
     public int nextRequestId() {
@@ -32,38 +47,33 @@ final class McpClientState {
         if (lastId == 0) {
             return null;
         }
-        Awaitility.await().until(() -> responses.stream().anyMatch(r -> r.getInteger("id") == lastId));
-        return responses.stream().filter(r -> r.getInteger("id") == lastId).findFirst().orElseThrow();
+        Awaitility.await().pollInterval(POLL_INTERVAL).until(() -> responseMap.containsKey(lastId));
+        return responseMap.get(lastId);
     }
 
     public List<JsonObject> waitForNotifications(int count) {
-        Awaitility.await().until(() -> notifications.size() >= count);
+        Awaitility.await().pollInterval(POLL_INTERVAL).until(() -> notifications.size() >= count);
         return notifications;
     }
 
     public List<JsonObject> waitForRequests(int count) {
-        Awaitility.await().until(() -> requests.size() >= count);
+        Awaitility.await().pollInterval(POLL_INTERVAL).until(() -> requests.size() >= count);
         return requests;
     }
 
     public List<JsonObject> waitForResponses(int count) {
-        Awaitility.await().until(() -> responses.size() >= count);
+        Awaitility.await().pollInterval(POLL_INTERVAL).until(() -> responses.size() >= count);
         return responses;
     }
 
     public JsonObject waitForResponse(JsonObject request) {
         int id = request.getInteger("id");
-        Awaitility.await().until(() -> getResponse(id) != null);
-        return getResponse(id);
+        Awaitility.await().pollInterval(POLL_INTERVAL).until(() -> responseMap.containsKey(id));
+        return responseMap.get(id);
     }
 
     public JsonObject getResponse(int id) {
-        for (JsonObject r : responses) {
-            if (r.getInteger("id") == id) {
-                return r;
-            }
-        }
-        return null;
+        return responseMap.get(id);
     }
 
     public List<JsonObject> getRequests() {

--- a/test/src/main/java/io/quarkiverse/mcp/server/test/McpSseClient.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/McpSseClient.java
@@ -28,7 +28,7 @@ class McpSseClient extends SseClient {
     }
 
     public SseEvent waitForFirstEvent() {
-        Awaitility.await().until(() -> !allEvents.isEmpty());
+        Awaitility.await().pollInterval(McpClientState.POLL_INTERVAL).until(() -> !allEvents.isEmpty());
         return allEvents.get(0);
     }
 
@@ -39,7 +39,7 @@ class McpSseClient extends SseClient {
             JsonObject json = new JsonObject(event.data());
             if (json.containsKey("id")) {
                 if (json.containsKey("result") || json.containsKey("error")) {
-                    state.responses.add(json);
+                    state.addResponse(json);
                 } else {
                     // Request from the server
                     state.requests.add(json);

--- a/test/src/main/java/io/quarkiverse/mcp/server/test/McpSseTestClientImpl.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/McpSseTestClientImpl.java
@@ -8,7 +8,6 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.http.HttpClient;
 import java.net.http.HttpClient.Version;
 import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublishers;
@@ -45,7 +44,6 @@ class McpSseTestClientImpl extends McpTestClientBase<McpSseAssert, McpSseTestCli
     private static final Logger LOG = Logger.getLogger(McpSseTestClientImpl.class);
 
     private final URI sseEndpoint;
-    private final HttpClient httpClient;
     private final boolean expectSseConnectionFailure;
 
     private volatile McpSseClient client;
@@ -57,7 +55,6 @@ class McpSseTestClientImpl extends McpTestClientBase<McpSseAssert, McpSseTestCli
                 builder.openTelemetry);
         this.sseEndpoint = createEndpointUri(builder.baseUri, builder.ssePath);
         this.expectSseConnectionFailure = builder.expectSseConnectionFailure;
-        this.httpClient = HttpClient.newHttpClient();
         LOG.debugf("McpSseTestClient created with SSE endpoint: %s", sseEndpoint);
     }
 
@@ -92,7 +89,7 @@ class McpSseTestClientImpl extends McpTestClientBase<McpSseAssert, McpSseTestCli
         }
 
         // Normally, the CF returned from the connect method never completes
-        CompletableFuture<java.net.http.HttpResponse<Void>> cf = client.connect(headers);
+        CompletableFuture<java.net.http.HttpResponse<Void>> cf = client.connect(HttpClients.getDefault(), headers);
         if (expectSseConnectionFailure) {
             try {
                 java.net.http.HttpResponse<Void> response = cf.get(5, TimeUnit.SECONDS);
@@ -392,7 +389,7 @@ class McpSseTestClientImpl extends McpTestClientBase<McpSseAssert, McpSseTestCli
         if (messageEndpoint == null) {
             throw new IllegalStateException("Message endpoint not ready");
         }
-        return httpClient.sendAsync(buildRequest(data, additionalHeaders, basicAuth), BodyHandlers.ofString());
+        return HttpClients.getDefault().sendAsync(buildRequest(data, additionalHeaders, basicAuth), BodyHandlers.ofString());
     }
 
     private HttpResponse sendSync(String data, MultiMap additionalHeaders, BasicAuth basicAuth) {
@@ -401,7 +398,7 @@ class McpSseTestClientImpl extends McpTestClientBase<McpSseAssert, McpSseTestCli
         }
         java.net.http.HttpResponse<String> r;
         try {
-            r = httpClient.send(buildRequest(data, additionalHeaders, basicAuth), BodyHandlers.ofString());
+            r = HttpClients.getDefault().send(buildRequest(data, additionalHeaders, basicAuth), BodyHandlers.ofString());
             MultiMap responseHeaders = MultiMap.caseInsensitiveMultiMap();
             for (Entry<String, List<String>> e : r.headers().map().entrySet()) {
                 for (String val : e.getValue()) {

--- a/test/src/main/java/io/quarkiverse/mcp/server/test/McpStdioTestClientImpl.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/McpStdioTestClientImpl.java
@@ -104,7 +104,7 @@ class McpStdioTestClientImpl extends McpTestClientBase<McpStdioAssert, McpStdioT
                     JsonObject json = new JsonObject(line);
                     if (json.containsKey("id")) {
                         if (json.containsKey("result") || json.containsKey("error")) {
-                            state.responses.add(json);
+                            state.addResponse(json);
                         } else {
                             // Request from the server
                             state.requests.add(json);

--- a/test/src/main/java/io/quarkiverse/mcp/server/test/McpStreamableClient.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/McpStreamableClient.java
@@ -2,7 +2,6 @@ package io.quarkiverse.mcp.server.test;
 
 import java.io.IOException;
 import java.net.URI;
-import java.net.http.HttpClient;
 import java.net.http.HttpClient.Version;
 import java.net.http.HttpRequest;
 import java.net.http.HttpRequest.BodyPublishers;
@@ -18,14 +17,12 @@ import io.vertx.core.json.JsonObject;
 
 class McpStreamableClient extends SseClient {
 
-    final HttpClient httpClient;
     final URI mcpEndpoint;
     final McpClientState state;
     final AtomicReference<Consumer<JsonObject>> requestConsumer = new AtomicReference<>();
 
     McpStreamableClient(URI mcpEndpoint) {
         super(mcpEndpoint);
-        this.httpClient = HttpClient.newHttpClient();
         this.mcpEndpoint = mcpEndpoint;
         this.state = new McpClientState();
     }
@@ -59,7 +56,7 @@ class McpStreamableClient extends SseClient {
 
     private HttpResponse<String> doSend(HttpRequest request) {
         try {
-            return httpClient.send(request, BodyHandlers.ofString());
+            return HttpClients.getDefault().send(request, BodyHandlers.ofString());
         } catch (InterruptedException e) {
             Thread.currentThread().interrupt();
             throw new IllegalStateException("Interrupted");
@@ -69,13 +66,14 @@ class McpStreamableClient extends SseClient {
     }
 
     void send(String body, MultiMap headers) {
-        McpStremableRequest request = new McpStremableRequest(httpClient, mcpEndpoint, headers, state.responses::add,
+        McpStremableRequest request = new McpStremableRequest(HttpClients.getDefault(), mcpEndpoint, headers,
+                state::addResponse,
                 state.notifications::add, state.requests::add);
         request.send(body);
     }
 
     CompletableFuture<HttpResponse<Void>> connectSubsidiarySse(MultiMap headers) {
-        return connect(httpClient, headers);
+        return connect(HttpClients.getDefault(), headers);
     }
 
     @Override
@@ -84,7 +82,7 @@ class McpStreamableClient extends SseClient {
             JsonObject json = new JsonObject(event.data());
             if (json.getValue("id") != null) {
                 if (json.containsKey("result") || json.containsKey("error")) {
-                    state.responses.add(json);
+                    state.addResponse(json);
                 } else {
                     state.requests.add(json);
                 }

--- a/test/src/main/java/io/quarkiverse/mcp/server/test/McpStreamableTestClientImpl.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/McpStreamableTestClientImpl.java
@@ -86,7 +86,7 @@ class McpStreamableTestClientImpl extends McpTestClientBase<McpStreamableAssert,
         LOG.infof("Mcp-Session-Id received: %s", mcpSessionId);
 
         JsonObject initResponse = new JsonObject(response.body());
-        client.state.responses.add(initResponse);
+        client.state.addResponse(initResponse);
         JsonObject initResult = assertResultResponse(initMessage, initResponse);
         assertNotNull(initResult);
 

--- a/test/src/main/java/io/quarkiverse/mcp/server/test/McpWebSocketClient.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/McpWebSocketClient.java
@@ -3,6 +3,9 @@ package io.quarkiverse.mcp.server.test;
 import java.net.URI;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
@@ -38,7 +41,7 @@ class McpWebSocketClient {
             JsonObject json = new JsonObject(b);
             if (json.containsKey("id")) {
                 if (json.containsKey("result") || json.containsKey("error")) {
-                    state.responses.add(json);
+                    state.addResponse(json);
                 } else {
                     // Request from the server
                     state.requests.add(json);
@@ -56,8 +59,15 @@ class McpWebSocketClient {
         connectOptions.setPort(endpointUri.getPort());
         connectOptions.setHost(endpointUri.getHost());
         connectOptions.setURI(endpointUri.getPath());
-        webSocket.connect(connectOptions).toCompletionStage()
-                .toCompletableFuture().join();
+        try {
+            webSocket.connect(connectOptions).toCompletionStage()
+                    .toCompletableFuture().get(10, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while connecting WebSocket", e);
+        } catch (ExecutionException | TimeoutException e) {
+            throw new IllegalStateException("Failed to connect WebSocket", e);
+        }
     }
 
     Future<Void> send(String message) {
@@ -66,7 +76,15 @@ class McpWebSocketClient {
 
     void disconnect() {
         messages.clear();
-        webSocket.close().toCompletionStage().toCompletableFuture().join();
+        try {
+            webSocket.close().toCompletionStage()
+                    .toCompletableFuture().get(10, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while closing WebSocket", e);
+        } catch (ExecutionException | TimeoutException e) {
+            throw new IllegalStateException("Failed to close WebSocket", e);
+        }
     }
 
 }

--- a/test/src/main/java/io/quarkiverse/mcp/server/test/McpWebSocketTestClientImpl.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/McpWebSocketTestClientImpl.java
@@ -5,6 +5,9 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.function.Consumer;
 
 import org.jboss.logging.Logger;
@@ -105,7 +108,15 @@ class McpWebSocketTestClientImpl extends McpTestClientBase<McpWebSocketAssert, M
 
         // Send "notifications/initialized"
         JsonObject nofitication = newMessage("notifications/initialized");
-        client.send(nofitication.encode()).toCompletionStage().toCompletableFuture().join();
+        try {
+            client.send(nofitication.encode()).toCompletionStage()
+                    .toCompletableFuture().get(10, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while sending initialized notification", e);
+        } catch (ExecutionException | TimeoutException e) {
+            throw new IllegalStateException("Failed to send initialized notification", e);
+        }
 
         connected.set(true);
         return this;

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/McpServerTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/McpServerTest.java
@@ -18,10 +18,14 @@ public abstract class McpServerTest {
 
     public static QuarkusUnitTest defaultConfig(int textLimit) {
         QuarkusUnitTest config = new QuarkusUnitTest();
+        // Disable OTel by default
+        config.overrideConfigKey("quarkus.otel.enabled", "false");
+        // Enabled traffic logging if -DlogTraffic is used
         if (System.getProperty("logTraffic") != null) {
             config.overrideConfigKey("quarkus.mcp.server.traffic-logging.enabled", "true");
             config.overrideConfigKey("quarkus.mcp.server.traffic-logging.text-limit", "" + textLimit);
         }
+        // Disable all input schema generators by default
         config.overrideRuntimeConfigKey("quarkus.mcp.server.schema-generator.jackson.enabled", "false");
         config.overrideRuntimeConfigKey("quarkus.mcp.server.schema-generator.jakarta-validation.enabled", "false");
         config.overrideRuntimeConfigKey("quarkus.mcp.server.schema-generator.swagger2.enabled", "false");

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tracing/TracingTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tracing/TracingTest.java
@@ -49,6 +49,8 @@ public class TracingTest extends McpServerTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = defaultConfig()
+            // OTel is disabled by default
+            .overrideConfigKey("quarkus.otel.enabled", "true")
             .overrideConfigKey("quarkus.otel.bsp.schedule.delay", "100ms")
             .overrideConfigKey("quarkus.otel.metrics.exporter", "none")
             .overrideConfigKey("quarkus.otel.logs.exporter", "none")


### PR DESCRIPTION
- reduce Awaitility polling interval from 100ms to 50ms
- use ConcurrentHashMap for O(1) response lookup by id instead of linear scan
- share a single HttpClient instance across all test client types
- pass the shared HttpClient to SseClient.connect() to avoid creating redundant instances
- add 10s timeout to WebSocket CompletableFuture.join() calls to prevent indefinite hangs
- disable OTel by default in McpServerTest.defaultConfig() and re-enable it in TracingTest