### PR TITLE
Add setBearerToken() to McpAssured test client builders

### DIFF
--- a/test/src/main/java/io/quarkiverse/mcp/server/test/McpAssured.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/McpAssured.java
@@ -358,6 +358,14 @@ public class McpAssured {
             Builder setBasicAuth(String username, String password);
 
             /**
+             * Set the bearer token used in the {@code Authorization} header sent with every HTTP request.
+             *
+             * @param token
+             * @return self
+             */
+            Builder setBearerToken(String token);
+
+            /**
              *
              * @param additionalHeaders
              * @return self
@@ -426,6 +434,14 @@ public class McpAssured {
              * @return self
              */
             Builder setBasicAuth(String username, String password);
+
+            /**
+             * Set the bearer token used in the {@code Authorization} header sent with every HTTP request.
+             *
+             * @param token
+             * @return self
+             */
+            Builder setBearerToken(String token);
 
             /**
              * Set a function that is used to produce additional HTTP headers for a specific message. The message input may be
@@ -510,6 +526,14 @@ public class McpAssured {
              * @return self
              */
             Builder setBasicAuth(String username, String password);
+
+            /**
+             * Set the bearer token used in the {@code Authorization} header sent with the initial HTTP request.
+             *
+             * @param token
+             * @return self
+             */
+            Builder setBearerToken(String token);
 
             /**
              *

--- a/test/src/main/java/io/quarkiverse/mcp/server/test/McpSseTestClientImpl.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/McpSseTestClientImpl.java
@@ -51,7 +51,7 @@ class McpSseTestClientImpl extends McpTestClientBase<McpSseAssert, McpSseTestCli
 
     McpSseTestClientImpl(BuilderImpl builder) {
         super(builder.name, builder.version, builder.protocolVersion, builder.clientCapabilities, builder.additionalHeaders,
-                builder.autoPong, builder.basicAuth, builder.title, builder.description, builder.websiteUrl, builder.icons,
+                builder.autoPong, builder.authorization, builder.title, builder.description, builder.websiteUrl, builder.icons,
                 builder.openTelemetry);
         this.sseEndpoint = createEndpointUri(builder.baseUri, builder.ssePath);
         this.expectSseConnectionFailure = builder.expectSseConnectionFailure;
@@ -83,9 +83,8 @@ class McpSseTestClientImpl extends McpTestClientBase<McpSseAssert, McpSseTestCli
         }
 
         Map<String, String> headers = new HashMap<>();
-        if (clientBasicAuth != null) {
-            headers.put(HEADER_AUTHORIZATION,
-                    McpTestClientBase.getBasicAuthenticationHeader(clientBasicAuth.username(), clientBasicAuth.password()));
+        if (clientAuthorization != null && !clientAuthorization.isEmpty()) {
+            headers.put(HEADER_AUTHORIZATION, clientAuthorization.headerValue());
         }
 
         // Normally, the CF returned from the connect method never completes
@@ -120,7 +119,7 @@ class McpSseTestClientImpl extends McpTestClientBase<McpSseAssert, McpSseTestCli
         MultiMap initHeaders = additionalHeaders.apply(initMessage);
         HttpResponse response;
         try (TracingHandle ignored = startTracingSpan(initMessage, initHeaders)) {
-            response = sendSync(initMessage, initHeaders, clientBasicAuth);
+            response = sendSync(initMessage, initHeaders, clientAuthorization);
         }
         assertEquals(200, response.statusCode(), "Invalid HTTP response status: " + response.statusCode());
 
@@ -154,7 +153,7 @@ class McpSseTestClientImpl extends McpTestClientBase<McpSseAssert, McpSseTestCli
         JsonObject nofitication = newMessage("notifications/initialized");
         MultiMap notifHeaders = additionalHeaders.apply(nofitication);
         try (TracingHandle ignored = startTracingSpan(nofitication, notifHeaders)) {
-            response = sendSync(nofitication, notifHeaders, clientBasicAuth);
+            response = sendSync(nofitication, notifHeaders, clientAuthorization);
         }
         assertEquals(200, response.statusCode());
         connected.set(true);
@@ -164,7 +163,7 @@ class McpSseTestClientImpl extends McpTestClientBase<McpSseAssert, McpSseTestCli
     @Override
     public void disconnect() {
         JsonObject message = newMessage("q/close");
-        HttpResponse response = sendSync(message, additionalHeaders.apply(message), clientBasicAuth);
+        HttpResponse response = sendSync(message, additionalHeaders.apply(message), clientAuthorization);
         assertEquals(200, response.statusCode());
         messageEndpoint = null;
         connected.set(false);
@@ -196,7 +195,7 @@ class McpSseTestClientImpl extends McpTestClientBase<McpSseAssert, McpSseTestCli
     public void sendAndForget(JsonObject message) {
         MultiMap headers = additionalHeaders.apply(message);
         try (TracingHandle tracingHandle = startTracingSpan(message, headers)) {
-            sendAsync(message.encode(), headers, clientBasicAuth);
+            sendAsync(message.encode(), headers, clientAuthorization);
         }
     }
 
@@ -207,11 +206,11 @@ class McpSseTestClientImpl extends McpTestClientBase<McpSseAssert, McpSseTestCli
 
         protected final AtomicReference<Consumer<HttpResponse>> httpResponseValidator;
         protected final AtomicReference<MultiMap> additionalHeaders;
-        protected final AtomicReference<BasicAuth> basicAuth;
+        protected final AtomicReference<Authorization> authorization;
 
         McpSseAssertImpl() {
             this.additionalHeaders = new AtomicReference<>(MultiMap.caseInsensitiveMultiMap());
-            this.basicAuth = new AtomicReference<>();
+            this.authorization = new AtomicReference<>();
             this.httpResponseValidator = new AtomicReference<>(DEFAULT_HTTP_RESPONSE_VALIDATOR);
         }
 
@@ -235,24 +234,24 @@ class McpSseTestClientImpl extends McpTestClientBase<McpSseAssert, McpSseTestCli
 
         @Override
         public McpSseAssert basicAuth(String username, String password) {
-            this.basicAuth.set(new BasicAuth(username, password));
+            this.authorization.set(Authorization.basic(username, password));
             return this;
         }
 
         @Override
         public McpSseAssert noBasicAuth() {
-            this.basicAuth.set(new BasicAuth(null, null));
+            this.authorization.set(Authorization.none());
             return this;
         }
 
         protected TracingHandle doSend(JsonObject message) {
             MultiMap headers = additionalHeaders(message);
             try (TracingHandle tracingHandle = startTracingSpan(message, headers)) {
-                BasicAuth basicAuth = this.basicAuth.get();
-                if (basicAuth == null) {
-                    basicAuth = clientBasicAuth;
+                Authorization authorization = this.authorization.get();
+                if (authorization == null) {
+                    authorization = clientAuthorization;
                 }
-                HttpResponse response = sendSync(message, headers, basicAuth);
+                HttpResponse response = sendSync(message, headers, authorization);
                 Consumer<HttpResponse> validator = httpResponseValidator.get();
                 if (validator != null) {
                     validator.accept(response);
@@ -299,11 +298,11 @@ class McpSseTestClientImpl extends McpTestClientBase<McpSseAssert, McpSseTestCli
             if (additionalHeaders != null) {
                 headers.addAll(additionalHeaders);
             }
-            BasicAuth basicAuth = this.basicAuth.get();
-            if (basicAuth == null) {
-                basicAuth = clientBasicAuth;
+            Authorization authorization = this.authorization.get();
+            if (authorization == null) {
+                authorization = clientAuthorization;
             }
-            HttpResponse response = sendSync(batch, headers, basicAuth);
+            HttpResponse response = sendSync(batch, headers, authorization);
             Consumer<HttpResponse> validator = httpResponseValidator.get();
             if (validator != null) {
                 validator.accept(response);
@@ -318,7 +317,7 @@ class McpSseTestClientImpl extends McpTestClientBase<McpSseAssert, McpSseTestCli
         private String ssePath = "/mcp/sse";
         private URI baseUri = McpAssured.baseUri;
         private Function<JsonObject, MultiMap> additionalHeaders = m -> MultiMap.caseInsensitiveMultiMap();
-        private BasicAuth basicAuth;
+        private Authorization authorization;
         private boolean expectSseConnectionFailure;
 
         @Override
@@ -356,7 +355,16 @@ class McpSseTestClientImpl extends McpTestClientBase<McpSseAssert, McpSseTestCli
             if (password == null) {
                 throw mustNotBeNull("password");
             }
-            this.basicAuth = new BasicAuth(username, password);
+            this.authorization = Authorization.basic(username, password);
+            return this;
+        }
+
+        @Override
+        public McpSseTestClient.Builder setBearerToken(String token) {
+            if (token == null) {
+                throw mustNotBeNull("token");
+            }
+            this.authorization = Authorization.bearer(token);
             return this;
         }
 
@@ -376,29 +384,30 @@ class McpSseTestClientImpl extends McpTestClientBase<McpSseAssert, McpSseTestCli
 
     }
 
-    private HttpResponse sendSync(JsonObject message, MultiMap additionalHeaders, BasicAuth basicAuth) {
-        return sendSync(message.encode(), additionalHeaders, basicAuth);
+    private HttpResponse sendSync(JsonObject message, MultiMap additionalHeaders, Authorization authorization) {
+        return sendSync(message.encode(), additionalHeaders, authorization);
     }
 
-    private HttpResponse sendSync(JsonArray batch, MultiMap additionalHeaders, BasicAuth basicAuth) {
-        return sendSync(batch.encode(), additionalHeaders, basicAuth);
+    private HttpResponse sendSync(JsonArray batch, MultiMap additionalHeaders, Authorization authorization) {
+        return sendSync(batch.encode(), additionalHeaders, authorization);
     }
 
     private CompletableFuture<java.net.http.HttpResponse<String>> sendAsync(String data, MultiMap additionalHeaders,
-            BasicAuth basicAuth) {
+            Authorization authorization) {
         if (messageEndpoint == null) {
             throw new IllegalStateException("Message endpoint not ready");
         }
-        return HttpClients.getDefault().sendAsync(buildRequest(data, additionalHeaders, basicAuth), BodyHandlers.ofString());
+        return HttpClients.getDefault().sendAsync(buildRequest(data, additionalHeaders, authorization),
+                BodyHandlers.ofString());
     }
 
-    private HttpResponse sendSync(String data, MultiMap additionalHeaders, BasicAuth basicAuth) {
+    private HttpResponse sendSync(String data, MultiMap additionalHeaders, Authorization authorization) {
         if (messageEndpoint == null) {
             throw new IllegalStateException("Message endpoint not ready");
         }
         java.net.http.HttpResponse<String> r;
         try {
-            r = HttpClients.getDefault().send(buildRequest(data, additionalHeaders, basicAuth), BodyHandlers.ofString());
+            r = HttpClients.getDefault().send(buildRequest(data, additionalHeaders, authorization), BodyHandlers.ofString());
             MultiMap responseHeaders = MultiMap.caseInsensitiveMultiMap();
             for (Entry<String, List<String>> e : r.headers().map().entrySet()) {
                 for (String val : e.getValue()) {
@@ -414,7 +423,7 @@ class McpSseTestClientImpl extends McpTestClientBase<McpSseAssert, McpSseTestCli
         }
     }
 
-    private HttpRequest buildRequest(String data, MultiMap additionalHeaders, BasicAuth basicAuth) {
+    private HttpRequest buildRequest(String data, MultiMap additionalHeaders, Authorization authorization) {
         HttpRequest.Builder builder = HttpRequest.newBuilder()
                 .uri(messageEndpoint)
                 .version(Version.HTTP_1_1)
@@ -422,9 +431,8 @@ class McpSseTestClientImpl extends McpTestClientBase<McpSseAssert, McpSseTestCli
                 .POST(BodyPublishers.ofString(data));
         additionalHeaders.forEach(builder::header);
 
-        if (basicAuth != null && !basicAuth.isEmpty()) {
-            builder.header(HEADER_AUTHORIZATION,
-                    McpTestClientBase.getBasicAuthenticationHeader(basicAuth.username(), basicAuth.password()));
+        if (authorization != null && !authorization.isEmpty()) {
+            builder.header(HEADER_AUTHORIZATION, authorization.headerValue());
         }
         return builder.build();
     }

--- a/test/src/main/java/io/quarkiverse/mcp/server/test/McpStreamableTestClientImpl.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/McpStreamableTestClientImpl.java
@@ -40,7 +40,7 @@ class McpStreamableTestClientImpl extends McpTestClientBase<McpStreamableAssert,
 
     private McpStreamableTestClientImpl(BuilderImpl builder) {
         super(builder.name, builder.version, builder.protocolVersion, builder.clientCapabilities, builder.additionalHeaders,
-                builder.autoPong, builder.basicAuth, builder.title, builder.description, builder.websiteUrl, builder.icons,
+                builder.autoPong, builder.authorization, builder.title, builder.description, builder.websiteUrl, builder.icons,
                 builder.openTelemetry);
         this.mcpEndpoint = createEndpointUri(builder.baseUri, builder.mcpPath);
         this.client = new McpStreamableClient(mcpEndpoint);
@@ -65,7 +65,7 @@ class McpStreamableTestClientImpl extends McpTestClientBase<McpStreamableAssert,
         }
         JsonObject initMessage = newInitMessage();
         MultiMap initHeaders = additionalHeaders.apply(initMessage);
-        addAuthorizationHeader(initHeaders, clientBasicAuth);
+        addAuthorizationHeader(initHeaders, clientAuthorization);
         HttpResponse<String> response;
         try (TracingHandle ignored = startTracingSpan(initMessage, initHeaders)) {
             response = client.sendSync(initMessage.encode(), initHeaders);
@@ -131,7 +131,7 @@ class McpStreamableTestClientImpl extends McpTestClientBase<McpStreamableAssert,
         // Send "notifications/initialized"
         JsonObject nofitication = newMessage("notifications/initialized");
         MultiMap headers = additionalHeaders(nofitication);
-        addAuthorizationHeader(headers, clientBasicAuth);
+        addAuthorizationHeader(headers, clientAuthorization);
         try (TracingHandle ignored = startTracingSpan(nofitication, headers)) {
             response = client.sendSync(nofitication.encode(), headers);
         }
@@ -187,34 +187,34 @@ class McpStreamableTestClientImpl extends McpTestClientBase<McpStreamableAssert,
     public void sendAndForget(JsonObject message) {
         MultiMap headers = additionalHeaders(message);
         try (TracingHandle tracingHandle = startTracingSpan(message, headers)) {
-            send(message, headers, clientBasicAuth);
+            send(message, headers, clientAuthorization);
         }
     }
 
-    private void send(JsonObject message, MultiMap additionalHeaders, BasicAuth basicAuth) {
-        send(message.encode(), additionalHeaders, basicAuth);
+    private void send(JsonObject message, MultiMap additionalHeaders, Authorization authorization) {
+        send(message.encode(), additionalHeaders, authorization);
     }
 
-    private void send(JsonArray batch, MultiMap additionalHeaders, BasicAuth basicAuth) {
-        send(batch.encode(), additionalHeaders, basicAuth);
+    private void send(JsonArray batch, MultiMap additionalHeaders, Authorization authorization) {
+        send(batch.encode(), additionalHeaders, authorization);
     }
 
-    private void send(String data, MultiMap additionalHeaders, BasicAuth basicAuth) {
+    private void send(String data, MultiMap additionalHeaders, Authorization authorization) {
         if (!connected.get()) {
             throw new IllegalStateException("Client is not connected");
         }
-        addAuthorizationHeader(additionalHeaders, basicAuth);
+        addAuthorizationHeader(additionalHeaders, authorization);
         client.send(data, additionalHeaders);
     }
 
     class McpStreamableAssertImpl extends McpAssertBase implements McpStreamableAssert {
 
         protected final AtomicReference<MultiMap> additionalHeaders;
-        protected final AtomicReference<BasicAuth> basicAuth;
+        protected final AtomicReference<Authorization> authorization;
 
         private McpStreamableAssertImpl() {
             this.additionalHeaders = new AtomicReference<>();
-            this.basicAuth = new AtomicReference<>();
+            this.authorization = new AtomicReference<>();
         }
 
         @Override
@@ -225,13 +225,13 @@ class McpStreamableTestClientImpl extends McpTestClientBase<McpStreamableAssert,
 
         @Override
         public McpStreamableAssert basicAuth(String username, String password) {
-            this.basicAuth.set(new BasicAuth(username, password));
+            this.authorization.set(Authorization.basic(username, password));
             return this;
         }
 
         @Override
         public McpStreamableAssert noBasicAuth() {
-            this.basicAuth.set(new BasicAuth(null, null));
+            this.authorization.set(Authorization.none());
             return this;
         }
 
@@ -242,11 +242,11 @@ class McpStreamableTestClientImpl extends McpTestClientBase<McpStreamableAssert,
 
         protected TracingHandle doSend(JsonObject message) {
             try (TracingHandle tracingHandle = startTracingSpan(message, additionalHeaders(message))) {
-                BasicAuth basicAuth = this.basicAuth.get();
-                if (basicAuth == null) {
-                    basicAuth = clientBasicAuth;
+                Authorization authorization = this.authorization.get();
+                if (authorization == null) {
+                    authorization = clientAuthorization;
                 }
-                send(message, additionalHeaders(message), basicAuth);
+                send(message, additionalHeaders(message), authorization);
             }
             return null;
         }
@@ -279,11 +279,11 @@ class McpStreamableTestClientImpl extends McpTestClientBase<McpStreamableAssert,
             if (additionalHeaders != null) {
                 headers.addAll(additionalHeaders);
             }
-            BasicAuth basicAuth = this.basicAuth.get();
-            if (basicAuth == null) {
-                basicAuth = clientBasicAuth;
+            Authorization authorization = this.authorization.get();
+            if (authorization == null) {
+                authorization = clientAuthorization;
             }
-            send(batch, headers, basicAuth);
+            send(batch, headers, authorization);
             return super.thenAssertResults();
         }
 
@@ -295,7 +295,7 @@ class McpStreamableTestClientImpl extends McpTestClientBase<McpStreamableAssert,
         private String mcpPath = "/mcp";
         private URI baseUri = McpAssured.baseUri;
         private Function<JsonObject, MultiMap> additionalHeaders = m -> MultiMap.caseInsensitiveMultiMap();
-        private BasicAuth basicAuth;
+        private Authorization authorization;
         private boolean openSubsidiarySse = false;
         private Consumer<ConnectFailureResponse> connectFailureConsumer;
 
@@ -334,7 +334,16 @@ class McpStreamableTestClientImpl extends McpTestClientBase<McpStreamableAssert,
             if (password == null) {
                 throw mustNotBeNull("password");
             }
-            this.basicAuth = new BasicAuth(username, password);
+            this.authorization = Authorization.basic(username, password);
+            return this;
+        }
+
+        @Override
+        public McpStreamableTestClient.Builder setBearerToken(String token) {
+            if (token == null) {
+                throw mustNotBeNull("token");
+            }
+            this.authorization = Authorization.bearer(token);
             return this;
         }
 

--- a/test/src/main/java/io/quarkiverse/mcp/server/test/McpTestClientBase.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/McpTestClientBase.java
@@ -64,7 +64,7 @@ abstract class McpTestClientBase<ASSERT extends McpAssert<ASSERT>, CLIENT extend
     protected final Set<ClientCapability> clientCapabilities;
     protected final Function<JsonObject, MultiMap> additionalHeaders;
     protected final boolean autoPong;
-    protected final BasicAuth clientBasicAuth;
+    protected final Authorization clientAuthorization;
     protected final OpenTelemetry openTelemetry;
 
     protected final AtomicBoolean connected;
@@ -76,7 +76,7 @@ abstract class McpTestClientBase<ASSERT extends McpAssert<ASSERT>, CLIENT extend
     protected Set<Icon> icons;
 
     McpTestClientBase(String name, String version, String protocolVersion, Set<ClientCapability> clientCapabilities,
-            Function<JsonObject, MultiMap> additionalHeaders, boolean autoPong, BasicAuth clientBasicAuth,
+            Function<JsonObject, MultiMap> additionalHeaders, boolean autoPong, Authorization clientAuthorization,
             String title, String description, String websiteUrl, Set<Icon> icons, OpenTelemetry openTelemetry) {
         this.name = name;
         this.version = version;
@@ -84,7 +84,7 @@ abstract class McpTestClientBase<ASSERT extends McpAssert<ASSERT>, CLIENT extend
         this.clientCapabilities = clientCapabilities;
         this.additionalHeaders = additionalHeaders;
         this.autoPong = autoPong;
-        this.clientBasicAuth = clientBasicAuth;
+        this.clientAuthorization = clientAuthorization;
         this.openTelemetry = openTelemetry;
         this.connected = new AtomicBoolean();
         this.title = title;
@@ -387,17 +387,31 @@ abstract class McpTestClientBase<ASSERT extends McpAssert<ASSERT>, CLIENT extend
         return URI.create(endpointUri);
     }
 
-    record BasicAuth(String username, String password) {
+    /**
+     * The value of the {@code Authorization} header, e.g. the {@code Basic} or {@code Bearer} scheme.
+     */
+    record Authorization(String headerValue) {
+
+        static Authorization basic(String username, String password) {
+            return new Authorization(getBasicAuthenticationHeader(username, password));
+        }
+
+        static Authorization bearer(String token) {
+            return new Authorization("Bearer " + token);
+        }
+
+        static Authorization none() {
+            return new Authorization(null);
+        }
 
         boolean isEmpty() {
-            return username == null;
+            return headerValue == null;
         }
     }
 
-    protected void addAuthorizationHeader(MultiMap headers, BasicAuth basicAuth) {
-        if (basicAuth != null) {
-            headers.add(HEADER_AUTHORIZATION,
-                    McpTestClientBase.getBasicAuthenticationHeader(basicAuth.username(), basicAuth.password()));
+    protected void addAuthorizationHeader(MultiMap headers, Authorization authorization) {
+        if (authorization != null && !authorization.isEmpty()) {
+            headers.add(HEADER_AUTHORIZATION, authorization.headerValue());
         }
     }
 

--- a/test/src/main/java/io/quarkiverse/mcp/server/test/McpWebSocketTestClientImpl.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/McpWebSocketTestClientImpl.java
@@ -37,7 +37,7 @@ class McpWebSocketTestClientImpl extends McpTestClientBase<McpWebSocketAssert, M
 
     McpWebSocketTestClientImpl(BuilderImpl builder) {
         super(builder.name, builder.version, builder.protocolVersion, builder.clientCapabilities, null,
-                builder.autoPong, builder.basicAuth, builder.title, builder.description, builder.websiteUrl, builder.icons,
+                builder.autoPong, builder.authorization, builder.title, builder.description, builder.websiteUrl, builder.icons,
                 builder.openTelemetry);
         this.endpointUri = createEndpointUri(builder.baseUri, builder.endpointPath);
         LOG.debugf("McpWebSocketTestClient created with WebSocket endpoint: %s", endpointUri);
@@ -60,10 +60,7 @@ class McpWebSocketTestClientImpl extends McpTestClientBase<McpWebSocketAssert, M
             }
             // TODO additional headers
             MultiMap headers = MultiMap.caseInsensitiveMultiMap();
-            if (clientBasicAuth != null) {
-                headers.add(HEADER_AUTHORIZATION,
-                        McpTestClientBase.getBasicAuthenticationHeader(clientBasicAuth.username(), clientBasicAuth.password()));
-            }
+            addAuthorizationHeader(headers, clientAuthorization);
 
             client = new McpWebSocketClient(endpointUri, vertx, headers);
         }
@@ -187,12 +184,21 @@ class McpWebSocketTestClientImpl extends McpTestClientBase<McpWebSocketAssert, M
 
         private String endpointPath = "/mcp/ws";
         private URI baseUri = McpAssured.baseUri;
-        private BasicAuth basicAuth;
+        private Authorization authorization;
 
         @Override
         public McpWebSocketTestClient.Builder setBasicAuth(String username,
                 String password) {
-            this.basicAuth = new BasicAuth(username, password);
+            this.authorization = Authorization.basic(username, password);
+            return this;
+        }
+
+        @Override
+        public McpWebSocketTestClient.Builder setBearerToken(String token) {
+            if (token == null) {
+                throw mustNotBeNull("token");
+            }
+            this.authorization = Authorization.bearer(token);
             return this;
         }
 

--- a/transports/http/authorization-integration-tests/src/test/java/io/quarkiverse/mcp/server/authorization/it/ServerFeaturesTest.java
+++ b/transports/http/authorization-integration-tests/src/test/java/io/quarkiverse/mcp/server/authorization/it/ServerFeaturesTest.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.Test;
 import io.quarkiverse.mcp.server.test.McpAssured;
 import io.quarkiverse.mcp.server.test.McpAssured.McpStreamableTestClient;
 import io.quarkus.test.junit.QuarkusTest;
-import io.vertx.core.MultiMap;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
@@ -30,8 +29,7 @@ class ServerFeaturesTest {
         String accessToken = getAccessToken();
 
         McpStreamableTestClient client = McpAssured.newStreamableClient()
-                .setAdditionalHeaders(msg -> MultiMap.caseInsensitiveMultiMap()
-                        .add("Authorization", "Bearer " + accessToken))
+                .setBearerToken(accessToken)
                 .build()
                 .connect();
         client.when()
@@ -73,8 +71,7 @@ class ServerFeaturesTest {
         String accessToken = getAccessToken("http://localhost:8081/access-token-no-audience");
 
         McpAssured.newStreamableClient()
-                .setAdditionalHeaders(msg -> MultiMap.caseInsensitiveMultiMap()
-                        .add("Authorization", "Bearer " + accessToken))
+                .setBearerToken(accessToken)
                 .setExpectConnectFailure()
                 .build()
                 .connect();
@@ -88,8 +85,7 @@ class ServerFeaturesTest {
                 .pollInterval(1, TimeUnit.SECONDS)
                 .untilAsserted(() -> {
                     McpAssured.newStreamableClient()
-                            .setAdditionalHeaders(msg -> MultiMap.caseInsensitiveMultiMap()
-                                    .add("Authorization", "Bearer " + accessToken))
+                            .setBearerToken(accessToken)
                             .setExpectConnectFailure(r -> {
                                 assertEquals(401, r.statusCode());
                             })
@@ -104,8 +100,7 @@ class ServerFeaturesTest {
         String invalidToken = accessToken.substring(0, accessToken.lastIndexOf('.')) + ".invalid-signature";
 
         McpAssured.newStreamableClient()
-                .setAdditionalHeaders(msg -> MultiMap.caseInsensitiveMultiMap()
-                        .add("Authorization", "Bearer " + invalidToken))
+                .setBearerToken(invalidToken)
                 .setExpectConnectFailure(r -> {
                     assertEquals(401, r.statusCode());
                 })
@@ -118,8 +113,7 @@ class ServerFeaturesTest {
         String accessToken = getAccessToken();
 
         McpStreamableTestClient client = McpAssured.newStreamableClient()
-                .setAdditionalHeaders(msg -> MultiMap.caseInsensitiveMultiMap()
-                        .add("Authorization", "Bearer " + accessToken))
+                .setBearerToken(accessToken)
                 .build()
                 .connect();
 
@@ -141,8 +135,7 @@ class ServerFeaturesTest {
         String accessToken = getAccessToken("http://localhost:8081/access-token-phone-scope");
 
         McpStreamableTestClient client = McpAssured.newStreamableClient()
-                .setAdditionalHeaders(msg -> MultiMap.caseInsensitiveMultiMap()
-                        .add("Authorization", "Bearer " + accessToken))
+                .setBearerToken(accessToken)
                 .build()
                 .connect();
         client.when()
@@ -157,8 +150,7 @@ class ServerFeaturesTest {
         String accessToken = getAccessToken();
 
         McpStreamableTestClient client = McpAssured.newStreamableClient()
-                .setAdditionalHeaders(msg -> MultiMap.caseInsensitiveMultiMap()
-                        .add("Authorization", "Bearer " + accessToken))
+                .setBearerToken(accessToken)
                 .build()
                 .connect();
         client.when()
@@ -176,8 +168,7 @@ class ServerFeaturesTest {
 
         McpStreamableTestClient client = McpAssured.newStreamableClient()
                 .setMcpPath("/beta/mcp")
-                .setAdditionalHeaders(msg -> MultiMap.caseInsensitiveMultiMap()
-                        .add("Authorization", "Bearer " + accessToken))
+                .setBearerToken(accessToken)
                 .build()
                 .connect();
         client.when()
@@ -194,8 +185,7 @@ class ServerFeaturesTest {
 
         McpAssured.newStreamableClient()
                 .setMcpPath("/beta/mcp")
-                .setAdditionalHeaders(msg -> MultiMap.caseInsensitiveMultiMap()
-                        .add("Authorization", "Bearer " + accessToken))
+                .setBearerToken(accessToken)
                 .setExpectConnectFailure(r -> {
                     assertEquals(403, r.statusCode());
 

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/security/BearerTokenMcpEndpointTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/security/BearerTokenMcpEndpointTest.java
@@ -1,0 +1,122 @@
+package io.quarkiverse.mcp.server.test.tools.security;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import jakarta.enterprise.context.ApplicationScoped;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.TextContent;
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkiverse.mcp.server.test.McpAssured.McpSseTestClient;
+import io.quarkiverse.mcp.server.test.McpAssured.McpStreamableTestClient;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.security.credential.PasswordCredential;
+import io.quarkus.security.identity.IdentityProviderManager;
+import io.quarkus.security.identity.SecurityIdentity;
+import io.quarkus.security.identity.request.UsernamePasswordAuthenticationRequest;
+import io.quarkus.security.test.utils.TestIdentityController;
+import io.quarkus.security.test.utils.TestIdentityProvider;
+import io.quarkus.test.QuarkusUnitTest;
+import io.quarkus.vertx.http.runtime.security.ChallengeData;
+import io.quarkus.vertx.http.runtime.security.HttpAuthenticationMechanism;
+import io.smallrye.mutiny.Uni;
+import io.vertx.ext.web.RoutingContext;
+
+public class BearerTokenMcpEndpointTest extends McpServerTest {
+
+    private static final String TOKEN = "test-token-007";
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .withApplicationRoot(
+                    root -> root.addClasses(MyTools.class, TestBearerAuthMechanism.class, TestIdentityProvider.class,
+                            TestIdentityController.class))
+            .overrideConfigKey("quarkus.http.auth.permission.secured.paths", "/mcp*")
+            .overrideConfigKey("quarkus.http.auth.permission.secured.policy", "authenticated");
+
+    @BeforeAll
+    public static void setupUsers() {
+        TestIdentityController.resetRoles()
+                .add("alice", "alice", "admin");
+    }
+
+    @Test
+    public void testStreamableClientWithBearerToken() {
+        McpStreamableTestClient client = McpAssured.newStreamableClient()
+                .setExpectConnectFailure(response -> assertEquals(401, response.statusCode()))
+                .build()
+                .connect();
+        assertFalse(client.isConnected());
+
+        client = McpAssured.newStreamableClient()
+                .setBearerToken("nonsense")
+                .setExpectConnectFailure(response -> assertEquals(401, response.statusCode()))
+                .build()
+                .connect();
+        assertFalse(client.isConnected());
+
+        client = McpAssured.newStreamableClient()
+                .setBearerToken(TOKEN)
+                .build()
+                .connect();
+
+        client.when()
+                .toolsList(page -> {
+                    assertEquals(1, page.tools().size());
+                })
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testSseClientWithBearerToken() {
+        McpSseTestClient client = McpAssured.newSseClient()
+                .setExpectSseConnectionFailure()
+                .build()
+                .connect();
+        assertFalse(client.isConnected());
+
+        client = McpAssured.newSseClient()
+                .setBearerToken(TOKEN)
+                .build()
+                .connect();
+        assertTrue(client.isConnected());
+    }
+
+    public static class MyTools {
+
+        @Tool
+        TextContent alpha(int price) {
+            return new TextContent("foo".repeat(price));
+        }
+
+    }
+
+    /**
+     * Authenticates requests whose bearer token is {@link #TOKEN} as the user "alice".
+     */
+    @ApplicationScoped
+    public static class TestBearerAuthMechanism implements HttpAuthenticationMechanism {
+
+        @Override
+        public Uni<SecurityIdentity> authenticate(RoutingContext context, IdentityProviderManager identityProviderManager) {
+            String authorization = context.request().getHeader("Authorization");
+            if (("Bearer " + TOKEN).equals(authorization)) {
+                return identityProviderManager.authenticate(
+                        new UsernamePasswordAuthenticationRequest("alice", new PasswordCredential("alice".toCharArray())));
+            }
+            return Uni.createFrom().nullItem();
+        }
+
+        @Override
+        public Uni<ChallengeData> getChallenge(RoutingContext context) {
+            return Uni.createFrom().item(new ChallengeData(401, "WWW-Authenticate", "Bearer"));
+        }
+    }
+
+}


### PR DESCRIPTION
Adds `setBearerToken(String)` to the `McpAssured` SSE, Streamable HTTP and WebSocket client builders, next to the existing `setBasicAuth()`.

Testing an MCP server secured with bearer tokens (e.g. via `quarkus-oidc` and `quarkus-mcp-server-oidc`) previously required wiring the `Authorization` header manually:

```java
McpAssured.newStreamableClient()
        .setAdditionalHeaders(msg -> MultiMap.caseInsensitiveMultiMap()
                .add("Authorization", "Bearer " + accessToken))
        .build()
        .connect();
```

which becomes:

```java
McpAssured.newStreamableClient()
        .setBearerToken(accessToken)
        .build()
        .connect();
```

This should make it easier to write test cases when using bearer auth.
