### PR TITLE
Initial support for stateless version of the MCP protocol (2026-07-28-RC+)

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/Elicitation.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/Elicitation.java
@@ -7,7 +7,7 @@ package io.quarkiverse.mcp.server;
  * @see ElicitationRequest
  * @see UrlElicitationRequest
  */
-public interface Elicitation {
+public interface Elicitation extends MrtrRequest {
 
     /**
      * @return {@code true} if the client supports the {@link ClientCapability#ELICITATION} capability, {@code false} otherwise

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/InitialRequest.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/InitialRequest.java
@@ -11,13 +11,13 @@ import java.util.List;
  * @param transport the transport used by the client (must not be {@code null})
  * @param autoInitialized {@code true} if the request was created automatically (without client-initiated initialization)
  */
-public record InitialRequest(Implementation implementation, String protocolVersion,
+public record InitialRequest(Implementation implementation, McpProtocolVersion protocolVersion,
         List<ClientCapability> clientCapabilities, Transport transport, boolean autoInitialized) {
 
     /**
      * Creates a new initial request with {@code autoInitialized} set to {@code false}.
      */
-    public InitialRequest(Implementation implementation, String protocolVersion,
+    public InitialRequest(Implementation implementation, McpProtocolVersion protocolVersion,
             List<ClientCapability> clientCapabilities, Transport transport) {
         this(implementation, protocolVersion, clientCapabilities, transport, false);
     }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/InputRequiredException.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/InputRequiredException.java
@@ -1,0 +1,179 @@
+package io.quarkiverse.mcp.server;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+
+/**
+ * Indicates that a request cannot be processed until additional input is provided by the client.
+ * <p>
+ * When thrown from a server feature method (tool, prompt or resource), this exception is automatically converted to an
+ * {@code InputRequiredResult} JSON-RPC result with {@code resultType: "input_required"}.
+ * <p>
+ * This is part of the Multi Round-Trip Requests (MRTR) pattern used with stateless protocol versions, where server-initiated
+ * requests are not supported. Instead of calling {@link ElicitationRequest#send()} or {@link SamplingRequest#send()}, the
+ * server returns an {@code InputRequiredResult} and the client retries the original request with the gathered input.
+ *
+ * @see MrtrRequest#isServerInitiatedRequestSupported()
+ * @see MrtrRequest#inputRequired()
+ */
+public class InputRequiredException extends RuntimeException {
+
+    private static final long serialVersionUID = 1L;
+
+    private final Map<String, InputRequestEntry> inputRequests;
+    private final String requestState;
+
+    /**
+     * @see MrtrRequest#inputRequired()
+     */
+    InputRequiredException(Map<String, InputRequestEntry> inputRequests, String requestState) {
+        super("Additional input required");
+        this.inputRequests = Map.copyOf(inputRequests);
+        this.requestState = requestState;
+    }
+
+    /**
+     * @return the map of input requests keyed by server-assigned identifiers
+     */
+    public Map<String, InputRequestEntry> inputRequests() {
+        return inputRequests;
+    }
+
+    /**
+     * @return the opaque request state, or {@code null}
+     */
+    public String requestState() {
+        return requestState;
+    }
+
+    /**
+     * @see MrtrRequest#inputRequired()
+     */
+    static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * An input request entry included in the {@code InputRequiredResult}.
+     */
+    public sealed interface InputRequestEntry {
+    }
+
+    /**
+     * An elicitation (form mode) input request entry.
+     *
+     * @param request the elicitation request
+     */
+    public record ElicitationInputRequest(ElicitationRequest request) implements InputRequestEntry {
+        public ElicitationInputRequest {
+            Objects.requireNonNull(request, "request must not be null");
+        }
+    }
+
+    /**
+     * An elicitation (URL mode) input request entry.
+     *
+     * @param request the URL elicitation request
+     */
+    public record UrlElicitationInputRequest(UrlElicitationRequest request) implements InputRequestEntry {
+        public UrlElicitationInputRequest {
+            Objects.requireNonNull(request, "request must not be null");
+        }
+    }
+
+    /**
+     * A sampling input request entry.
+     *
+     * @param request the sampling request
+     */
+    public record SamplingInputRequest(SamplingRequest request) implements InputRequestEntry {
+        public SamplingInputRequest {
+            Objects.requireNonNull(request, "request must not be null");
+        }
+    }
+
+    /**
+     * A roots/list input request entry.
+     */
+    public record RootsInputRequest() implements InputRequestEntry {
+    }
+
+    public static class Builder {
+
+        private final Map<String, InputRequestEntry> inputRequests = new LinkedHashMap<>();
+        private String requestState;
+
+        Builder() {
+        }
+
+        /**
+         * Adds an elicitation (form mode) input request.
+         *
+         * @param key the server-assigned identifier
+         * @param request the elicitation request built via {@link Elicitation#requestBuilder()}
+         * @return self
+         */
+        public Builder addElicitationRequest(String key, ElicitationRequest request) {
+            inputRequests.put(Objects.requireNonNull(key), new ElicitationInputRequest(request));
+            return this;
+        }
+
+        /**
+         * Adds an elicitation (URL mode) input request.
+         *
+         * @param key the server-assigned identifier
+         * @param request the URL elicitation request built via {@link Elicitation#urlRequestBuilder()}
+         * @return self
+         */
+        public Builder addUrlElicitationRequest(String key, UrlElicitationRequest request) {
+            inputRequests.put(Objects.requireNonNull(key), new UrlElicitationInputRequest(request));
+            return this;
+        }
+
+        /**
+         * Adds a sampling input request.
+         *
+         * @param key the server-assigned identifier
+         * @param request the sampling request built via {@link Sampling#requestBuilder()}
+         * @return self
+         */
+        public Builder addSamplingRequest(String key, SamplingRequest request) {
+            inputRequests.put(Objects.requireNonNull(key), new SamplingInputRequest(request));
+            return this;
+        }
+
+        /**
+         * Adds a roots/list input request.
+         *
+         * @param key the server-assigned identifier
+         * @return self
+         */
+        public Builder addRootsRequest(String key) {
+            inputRequests.put(Objects.requireNonNull(key), new RootsInputRequest());
+            return this;
+        }
+
+        /**
+         * Sets the opaque request state. The client must echo this value back when retrying the request.
+         *
+         * @param requestState
+         * @return self
+         */
+        public Builder setRequestState(String requestState) {
+            this.requestState = Objects.requireNonNull(requestState);
+            return this;
+        }
+
+        /**
+         * @return a new exception
+         * @throws IllegalStateException if neither inputRequests nor requestState is set
+         */
+        public InputRequiredException build() {
+            if (inputRequests.isEmpty() && requestState == null) {
+                throw new IllegalStateException("At least one of inputRequests or requestState must be set");
+            }
+            return new InputRequiredException(inputRequests, requestState);
+        }
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/InputResponses.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/InputResponses.java
@@ -1,0 +1,51 @@
+package io.quarkiverse.mcp.server;
+
+import java.util.List;
+
+/**
+ * Provides access to the {@code inputResponses} from a client retry as part of the Multi Round-Trip Requests (MRTR) pattern.
+ * <p>
+ * When a server feature method throws an {@link InputRequiredException}, the client may retry the original request with the
+ * gathered input. This object provides typed access to those responses.
+ * <p>
+ * Obtain an instance via {@link Elicitation#inputResponses()}, {@link Sampling#inputResponses()}, or
+ * {@link Roots#inputResponses()}. The returned object is never {@code null} but may be {@linkplain #isEmpty() empty} on the
+ * initial request.
+ *
+ * @see InputRequiredException
+ * @see Elicitation#inputResponses()
+ * @see Sampling#inputResponses()
+ * @see Roots#inputResponses()
+ */
+public interface InputResponses {
+
+    /**
+     * @return {@code true} if no input responses are present (i.e. this is the initial request)
+     */
+    boolean isEmpty();
+
+    /**
+     * @param key the server-assigned identifier used in {@link InputRequiredException.Builder}
+     * @return {@code true} if a response with the given key exists
+     */
+    boolean has(String key);
+
+    /**
+     * @param key the server-assigned identifier
+     * @return the elicitation response, or {@code null} if not present
+     */
+    ElicitationResponse getElicitationResponse(String key);
+
+    /**
+     * @param key the server-assigned identifier
+     * @return the sampling response, or {@code null} if not present
+     */
+    SamplingResponse getSamplingResponse(String key);
+
+    /**
+     * @param key the server-assigned identifier
+     * @return the list of roots, or {@code null} if not present
+     */
+    List<Root> getRootsResponse(String key);
+
+}

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/JsonRpcErrorCodes.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/JsonRpcErrorCodes.java
@@ -8,7 +8,9 @@ public final class JsonRpcErrorCodes {
     public static final int METHOD_NOT_FOUND = -32601;
     public static final int INVALID_REQUEST = -32600;
     public static final int PARSE_ERROR = -32700;
-    public static final int SECURITY_ERROR = -32001;
+    public static final int HEADER_MISMATCH = -32001;
+    public static final int SECURITY_ERROR = -32005;
+    public static final int UNSUPPORTED_PROTOCOL_VERSION = -32004;
     public static final int URL_ELICITATION_REQUIRED = -32042;
 
     private JsonRpcErrorCodes() {

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/McpConnection.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/McpConnection.java
@@ -13,16 +13,25 @@ public interface McpConnection {
     String id();
 
     /**
+     * The connection status is not relevant for {@linkplain #isTransient()
+     * transient} connections, which are always {@link Status#IN_OPERATION}.
+     *
      * @return the current status (not {@code null})}
      */
     Status status();
 
     /**
+     * For {@linkplain #isTransient() transient} connections, the initial request is synthesized from per-request {@code _meta}
+     * data (protocol version, client info, client capabilities).
+     *
      * @return the initial request (not {@code null})}
      */
     InitialRequest initialRequest();
 
     /**
+     * For {@linkplain #isTransient() transient} connections, returns the per-request log level from
+     * {@code _meta} ({@code io.modelcontextprotocol/logLevel}), or the default level if not specified.
+     *
      * @return the current log level
      */
     LogLevel logLevel();
@@ -32,6 +41,14 @@ public interface McpConnection {
      * @see McpServer
      */
     String serverName();
+
+    /**
+     * A transient connection is created per-request and is not tracked on the server. Stateless clients and
+     * auto-initialized connections use transient connections.
+     *
+     * @return {@code true} if this connection is transient
+     */
+    boolean isTransient();
 
     enum Status {
 

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/McpMethod.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/McpMethod.java
@@ -1,5 +1,8 @@
 package io.quarkiverse.mcp.server;
 
+import java.util.HashMap;
+import java.util.Map;
+
 public enum McpMethod {
 
     INITIALIZE("initialize"),
@@ -40,6 +43,16 @@ public enum McpMethod {
     Q_CLOSE("q/close"),
     ;
 
+    private static final Map<String, McpMethod> BY_NAME;
+
+    static {
+        Map<String, McpMethod> map = new HashMap<>();
+        for (McpMethod m : values()) {
+            map.put(m.name, m);
+        }
+        BY_NAME = Map.copyOf(map);
+    }
+
     private final String name;
 
     McpMethod(String value) {
@@ -51,13 +64,9 @@ public enum McpMethod {
     }
 
     public static McpMethod from(String method) {
-        if (method != null && !method.isEmpty()) {
-            for (McpMethod m : values()) {
-                if (m.name.equals(method)) {
-                    return m;
-                }
-            }
+        if (method == null || method.isEmpty()) {
+            return null;
         }
-        return null;
+        return BY_NAME.get(method);
     }
 }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/McpMethod.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/McpMethod.java
@@ -33,6 +33,9 @@ public enum McpMethod {
     ELICITATION_CREATE("elicitation/create"),
     NOTIFICATIONS_ELICITATION_COMPLETE("notifications/elicitation/complete"),
 
+    SUBSCRIPTIONS_LISTEN("subscriptions/listen"),
+    NOTIFICATIONS_SUBSCRIPTIONS_ACKNOWLEDGED("notifications/subscriptions/acknowledged"),
+
     // non-standard methods
     Q_CLOSE("q/close"),
     ;

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/McpMethod.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/McpMethod.java
@@ -3,6 +3,7 @@ package io.quarkiverse.mcp.server;
 public enum McpMethod {
 
     INITIALIZE("initialize"),
+    SERVER_DISCOVER("server/discover"),
 
     PROMPTS_LIST("prompts/list"),
     PROMPTS_GET("prompts/get"),

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/McpProtocolVersion.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/McpProtocolVersion.java
@@ -1,6 +1,8 @@
 package io.quarkiverse.mcp.server;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Represents the supported MCP protocol versions.
@@ -65,6 +67,16 @@ public enum McpProtocolVersion {
             V_2025_03_26.version,
             V_2024_11_05.version);
 
+    private static final Map<String, McpProtocolVersion> BY_VERSION;
+
+    static {
+        Map<String, McpProtocolVersion> map = new HashMap<>();
+        for (McpProtocolVersion v : values()) {
+            map.put(v.version, v);
+        }
+        BY_VERSION = Map.copyOf(map);
+    }
+
     /**
      * @return {@code true} if the given version string uses the stateless model
      */
@@ -80,14 +92,10 @@ public enum McpProtocolVersion {
      * @return the matching enum constant, or {@code null} if no match
      */
     public static McpProtocolVersion from(String version) {
-        if (version != null) {
-            for (McpProtocolVersion v : values()) {
-                if (v.version.equals(version)) {
-                    return v;
-                }
-            }
+        if (version == null) {
+            return null;
         }
-        return null;
+        return BY_VERSION.get(version);
     }
 
 }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/McpProtocolVersion.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/McpProtocolVersion.java
@@ -1,0 +1,93 @@
+package io.quarkiverse.mcp.server;
+
+import java.util.List;
+
+/**
+ * Represents the supported MCP protocol versions.
+ * <p>
+ * Protocol versions are ISO 8601 dates (YYYY-MM-DD). Versions {@link #FIRST_STATELESS} and later use the stateless
+ * (per-request metadata) model. Earlier versions use the stateful (session-based) model.
+ */
+public enum McpProtocolVersion {
+
+    V_2024_11_05("2024-11-05"),
+    V_2025_03_26("2025-03-26"),
+    V_2025_06_18("2025-06-18"),
+    V_2025_11_25("2025-11-25"),
+    V_2026_07_28("2026-07-28"),
+    ;
+
+    private final String version;
+
+    private McpProtocolVersion(String version) {
+        this.version = version;
+    }
+
+    /**
+     * @return the version string in ISO 8601 date format (YYYY-MM-DD)
+     */
+    public String version() {
+        return version;
+    }
+
+    /**
+     * @return {@code true} if this version uses the stateless (per-request metadata) model
+     */
+    public boolean isStateless() {
+        return version.compareTo(FIRST_STATELESS.version) >= 0;
+    }
+
+    /**
+     * The first protocol version that uses the stateless model.
+     */
+    public static final McpProtocolVersion FIRST_STATELESS = V_2026_07_28;
+
+    /**
+     * The latest protocol version that uses the stateful (session-based) model.
+     */
+    public static final McpProtocolVersion LATEST_STATEFUL = V_2025_11_25;
+
+    /**
+     * The protocol version to assume when no {@code MCP-Protocol-Version} header is present.
+     *
+     * @see <a href="https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#backwards-compatibility">MCP
+     *      spec</a>
+     */
+    public static final McpProtocolVersion DEFAULT_ASSUMED = V_2025_03_26;
+
+    /**
+     * All supported protocol versions.
+     */
+    public static final List<String> SUPPORTED_VERSIONS = List.of(
+            V_2026_07_28.version,
+            V_2025_11_25.version,
+            V_2025_06_18.version,
+            V_2025_03_26.version,
+            V_2024_11_05.version);
+
+    /**
+     * @return {@code true} if the given version string uses the stateless model
+     */
+    public static boolean isStateless(String version) {
+        if (version == null) {
+            throw new IllegalArgumentException("version must not be null");
+        }
+        return version.compareTo(FIRST_STATELESS.version) >= 0;
+    }
+
+    /**
+     * @param version the version string
+     * @return the matching enum constant, or {@code null} if no match
+     */
+    public static McpProtocolVersion from(String version) {
+        if (version != null) {
+            for (McpProtocolVersion v : values()) {
+                if (v.version.equals(version)) {
+                    return v;
+                }
+            }
+        }
+        return null;
+    }
+
+}

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/MetaKey.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/MetaKey.java
@@ -28,6 +28,16 @@ public record MetaKey(String prefix, String name) {
     public static final MetaKey CLIENT_CAPABILITIES = new MetaKey("io.modelcontextprotocol/", "clientCapabilities");
 
     /**
+     * The {@code io.modelcontextprotocol/protocolVersion} key.
+     */
+    public static final MetaKey PROTOCOL_VERSION = new MetaKey("io.modelcontextprotocol/", "protocolVersion");
+
+    /**
+     * The {@code io.modelcontextprotocol/logLevel} key.
+     */
+    public static final MetaKey LOG_LEVEL = new MetaKey("io.modelcontextprotocol/", "logLevel");
+
+    /**
      * Create a new key from the specified string value, i.e. from {@code foo.bar/myKey}.
      *
      * @param value

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/MetaKey.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/MetaKey.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.annotation.JsonValue;
  * <p>
  * {@code _meta} keys have two segments: an optional prefix, and a name.
  */
-public record MetaKey(String prefix, String name) {
+public record MetaKey(String prefix, String name, String key) {
 
     private static final Pattern NAME_PATTERN = Pattern.compile("[a-zA-Z0-9][a-zA-Z0-9_.-]*[a-zA-Z0-9]");
     private static final Pattern PREFIX_PATTERN = Pattern
@@ -43,17 +43,30 @@ public record MetaKey(String prefix, String name) {
     public static final MetaKey SUBSCRIPTION_ID = new MetaKey("io.modelcontextprotocol/", "subscriptionId");
 
     /**
+     * Create a new key with the specified prefix and name.
+     *
+     * @param prefix the optional prefix (e.g. {@code "io.modelcontextprotocol/"})
+     * @param name the key name
+     */
+    public MetaKey(String prefix, String name) {
+        this(prefix, name, prefix == null ? name : prefix + name);
+    }
+
+    /**
      * Create a new key from the specified string value, i.e. from {@code foo.bar/myKey}.
      *
      * @param value
      * @return the key
      */
     public static MetaKey from(String value) {
-        if (!value.contains("/")) {
-            return new MetaKey(null, value);
+        if (value == null || value.isEmpty()) {
+            throw new IllegalArgumentException("value must not be null or empty");
         }
         int slashIdx = value.indexOf('/');
-        return new MetaKey(value.substring(0, slashIdx + 1), value.substring(slashIdx + 1));
+        if (slashIdx < 0) {
+            return new MetaKey(null, value, value);
+        }
+        return new MetaKey(value.substring(0, slashIdx + 1), value.substring(slashIdx + 1), value);
     }
 
     /**
@@ -93,10 +106,7 @@ public record MetaKey(String prefix, String name) {
     @JsonValue
     @Override
     public String toString() {
-        if (prefix == null) {
-            return name;
-        }
-        return prefix + name;
+        return key;
     }
 
     public static boolean isValidName(String value) {

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/MetaKey.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/MetaKey.java
@@ -38,6 +38,11 @@ public record MetaKey(String prefix, String name) {
     public static final MetaKey LOG_LEVEL = new MetaKey("io.modelcontextprotocol/", "logLevel");
 
     /**
+     * The {@code io.modelcontextprotocol/subscriptionId} key.
+     */
+    public static final MetaKey SUBSCRIPTION_ID = new MetaKey("io.modelcontextprotocol/", "subscriptionId");
+
+    /**
      * Create a new key from the specified string value, i.e. from {@code foo.bar/myKey}.
      *
      * @param value

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/MrtrRequest.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/MrtrRequest.java
@@ -1,0 +1,56 @@
+package io.quarkiverse.mcp.server;
+
+/**
+ * Shared interface for the Multi Round-Trip Requests (MRTR) pattern. Provides access to the {@link InputResponses},
+ * {@linkplain #requestState() request state}, and a convenient {@link InputRequiredException} builder.
+ * <p>
+ * With stateless protocol versions, server-initiated requests are not supported. Instead, the server throws an
+ * {@link InputRequiredException} from the feature method. The client retries the original request with the gathered input
+ * and echoes back the {@linkplain #requestState() request state}.
+ *
+ * @see Elicitation
+ * @see Sampling
+ * @see Roots
+ */
+public interface MrtrRequest {
+
+    /**
+     * If the protocol version is stateless then the server-initiated request pattern is not supported and the server must use
+     * the Multi Round-Trip Requests (MRTR) pattern instead, i.e. throw an {@link InputRequiredException} from the feature
+     * method.
+     *
+     * @return {@code true} if the server-initiated request pattern is supported
+     */
+    boolean isServerInitiatedRequestSupported();
+
+    /**
+     * Returns the {@link InputResponses} object associated with the current request. The returned object is never {@code null}
+     * but may be {@linkplain InputResponses#isEmpty() empty} on the initial request.
+     *
+     * @return the input responses, never {@code null}
+     */
+    InputResponses inputResponses();
+
+    /**
+     * Returns the opaque request state echoed back by the client from a previous {@link InputRequiredException}, or
+     * {@code null} if not present.
+     *
+     * @return the request state, or {@code null}
+     */
+    String requestState();
+
+    /**
+     * Returns a new {@link InputRequiredException} builder for the Multi Round-Trip Requests (MRTR) pattern.
+     *
+     * @return a new builder
+     * @throws IllegalStateException if the server-initiated request pattern is supported, i.e. the protocol is stateful
+     */
+    default InputRequiredException.Builder inputRequired() {
+        if (isServerInitiatedRequestSupported()) {
+            throw new IllegalStateException(
+                    "Server-initiated requests are supported; use the server-initiated request API instead");
+        }
+        return InputRequiredException.builder();
+    }
+
+}

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/Roots.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/Roots.java
@@ -12,7 +12,7 @@ import io.smallrye.mutiny.Uni;
  *
  * @see Notification.Type#ROOTS_LIST_CHANGED
  */
-public interface Roots {
+public interface Roots extends MrtrRequest {
 
     /**
      * @return {@code true} if the client supports the {@value ClientCapability#ROOTS} capability, {@code false} otherwise

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/Sampling.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/Sampling.java
@@ -7,7 +7,7 @@ package io.quarkiverse.mcp.server;
  * @see SamplingRequest
  * @see SamplingResponse
  */
-public interface Sampling {
+public interface Sampling extends MrtrRequest {
 
     /**
      * @return {@code true} if the client supports the {@value ClientCapability#SAMPLING} capability, {@code false} otherwise

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ConnectionManager.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ConnectionManager.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
 
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Singleton;
@@ -117,8 +118,14 @@ public class ConnectionManager implements Iterable<McpConnectionBase> {
         return min;
     }
 
+    private static final AtomicLong TRANSIENT_COUNTER = new AtomicLong();
+
     public static String connectionId() {
         return Base64.getUrlEncoder().encodeToString(UUID.randomUUID().toString().getBytes());
+    }
+
+    public static String transientConnectionId() {
+        return "transient/" + TRANSIENT_COUNTER.incrementAndGet();
     }
 
 }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ElicitationImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ElicitationImpl.java
@@ -11,18 +11,23 @@ import io.quarkiverse.mcp.server.Elicitation;
 import io.quarkiverse.mcp.server.ElicitationRequest;
 import io.quarkiverse.mcp.server.ElicitationRequest.Builder;
 import io.quarkiverse.mcp.server.ElicitationRequest.PrimitiveSchema;
+import io.quarkiverse.mcp.server.InputResponses;
 import io.quarkiverse.mcp.server.McpConnection;
 import io.quarkiverse.mcp.server.UrlElicitationRequest;
+import io.vertx.core.json.JsonObject;
 
 class ElicitationImpl implements Elicitation {
 
     static ElicitationImpl from(ArgumentProviders argProviders) {
         ServerRequests sr = argProviders.serverRequests();
         String serverName = argProviders.serverName();
+        JsonObject params = Messages.getParams(argProviders.rawMessage());
         return new ElicitationImpl(argProviders.connection(), argProviders.sender(), sr,
                 sr.getElicitationTimeout(serverName),
                 sr.getElicitationCompletionTimeout(serverName),
-                argProviders.mcpTracing());
+                argProviders.mcpTracing(),
+                InputResponsesImpl.from(params),
+                params != null ? params.getString("requestState") : null);
     }
 
     private final McpConnection connection;
@@ -37,20 +42,41 @@ class ElicitationImpl implements Elicitation {
 
     private final McpTracing mcpTracing;
 
+    private final InputResponses inputResponses;
+
+    private final String requestState;
+
     ElicitationImpl(McpConnection connection, Sender sender, ServerRequests serverRequests, Duration timeout,
-            Duration completionTimeout, McpTracing mcpTracing) {
+            Duration completionTimeout, McpTracing mcpTracing, InputResponses inputResponses, String requestState) {
         this.connection = connection;
         this.sender = sender;
         this.serverRequests = serverRequests;
         this.defaultTimeout = timeout;
         this.defaultCompletionTimeout = completionTimeout;
         this.mcpTracing = mcpTracing;
+        this.inputResponses = inputResponses;
+        this.requestState = requestState;
     }
 
     @Deprecated(forRemoval = true)
     @Override
     public boolean isSupported() {
         return connection.initialRequest().supportsElicitation();
+    }
+
+    @Override
+    public boolean isServerInitiatedRequestSupported() {
+        return !connection.initialRequest().protocolVersion().isStateless();
+    }
+
+    @Override
+    public InputResponses inputResponses() {
+        return inputResponses;
+    }
+
+    @Override
+    public String requestState() {
+        return requestState;
     }
 
     @Override
@@ -122,7 +148,8 @@ class ElicitationImpl implements Elicitation {
                 throw new IllegalStateException("requestedSchema must be set");
             }
             return new ElicitationRequestImpl(message, requestedSchema, sender, serverRequests, timeout,
-                    ElicitationImpl.this.mcpTracing);
+                    ElicitationImpl.this.mcpTracing,
+                    ElicitationImpl.this.connection.initialRequest().protocolVersion().isStateless());
         }
 
     }
@@ -177,7 +204,8 @@ class ElicitationImpl implements Elicitation {
                 throw new IllegalStateException("completionTimeout must not be less than timeout");
             }
             return new UrlElicitationRequestImpl(message, url, elicitationId, sender, serverRequests, timeout,
-                    completionTimeout, ElicitationImpl.this.mcpTracing, ElicitationImpl.this.connection.id());
+                    completionTimeout, ElicitationImpl.this.mcpTracing, ElicitationImpl.this.connection.id(),
+                    ElicitationImpl.this.connection.initialRequest().protocolVersion().isStateless());
         }
 
     }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ElicitationRequestImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ElicitationRequestImpl.java
@@ -32,15 +32,17 @@ public class ElicitationRequestImpl implements ElicitationRequest {
     private final ServerRequests serverRequests;
     private final Duration timeout;
     private final McpTracing mcpTracing;
+    private final boolean stateless;
 
     ElicitationRequestImpl(String message, Map<String, PrimitiveSchema> requestedSchema, Sender sender,
-            ServerRequests serverRequests, Duration timeout, McpTracing mcpTracing) {
+            ServerRequests serverRequests, Duration timeout, McpTracing mcpTracing, boolean stateless) {
         this.message = message;
         this.requestedSchema = Map.copyOf(requestedSchema);
         this.sender = sender;
         this.serverRequests = serverRequests;
         this.timeout = timeout;
         this.mcpTracing = mcpTracing;
+        this.stateless = stateless;
     }
 
     @JsonProperty
@@ -56,6 +58,10 @@ public class ElicitationRequestImpl implements ElicitationRequest {
 
     @Override
     public Uni<ElicitationResponse> send() {
+        if (stateless) {
+            throw new IllegalStateException(
+                    "Server-initiated requests are not supported with stateless protocol versions; use InputRequiredException instead");
+        }
         AtomicLong id = new AtomicLong();
         Uni<ElicitationResponse> ret = Uni.createFrom().completionStage(() -> {
             CompletableFuture<ElicitationResponse> future = new CompletableFuture<ElicitationResponse>();
@@ -102,6 +108,26 @@ public class ElicitationRequestImpl implements ElicitationRequest {
                     });
         }
         return ret;
+    }
+
+    JsonObject toInputRequestJson() {
+        JsonObject properties = new JsonObject();
+        JsonObject schema = new JsonObject().put("type", "object").put("properties", properties);
+        JsonArray required = new JsonArray();
+        for (Entry<String, PrimitiveSchema> e : requestedSchema.entrySet()) {
+            if (e.getValue().required()) {
+                required.add(e.getKey());
+            }
+            properties.put(e.getKey(), e.getValue().asJson());
+        }
+        schema.put("required", required);
+        JsonObject params = new JsonObject()
+                .put("mode", "form")
+                .put("message", message)
+                .put("requestedSchema", schema);
+        return new JsonObject()
+                .put("method", McpMethod.ELICITATION_CREATE.jsonRpcName())
+                .put("params", params);
     }
 
     static class ContentImpl implements Content {

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/FeatureManagerBase.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/FeatureManagerBase.java
@@ -372,10 +372,16 @@ public abstract class FeatureManagerBase<RESULT, INFO extends FeatureManager.Fea
     }
 
     protected void notifyConnections(McpMethod method) {
-        // Notify all connections
         JsonObject notification = Messages.newNotification(method.jsonRpcName());
         for (McpConnectionBase c : connectionManager) {
-            c.send(notification);
+            if (c.status() != McpConnection.Status.IN_OPERATION) {
+                continue;
+            }
+            if (c.supportsSubscriptionsListen()) {
+                c.sendNotification(notification, null);
+            } else {
+                c.send(notification);
+            }
         }
     }
 

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/InputResponsesImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/InputResponsesImpl.java
@@ -1,0 +1,92 @@
+package io.quarkiverse.mcp.server.runtime;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import io.quarkiverse.mcp.server.Content;
+import io.quarkiverse.mcp.server.ElicitationResponse;
+import io.quarkiverse.mcp.server.ElicitationResponse.Action;
+import io.quarkiverse.mcp.server.InputResponses;
+import io.quarkiverse.mcp.server.Role;
+import io.quarkiverse.mcp.server.Root;
+import io.quarkiverse.mcp.server.SamplingResponse;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+class InputResponsesImpl implements InputResponses {
+
+    private static final InputResponsesImpl EMPTY = new InputResponsesImpl(null);
+
+    static InputResponsesImpl from(JsonObject params) {
+        JsonObject inputResponses = params != null ? params.getJsonObject("inputResponses") : null;
+        return inputResponses != null ? new InputResponsesImpl(inputResponses) : EMPTY;
+    }
+
+    private final JsonObject inputResponses;
+
+    InputResponsesImpl(JsonObject inputResponses) {
+        this.inputResponses = inputResponses;
+    }
+
+    @Override
+    public boolean isEmpty() {
+        return inputResponses == null || inputResponses.isEmpty();
+    }
+
+    @Override
+    public boolean has(String key) {
+        return inputResponses != null && inputResponses.containsKey(key);
+    }
+
+    @Override
+    public ElicitationResponse getElicitationResponse(String key) {
+        if (inputResponses == null) {
+            return null;
+        }
+        JsonObject response = inputResponses.getJsonObject(key);
+        if (response == null) {
+            return null;
+        }
+        Action action = Action.valueOf(response.getString("action").toUpperCase());
+        JsonObject content = response.getJsonObject("content");
+        return new ElicitationResponse(action, new ElicitationRequestImpl.ContentImpl(content), MetaImpl.from(response));
+    }
+
+    @Override
+    public SamplingResponse getSamplingResponse(String key) {
+        if (inputResponses == null) {
+            return null;
+        }
+        JsonObject response = inputResponses.getJsonObject(key);
+        if (response == null) {
+            return null;
+        }
+        String model = response.getString("model");
+        Role role = Role.valueOf(response.getString("role").toUpperCase());
+        Content content = Contents.parseContent(response.getJsonObject("content"));
+        return new SamplingResponse(content, model, role, response.getString("stopReason"), MetaImpl.from(response));
+    }
+
+    @Override
+    public List<Root> getRootsResponse(String key) {
+        if (inputResponses == null) {
+            return null;
+        }
+        JsonObject response = inputResponses.getJsonObject(key);
+        if (response == null) {
+            return null;
+        }
+        JsonArray roots = response.getJsonArray("roots");
+        if (roots == null) {
+            return List.of();
+        }
+        List<Root> list = new ArrayList<>(roots.size());
+        for (Object root : roots) {
+            if (root instanceof JsonObject jo) {
+                list.add(new Root(jo.getString("name"), jo.getString("uri")));
+            }
+        }
+        return list;
+    }
+
+}

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpConnectionBase.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpConnectionBase.java
@@ -1,7 +1,6 @@
 package io.quarkiverse.mcp.server.runtime;
 
 import java.time.Duration;
-import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -36,7 +35,7 @@ public abstract class McpConnectionBase implements McpConnection, Sender {
 
     protected final boolean transientConnection;
 
-    private final List<Subscription> subscriptions = new CopyOnWriteArrayList<>();
+    private volatile List<Subscription> subscriptions;
 
     protected McpConnectionBase(String id, McpServerRuntimeConfig serverConfig, String serverName) {
         this(id, serverConfig, serverName, false);
@@ -50,9 +49,9 @@ public abstract class McpConnectionBase implements McpConnection, Sender {
         this.trafficLoggerTextLimit = serverConfig.trafficLogging().enabled()
                 ? serverConfig.trafficLogging().textLimit()
                 : -1;
-        this.autoPingInterval = serverConfig.autoPingInterval();
-        this.lastUsed = Instant.now().toEpochMilli();
-        this.idleTimeout = serverConfig.connectionIdleTimeout().toMillis();
+        this.autoPingInterval = transientConnection ? Optional.empty() : serverConfig.autoPingInterval();
+        this.lastUsed = System.currentTimeMillis();
+        this.idleTimeout = transientConnection ? 0 : serverConfig.connectionIdleTimeout().toMillis();
         this.serverName = serverName;
         this.transientConnection = transientConnection;
     }
@@ -116,7 +115,7 @@ public abstract class McpConnectionBase implements McpConnection, Sender {
     }
 
     public McpConnectionBase touch() {
-        this.lastUsed = Instant.now().toEpochMilli();
+        this.lastUsed = System.currentTimeMillis();
         return this;
     }
 
@@ -124,7 +123,7 @@ public abstract class McpConnectionBase implements McpConnection, Sender {
         if (idleTimeout <= 0) {
             return false;
         }
-        return Instant.now().minusMillis(lastUsed).toEpochMilli() > idleTimeout;
+        return System.currentTimeMillis() - lastUsed > idleTimeout;
     }
 
     protected void messageSent(JsonObject message) {
@@ -134,11 +133,25 @@ public abstract class McpConnectionBase implements McpConnection, Sender {
     }
 
     public void addSubscription(Subscription subscription) {
-        subscriptions.add(subscription);
+        List<Subscription> subs = this.subscriptions;
+        if (subs == null) {
+            synchronized (this) {
+                subs = this.subscriptions;
+                if (subs == null) {
+                    subs = new CopyOnWriteArrayList<>();
+                    this.subscriptions = subs;
+                }
+            }
+        }
+        subs.add(subscription);
     }
 
     public boolean removeSubscription(Object subscriptionId) {
-        return subscriptions.removeIf(s -> s.subscriptionId().equals(subscriptionId));
+        List<Subscription> subs = this.subscriptions;
+        if (subs == null) {
+            return false;
+        }
+        return subs.removeIf(s -> s.subscriptionId().equals(subscriptionId));
     }
 
     public boolean supportsSubscriptionsListen() {
@@ -155,11 +168,12 @@ public abstract class McpConnectionBase implements McpConnection, Sender {
      * @param resourceUri the resource URI (for {@code notifications/resources/updated}), or {@code null}
      */
     public void sendNotification(JsonObject notification, String resourceUri) {
-        if (subscriptions.isEmpty()) {
+        List<Subscription> subs = this.subscriptions;
+        if (subs == null || subs.isEmpty()) {
             return;
         }
         String method = notification.getString("method");
-        for (Subscription sub : subscriptions) {
+        for (Subscription sub : subs) {
             if (sub.filter().matches(method, resourceUri)) {
                 JsonObject clone = notification.copy();
                 injectSubscriptionId(clone, sub.subscriptionId());

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpConnectionBase.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpConnectionBase.java
@@ -2,12 +2,15 @@ package io.quarkiverse.mcp.server.runtime;
 
 import java.time.Duration;
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.quarkiverse.mcp.server.InitialRequest;
 import io.quarkiverse.mcp.server.McpConnection;
 import io.quarkiverse.mcp.server.McpLog.LogLevel;
+import io.quarkiverse.mcp.server.MetaKey;
 import io.quarkiverse.mcp.server.runtime.config.McpServerRuntimeConfig;
 import io.vertx.core.json.JsonObject;
 
@@ -32,6 +35,8 @@ public abstract class McpConnectionBase implements McpConnection, Sender {
     protected final String serverName;
 
     protected final boolean transientConnection;
+
+    private final List<Subscription> subscriptions = new CopyOnWriteArrayList<>();
 
     protected McpConnectionBase(String id, McpServerRuntimeConfig serverConfig, String serverName) {
         this(id, serverConfig, serverName, false);
@@ -126,6 +131,59 @@ public abstract class McpConnectionBase implements McpConnection, Sender {
         if (trafficLoggerTextLimit > 0) {
             TrafficLogger.messageSent(message, this, trafficLoggerTextLimit);
         }
+    }
+
+    public void addSubscription(Subscription subscription) {
+        subscriptions.add(subscription);
+    }
+
+    public boolean removeSubscription(Object subscriptionId) {
+        return subscriptions.removeIf(s -> s.subscriptionId().equals(subscriptionId));
+    }
+
+    public boolean supportsSubscriptionsListen() {
+        InitialRequest ir = initializeRequest;
+        return ir != null && ir.protocolVersion() != null && ir.protocolVersion().isStateless();
+    }
+
+    /**
+     * Delivers a notification to all matching subscriptions on this connection.
+     * For each matching subscription, the notification is cloned, the {@code subscriptionId} is injected
+     * into {@code _meta}, and the notification is delivered via {@link #deliverSubscriptionNotification}.
+     *
+     * @param notification the notification to deliver
+     * @param resourceUri the resource URI (for {@code notifications/resources/updated}), or {@code null}
+     */
+    public void sendNotification(JsonObject notification, String resourceUri) {
+        if (subscriptions.isEmpty()) {
+            return;
+        }
+        String method = notification.getString("method");
+        for (Subscription sub : subscriptions) {
+            if (sub.filter().matches(method, resourceUri)) {
+                JsonObject clone = notification.copy();
+                injectSubscriptionId(clone, sub.subscriptionId());
+                deliverSubscriptionNotification(clone, sub);
+            }
+        }
+    }
+
+    protected void deliverSubscriptionNotification(JsonObject notification, Subscription subscription) {
+        send(notification);
+    }
+
+    public static void injectSubscriptionId(JsonObject notification, Object subscriptionId) {
+        JsonObject params = notification.getJsonObject("params");
+        if (params == null) {
+            params = new JsonObject();
+            notification.put("params", params);
+        }
+        JsonObject meta = params.getJsonObject("_meta");
+        if (meta == null) {
+            meta = new JsonObject();
+            params.put("_meta", meta);
+        }
+        meta.put(MetaKey.SUBSCRIPTION_ID.toString(), subscriptionId);
     }
 
     @Override

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpConnectionBase.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpConnectionBase.java
@@ -31,7 +31,14 @@ public abstract class McpConnectionBase implements McpConnection, Sender {
 
     protected final String serverName;
 
+    protected final boolean transientConnection;
+
     protected McpConnectionBase(String id, McpServerRuntimeConfig serverConfig, String serverName) {
+        this(id, serverConfig, serverName, false);
+    }
+
+    protected McpConnectionBase(String id, McpServerRuntimeConfig serverConfig, String serverName,
+            boolean transientConnection) {
         this.id = id;
         this.status = new AtomicReference<>(Status.NEW);
         this.logLevel = serverConfig.clientLogging().defaultLevel();
@@ -42,6 +49,7 @@ public abstract class McpConnectionBase implements McpConnection, Sender {
         this.lastUsed = Instant.now().toEpochMilli();
         this.idleTimeout = serverConfig.connectionIdleTimeout().toMillis();
         this.serverName = serverName;
+        this.transientConnection = transientConnection;
     }
 
     @Override
@@ -76,13 +84,18 @@ public abstract class McpConnectionBase implements McpConnection, Sender {
         return logLevel;
     }
 
-    void setLogLevel(LogLevel level) {
+    public void setLogLevel(LogLevel level) {
         this.logLevel = level;
     }
 
     @Override
     public String serverName() {
         return serverName;
+    }
+
+    @Override
+    public boolean isTransient() {
+        return transientConnection;
     }
 
     public boolean setInitialized() {

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpMessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpMessageHandler.java
@@ -1,9 +1,5 @@
 package io.quarkiverse.mcp.server.runtime;
 
-import static io.quarkiverse.mcp.server.McpMethod.LOGGING_SET_LEVEL;
-import static io.quarkiverse.mcp.server.McpMethod.PING;
-import static io.quarkiverse.mcp.server.McpMethod.Q_CLOSE;
-
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -242,7 +238,7 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
                     && serverConfig(mcpRequest).devMode().dummyInit()) {
                 // In the dev mode, perform an automatic initialization
                 autoInit = new InitialRequest(new Implementation("dummy", "1", null),
-                        McpProtocolVersion.LATEST_STATEFUL.version(),
+                        McpProtocolVersion.LATEST_STATEFUL,
                         List.of(), transport(), true);
             } else {
                 autoInit = autoInitialRequest(mcpRequest);
@@ -395,11 +391,11 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
         }
         // Few operations do not involve user code
         // and don't need a new duplicated context
-        if (method == PING) {
+        if (method == McpMethod.PING) {
             return ping(message, mcpRequest);
-        } else if (method == Q_CLOSE) {
+        } else if (method == McpMethod.Q_CLOSE) {
             return close(message, mcpRequest);
-        } else if (method == LOGGING_SET_LEVEL) {
+        } else if (method == McpMethod.LOGGING_SET_LEVEL) {
             return setLogLevel(message, mcpRequest);
         } else if (method == McpMethod.NOTIFICATIONS_PROGRESS) {
             return progress(message, mcpRequest);
@@ -573,7 +569,10 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
     private InitialRequest decodeInitializeRequest(JsonObject params) {
         JsonObject clientInfo = params.getJsonObject("clientInfo");
         Implementation implementation = Messages.decodeImplementation(clientInfo);
-        String protocolVersion = params.getString("protocolVersion");
+        McpProtocolVersion protocolVersion = McpProtocolVersion.from(params.getString("protocolVersion"));
+        if (protocolVersion == null) {
+            protocolVersion = McpProtocolVersion.LATEST_STATEFUL;
+        }
         List<ClientCapability> clientCapabilities = new ArrayList<>();
         JsonObject capabilities = params.getJsonObject("capabilities");
         if (capabilities != null) {
@@ -607,12 +606,9 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
     private static final EnumSet<McpMethod> STATELESS_REMOVED_METHODS = EnumSet.of(
             McpMethod.INITIALIZE,
             McpMethod.NOTIFICATIONS_INITIALIZED,
-            PING,
-            LOGGING_SET_LEVEL,
+            McpMethod.PING,
+            McpMethod.LOGGING_SET_LEVEL,
             McpMethod.NOTIFICATIONS_ROOTS_LIST_CHANGED);
-
-    protected static final String AUTO_INIT_IMPL_NAME = "quarkus.mcp.auto-init";
-    private static final Implementation AUTO_INIT_IMPLEMENTATION = new Implementation(AUTO_INIT_IMPL_NAME, "1", null);
 
     private static final Map<String, Object> LIST_CHANGED_PROPERTIES = Map.of("listChanged", true);
     private static final Map<String, Object> SUBSCRIBE_PROPERTIES = Map.of("subscribe", true);
@@ -683,17 +679,22 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
      * @return the initial request
      * @throws McpException with {@link JsonRpcErrorCodes#INVALID_PARAMS} if any required {@code _meta} field is missing
      */
-    protected static InitialRequest buildStatelessInitialRequest(JsonObject meta, String protocolVersion,
+    protected static InitialRequest buildStatelessInitialRequest(JsonObject meta, String protocolVersionStr,
             InitialRequest.Transport transport) {
         validateStatelessMeta(meta);
-        String version = protocolVersion != null ? protocolVersion : meta.getString(MetaKey.PROTOCOL_VERSION.toString());
+        String versionStr = protocolVersionStr != null ? protocolVersionStr
+                : meta.getString(MetaKey.PROTOCOL_VERSION.toString());
+        McpProtocolVersion protocolVersion = McpProtocolVersion.from(versionStr);
+        if (protocolVersion == null) {
+            protocolVersion = McpProtocolVersion.FIRST_STATELESS;
+        }
         Implementation implementation = Messages.decodeImplementation(meta.getJsonObject(MetaKey.CLIENT_INFO.toString()));
         JsonObject capabilities = meta.getJsonObject(MetaKey.CLIENT_CAPABILITIES.toString());
         List<ClientCapability> clientCapabilities = new ArrayList<>();
         for (String name : capabilities.fieldNames()) {
             clientCapabilities.add(new ClientCapability(name, Map.of()));
         }
-        return new InitialRequest(implementation, version, List.copyOf(clientCapabilities), transport, true);
+        return new InitialRequest(implementation, protocolVersion, List.copyOf(clientCapabilities), transport, true);
     }
 
     /**
@@ -728,7 +729,6 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
         Object id = Messages.getId(message);
         FilterContextImpl filterContext = FilterContextImpl.of(McpMethod.SERVER_DISCOVER, message, mcpRequest);
         Map<String, Object> ret = new HashMap<>();
-        ret.put("resultType", "complete");
         ret.put("supportedVersions", McpProtocolVersion.SUPPORTED_VERSIONS);
         ret.put("capabilities", buildCapabilities(filterContext));
         ret.put("serverInfo", buildServerInfo(mcpRequest));
@@ -742,11 +742,7 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
     private Map<String, Object> initResult(MCP_REQUEST mcpRequest, InitialRequest initialRequest, JsonObject message) {
         Map<String, Object> ret = new HashMap<>();
 
-        String version = McpProtocolVersion.LATEST_STATEFUL.version();
-        if (McpProtocolVersion.SUPPORTED_VERSIONS.contains(initialRequest.protocolVersion())) {
-            version = initialRequest.protocolVersion();
-        }
-        ret.put("protocolVersion", version);
+        ret.put("protocolVersion", initialRequest.protocolVersion().version());
 
         FilterContextImpl filterContext = FilterContextImpl.of(McpMethod.INITIALIZE, message, mcpRequest);
         ret.put("capabilities", buildCapabilities(filterContext));

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpMessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpMessageHandler.java
@@ -751,17 +751,24 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
                     + MetaKey.PROTOCOL_VERSION + ", " + MetaKey.CLIENT_INFO + ", " + MetaKey.CLIENT_CAPABILITIES,
                     JsonRpcErrorCodes.INVALID_PARAMS);
         }
-        List<String> missing = new ArrayList<>();
+        List<String> missing = null;
         if (meta.getString(MetaKey.PROTOCOL_VERSION.toString()) == null) {
+            missing = new ArrayList<>();
             missing.add(MetaKey.PROTOCOL_VERSION.toString());
         }
         if (meta.getJsonObject(MetaKey.CLIENT_INFO.toString()) == null) {
+            if (missing == null) {
+                missing = new ArrayList<>();
+            }
             missing.add(MetaKey.CLIENT_INFO.toString());
         }
         if (meta.getJsonObject(MetaKey.CLIENT_CAPABILITIES.toString()) == null) {
+            if (missing == null) {
+                missing = new ArrayList<>();
+            }
             missing.add(MetaKey.CLIENT_CAPABILITIES.toString());
         }
-        if (!missing.isEmpty()) {
+        if (missing != null) {
             throw new McpException("Stateless request is missing required _meta fields: " + String.join(", ", missing),
                     JsonRpcErrorCodes.INVALID_PARAMS);
         }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpMessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpMessageHandler.java
@@ -399,6 +399,8 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
             return setLogLevel(message, mcpRequest);
         } else if (method == McpMethod.NOTIFICATIONS_PROGRESS) {
             return progress(message, mcpRequest);
+        } else if (method == McpMethod.SUBSCRIPTIONS_LISTEN) {
+            return subscriptionsListen(message, mcpRequest);
         }
         // Create a new duplicated context and process the operation on this context
         Context context = VertxContext.createNewDuplicatedContext(vertx.getOrCreateContext());
@@ -472,12 +474,50 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
                 String reason = params.getString("reason");
                 LOG.debugf("Cancel request with id %s: %s [%s]", requestId, reason != null ? reason : "no reason",
                         mcpRequest.connection().id());
+            } else if (requestId != null && mcpRequest.connection().removeSubscription(requestId)) {
+                LOG.debugf("Subscription %s cancelled [%s]", requestId, mcpRequest.connection().id());
             } else {
                 LOG.warnf("Ignored unknown/completed/invalid cancel request with id %s [%s]", requestId,
                         mcpRequest.connection().id());
             }
         }
         return Future.succeededFuture();
+    }
+
+    private Future<Void> subscriptionsListen(JsonObject message, MCP_REQUEST mcpRequest) {
+        Object id = Messages.getId(message);
+        JsonObject params = Messages.getParams(message);
+        if (params == null) {
+            return mcpRequest.sender().sendError(id, JsonRpcErrorCodes.INVALID_PARAMS, "Missing params");
+        }
+        JsonObject notifications = params.getJsonObject("notifications");
+        if (notifications == null) {
+            return mcpRequest.sender().sendError(id, JsonRpcErrorCodes.INVALID_PARAMS,
+                    "Missing notifications in params");
+        }
+        SubscriptionFilter filter = SubscriptionFilter.parse(notifications);
+        Subscription subscription = new Subscription(id, filter);
+        mcpRequest.connection().addSubscription(subscription);
+        LOG.debugf("Subscription %s opened [%s]", id, mcpRequest.connection().id());
+        return onSubscriptionOpened(message, mcpRequest, subscription);
+    }
+
+    /**
+     * Called after a {@code subscriptions/listen} request is processed and the subscription is registered.
+     * Transports override this to handle transport-specific stream setup.
+     * <p>
+     * The default implementation registers transient connections in the {@link ConnectionManager} and sends the
+     * {@code notifications/subscriptions/acknowledged} notification via the request sender.
+     */
+    protected Future<Void> onSubscriptionOpened(JsonObject message, MCP_REQUEST mcpRequest, Subscription subscription) {
+        if (mcpRequest.connection().isTransient()) {
+            connectionManager.add(mcpRequest.connection());
+        }
+        JsonObject params = new JsonObject().put("notifications", subscription.filter().toAcknowledgedJson());
+        JsonObject acknowledged = Messages.newNotification(
+                McpMethod.NOTIFICATIONS_SUBSCRIPTIONS_ACKNOWLEDGED.jsonRpcName(), params);
+        McpConnectionBase.injectSubscriptionId(acknowledged, subscription.subscriptionId());
+        return mcpRequest.sender().send(acknowledged);
     }
 
     private String ongoingId(JsonObject message, MCP_REQUEST mcpRequest) {
@@ -608,7 +648,9 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
             McpMethod.NOTIFICATIONS_INITIALIZED,
             McpMethod.PING,
             McpMethod.LOGGING_SET_LEVEL,
-            McpMethod.NOTIFICATIONS_ROOTS_LIST_CHANGED);
+            McpMethod.NOTIFICATIONS_ROOTS_LIST_CHANGED,
+            McpMethod.RESOURCES_SUBSCRIBE,
+            McpMethod.RESOURCES_UNSUBSCRIBE);
 
     private static final Map<String, Object> LIST_CHANGED_PROPERTIES = Map.of("listChanged", true);
     private static final Map<String, Object> SUBSCRIBE_PROPERTIES = Map.of("subscribe", true);

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpMessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpMessageHandler.java
@@ -5,6 +5,7 @@ import static io.quarkiverse.mcp.server.McpMethod.PING;
 import static io.quarkiverse.mcp.server.McpMethod.Q_CLOSE;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -29,6 +30,7 @@ import io.quarkiverse.mcp.server.McpConnection;
 import io.quarkiverse.mcp.server.McpException;
 import io.quarkiverse.mcp.server.McpLog.LogLevel;
 import io.quarkiverse.mcp.server.McpMethod;
+import io.quarkiverse.mcp.server.McpProtocolVersion;
 import io.quarkiverse.mcp.server.MetaKey;
 import io.quarkiverse.mcp.server.Notification.Type;
 import io.quarkiverse.mcp.server.NotificationManager;
@@ -207,6 +209,9 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
     }
 
     private Future<Void> doHandleRequest(JsonObject message, MCP_REQUEST mcpRequest, McpMethod method) {
+        if (method == McpMethod.SERVER_DISCOVER) {
+            return serverDiscover(message, mcpRequest);
+        }
         return switch (mcpRequest.connection().status()) {
             case NEW -> initializeNew(method, message, mcpRequest);
             case INITIALIZING -> initializing(method, message, mcpRequest);
@@ -237,7 +242,7 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
                     && serverConfig(mcpRequest).devMode().dummyInit()) {
                 // In the dev mode, perform an automatic initialization
                 autoInit = new InitialRequest(new Implementation("dummy", "1", null),
-                        SUPPORTED_PROTOCOL_VERSIONS.get(0),
+                        McpProtocolVersion.LATEST_STATEFUL.version(),
                         List.of(), transport(), true);
             } else {
                 autoInit = autoInitialRequest(mcpRequest);
@@ -383,6 +388,11 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
     }
 
     private Future<Void> operation(McpMethod method, JsonObject message, MCP_REQUEST mcpRequest) {
+        McpProtocolVersion protocolVersion = mcpRequest.protocolVersion();
+        if (protocolVersion != null && protocolVersion.isStateless() && STATELESS_REMOVED_METHODS.contains(method)) {
+            return mcpRequest.sender().sendError(Messages.getId(message), JsonRpcErrorCodes.METHOD_NOT_FOUND,
+                    "Method not available in stateless protocol version: " + method.jsonRpcName());
+        }
         // Few operations do not involve user code
         // and don't need a new duplicated context
         if (method == PING) {
@@ -584,27 +594,180 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
         return new InitialRequest(implementation, protocolVersion, List.copyOf(clientCapabilities), transport());
     }
 
-    public static final List<String> SUPPORTED_PROTOCOL_VERSIONS = List.of(
-            "2025-11-25",
-            "2025-06-18",
-            "2025-03-26",
-            "2024-11-05");
+    public static final String FIRST_STATELESS_PROTOCOL_VERSION = McpProtocolVersion.FIRST_STATELESS.version();
+
+    /**
+     * @return {@code true} if the given protocol version uses the stateless (per-request metadata) model,
+     *         i.e. is {@value #FIRST_STATELESS_PROTOCOL_VERSION} or later
+     */
+    public static boolean isStateless(String protocolVersion) {
+        return McpProtocolVersion.isStateless(protocolVersion);
+    }
+
+    private static final EnumSet<McpMethod> STATELESS_REMOVED_METHODS = EnumSet.of(
+            McpMethod.INITIALIZE,
+            McpMethod.NOTIFICATIONS_INITIALIZED,
+            PING,
+            LOGGING_SET_LEVEL,
+            McpMethod.NOTIFICATIONS_ROOTS_LIST_CHANGED);
+
+    protected static final String AUTO_INIT_IMPL_NAME = "quarkus.mcp.auto-init";
+    private static final Implementation AUTO_INIT_IMPLEMENTATION = new Implementation(AUTO_INIT_IMPL_NAME, "1", null);
 
     private static final Map<String, Object> LIST_CHANGED_PROPERTIES = Map.of("listChanged", true);
     private static final Map<String, Object> SUBSCRIBE_PROPERTIES = Map.of("subscribe", true);
 
+    /**
+     * @return the {@code _meta} object from the message params, or {@code null}
+     */
+    protected static JsonObject findMeta(JsonObject message) {
+        JsonObject params = Messages.getParams(message);
+        if (params != null) {
+            return params.getJsonObject("_meta");
+        }
+        return null;
+    }
+
+    /**
+     * @return {@code true} if the message uses the stateless protocol (based on method name or {@code _meta} protocol version)
+     */
+    protected static boolean isStatelessMessage(JsonObject message) {
+        return isStatelessMessage(message, findMeta(message));
+    }
+
+    /**
+     * @return {@code true} if the message uses the stateless protocol (based on method name or {@code _meta} protocol version)
+     */
+    protected static boolean isStatelessMessage(JsonObject message, JsonObject meta) {
+        String method = message.getString("method");
+        if ("server/discover".equals(method)) {
+            return true;
+        }
+        if ("initialize".equals(method)) {
+            return false;
+        }
+        if (meta != null) {
+            String metaVersion = meta.getString(MetaKey.PROTOCOL_VERSION.toString());
+            if (metaVersion != null && isStateless(metaVersion)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Applies the per-request log level from the {@code _meta} object to the connection.
+     *
+     * @throws McpException if the log level value is not valid
+     */
+    protected static void applyMetaLogLevel(JsonObject meta, McpConnectionBase connection) {
+        if (meta == null) {
+            return;
+        }
+        String logLevelStr = meta.getString(MetaKey.LOG_LEVEL.toString());
+        if (logLevelStr != null) {
+            LogLevel logLevel = LogLevel.from(logLevelStr);
+            if (logLevel == null) {
+                throw new McpException("Invalid log level: " + logLevelStr, JsonRpcErrorCodes.INVALID_PARAMS);
+            }
+            connection.setLogLevel(logLevel);
+        }
+    }
+
+    /**
+     * Builds an {@link InitialRequest} for a stateless request by extracting client info and capabilities from {@code _meta}.
+     *
+     * @param meta the {@code _meta} object from the JSON-RPC message
+     * @param protocolVersion the protocol version to use, or {@code null} to use the value from {@code _meta}
+     * @param transport the transport type
+     * @return the initial request
+     * @throws McpException with {@link JsonRpcErrorCodes#INVALID_PARAMS} if any required {@code _meta} field is missing
+     */
+    protected static InitialRequest buildStatelessInitialRequest(JsonObject meta, String protocolVersion,
+            InitialRequest.Transport transport) {
+        validateStatelessMeta(meta);
+        String version = protocolVersion != null ? protocolVersion : meta.getString(MetaKey.PROTOCOL_VERSION.toString());
+        Implementation implementation = Messages.decodeImplementation(meta.getJsonObject(MetaKey.CLIENT_INFO.toString()));
+        JsonObject capabilities = meta.getJsonObject(MetaKey.CLIENT_CAPABILITIES.toString());
+        List<ClientCapability> clientCapabilities = new ArrayList<>();
+        for (String name : capabilities.fieldNames()) {
+            clientCapabilities.add(new ClientCapability(name, Map.of()));
+        }
+        return new InitialRequest(implementation, version, List.copyOf(clientCapabilities), transport, true);
+    }
+
+    /**
+     * Validates that all required per-request {@code _meta} fields are present.
+     *
+     * @param meta the {@code _meta} object from the JSON-RPC message
+     * @throws McpException with {@link JsonRpcErrorCodes#INVALID_PARAMS} if any required field is missing
+     */
+    static void validateStatelessMeta(JsonObject meta) {
+        if (meta == null) {
+            throw new McpException("Stateless request must include _meta with required fields: "
+                    + MetaKey.PROTOCOL_VERSION + ", " + MetaKey.CLIENT_INFO + ", " + MetaKey.CLIENT_CAPABILITIES,
+                    JsonRpcErrorCodes.INVALID_PARAMS);
+        }
+        List<String> missing = new ArrayList<>();
+        if (meta.getString(MetaKey.PROTOCOL_VERSION.toString()) == null) {
+            missing.add(MetaKey.PROTOCOL_VERSION.toString());
+        }
+        if (meta.getJsonObject(MetaKey.CLIENT_INFO.toString()) == null) {
+            missing.add(MetaKey.CLIENT_INFO.toString());
+        }
+        if (meta.getJsonObject(MetaKey.CLIENT_CAPABILITIES.toString()) == null) {
+            missing.add(MetaKey.CLIENT_CAPABILITIES.toString());
+        }
+        if (!missing.isEmpty()) {
+            throw new McpException("Stateless request is missing required _meta fields: " + String.join(", ", missing),
+                    JsonRpcErrorCodes.INVALID_PARAMS);
+        }
+    }
+
+    private Future<Void> serverDiscover(JsonObject message, MCP_REQUEST mcpRequest) {
+        Object id = Messages.getId(message);
+        FilterContextImpl filterContext = FilterContextImpl.of(McpMethod.SERVER_DISCOVER, message, mcpRequest);
+        Map<String, Object> ret = new HashMap<>();
+        ret.put("resultType", "complete");
+        ret.put("supportedVersions", McpProtocolVersion.SUPPORTED_VERSIONS);
+        ret.put("capabilities", buildCapabilities(filterContext));
+        ret.put("serverInfo", buildServerInfo(mcpRequest));
+        Optional<String> instructions = buildInstructions(mcpRequest);
+        if (instructions.isPresent()) {
+            ret.put("instructions", instructions.get());
+        }
+        return mcpRequest.sender().sendResult(id, ret);
+    }
+
     private Map<String, Object> initResult(MCP_REQUEST mcpRequest, InitialRequest initialRequest, JsonObject message) {
         Map<String, Object> ret = new HashMap<>();
 
-        // Note that currently the protocol version does not affect the behavior
-        // of the server except for opt-in schema validation
-        String version = SUPPORTED_PROTOCOL_VERSIONS.get(0);
-        if (SUPPORTED_PROTOCOL_VERSIONS.contains(initialRequest.protocolVersion())) {
+        String version = McpProtocolVersion.LATEST_STATEFUL.version();
+        if (McpProtocolVersion.SUPPORTED_VERSIONS.contains(initialRequest.protocolVersion())) {
             version = initialRequest.protocolVersion();
         }
         ret.put("protocolVersion", version);
 
         FilterContextImpl filterContext = FilterContextImpl.of(McpMethod.INITIALIZE, message, mcpRequest);
+        ret.put("capabilities", buildCapabilities(filterContext));
+        ret.put("serverInfo", buildServerInfo(mcpRequest));
+
+        Optional<String> instructions = buildInstructions(mcpRequest);
+        if (instructions.isPresent()) {
+            ret.put("instructions", instructions.get());
+        }
+
+        for (InitialResponseInfo info : initialResponseInfos) {
+            Optional<Map<MetaKey, Object>> meta = info.meta(mcpRequest.serverName());
+            if (meta != null && meta.isPresent()) {
+                ret.put("_meta", meta.get());
+                break;
+            }
+        }
+        return ret;
+    }
+
+    private Map<String, Map<String, Object>> buildCapabilities(FilterContextImpl filterContext) {
         Map<String, Map<String, Object>> capabilities = new HashMap<>();
         if (promptManager.hasInfos(filterContext)) {
             capabilities.put("prompts", metadata.isPromptManagerUsed() ? LIST_CHANGED_PROPERTIES : Map.of());
@@ -627,77 +790,63 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
             capabilities.put("completions", Map.of());
         }
         capabilities.put("logging", Map.of());
-        ret.put("capabilities", capabilities);
+        return capabilities;
+    }
 
-        ServerInfo serverInfo = serverConfig(mcpRequest).serverInfo();
-        Optional<Implementation> implementation = Optional.empty();
+    private Object buildServerInfo(MCP_REQUEST mcpRequest) {
         for (InitialResponseInfo info : initialResponseInfos) {
             Optional<Implementation> impl = info.implementation(mcpRequest.serverName());
             if (impl != null && impl.isPresent()) {
-                implementation = impl;
-                break;
+                return impl.get();
             }
         }
-        if (implementation.isPresent()) {
-            ret.put("serverInfo", implementation);
-        } else {
-            JsonObject impl = new JsonObject();
-            String serverName = serverInfo.name()
-                    .orElse(ConfigProvider.getConfig().getOptionalValue("quarkus.application.name", String.class)
-                            .orElse("N/A"));
-            impl.put("name", serverName);
-            impl.put("version", serverInfo.version()
-                    .orElse(ConfigProvider.getConfig().getOptionalValue("quarkus.application.version", String.class)
-                            .orElse("N/A")));
-            impl.put("title", serverInfo.title().orElse(serverName));
-            if (serverInfo.description().isPresent()) {
-                impl.put("description", serverInfo.description().get());
-            }
-            if (serverInfo.websiteUrl().isPresent()) {
-                impl.put("websiteUrl", serverInfo.websiteUrl().get());
-            }
-            if (!serverInfo.icons().isEmpty()) {
-                JsonArray icons = new JsonArray();
-                for (Icon icon : serverInfo.icons()) {
-                    JsonObject i = new JsonObject()
-                            .put("src", icon.src());
-                    if (icon.mimeType().isPresent()) {
-                        i.put("mimeType", icon.mimeType().get());
-                    }
-                    if (icon.theme().isPresent()) {
-                        i.put("theme", icon.theme().get().toString().toLowerCase());
-                    }
-                    if (!icon.sizes().isEmpty()) {
-                        i.put("sizes", icon.sizes());
-                    }
-                    icons.add(i);
+        ServerInfo serverInfo = serverConfig(mcpRequest).serverInfo();
+        JsonObject impl = new JsonObject();
+        String serverName = serverInfo.name()
+                .orElse(ConfigProvider.getConfig().getOptionalValue("quarkus.application.name", String.class)
+                        .orElse("N/A"));
+        impl.put("name", serverName);
+        impl.put("version", serverInfo.version()
+                .orElse(ConfigProvider.getConfig().getOptionalValue("quarkus.application.version", String.class)
+                        .orElse("N/A")));
+        impl.put("title", serverInfo.title().orElse(serverName));
+        if (serverInfo.description().isPresent()) {
+            impl.put("description", serverInfo.description().get());
+        }
+        if (serverInfo.websiteUrl().isPresent()) {
+            impl.put("websiteUrl", serverInfo.websiteUrl().get());
+        }
+        if (!serverInfo.icons().isEmpty()) {
+            JsonArray icons = new JsonArray();
+            for (Icon icon : serverInfo.icons()) {
+                JsonObject i = new JsonObject()
+                        .put("src", icon.src());
+                if (icon.mimeType().isPresent()) {
+                    i.put("mimeType", icon.mimeType().get());
                 }
-                impl.put("icons", icons);
+                if (icon.theme().isPresent()) {
+                    i.put("theme", icon.theme().get().toString().toLowerCase());
+                }
+                if (!icon.sizes().isEmpty()) {
+                    i.put("sizes", icon.sizes());
+                }
+                icons.add(i);
             }
-            ret.put("serverInfo", impl);
-
+            impl.put("icons", icons);
         }
+        return impl;
+    }
 
+    private Optional<String> buildInstructions(MCP_REQUEST mcpRequest) {
+        ServerInfo serverInfo = serverConfig(mcpRequest).serverInfo();
         Optional<String> instructions = serverInfo.instructions();
         for (InitialResponseInfo info : initialResponseInfos) {
             Optional<String> instr = info.instructions(mcpRequest.serverName());
             if (instr != null && instr.isPresent()) {
-                instructions = instr;
-                break;
+                return instr;
             }
         }
-        if (instructions.isPresent()) {
-            ret.put("instructions", instructions.get());
-        }
-
-        for (InitialResponseInfo info : initialResponseInfos) {
-            Optional<Map<MetaKey, Object>> meta = info.meta(mcpRequest.serverName());
-            if (meta != null && meta.isPresent()) {
-                ret.put("_meta", meta.get());
-                break;
-            }
-        }
-        return ret;
+        return instructions;
     }
 
     private void validateServerConfigs() {

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpRequest.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpRequest.java
@@ -2,6 +2,7 @@ package io.quarkiverse.mcp.server.runtime;
 
 import io.quarkiverse.mcp.server.InitialRequest;
 import io.quarkiverse.mcp.server.McpMethod;
+import io.quarkiverse.mcp.server.McpProtocolVersion;
 import io.vertx.core.json.JsonObject;
 
 public interface McpRequest {
@@ -49,5 +50,5 @@ public interface McpRequest {
 
     void contextEnd(Throwable error);
 
-    String protocolVersion();
+    McpProtocolVersion protocolVersion();
 }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpRequestImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpRequestImpl.java
@@ -3,6 +3,7 @@ package io.quarkiverse.mcp.server.runtime;
 import io.quarkiverse.mcp.server.InitialRequest;
 import io.quarkiverse.mcp.server.McpConnection.Status;
 import io.quarkiverse.mcp.server.McpMethod;
+import io.quarkiverse.mcp.server.McpProtocolVersion;
 import io.quarkiverse.mcp.server.runtime.tracing.McpRequestInfo;
 import io.quarkiverse.mcp.server.runtime.tracing.McpResponseInfo;
 import io.quarkus.arc.Arc;
@@ -24,6 +25,8 @@ public abstract class McpRequestImpl<CONNECTION extends McpConnectionBase> imple
 
     // Tracing span - started by prepareTracing(), ended by contextEnd()
     private volatile McpTracingSpan tracingSpan;
+
+    private volatile McpProtocolVersion protocolVersion;
 
     public McpRequestImpl(String serverName, JsonObject message, CONNECTION connection, Sender sender,
             SecuritySupport securitySupport,
@@ -120,12 +123,16 @@ public abstract class McpRequestImpl<CONNECTION extends McpConnectionBase> imple
     }
 
     @Override
-    public String protocolVersion() {
-        if ((connection.status() == Status.IN_OPERATION || connection.status() == Status.INITIALIZING)
-                && connection.initialRequest() != null) {
-            return connection.initialRequest().protocolVersion();
+    public McpProtocolVersion protocolVersion() {
+        McpProtocolVersion ret = protocolVersion;
+        if (ret == null) {
+            if ((connection.status() == Status.IN_OPERATION || connection.status() == Status.INITIALIZING)
+                    && connection.initialRequest() != null) {
+                ret = McpProtocolVersion.from(connection.initialRequest().protocolVersion());
+                protocolVersion = ret;
+            }
         }
-        return null;
+        return ret;
     }
 
 }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpRequestImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpRequestImpl.java
@@ -1,7 +1,6 @@
 package io.quarkiverse.mcp.server.runtime;
 
 import io.quarkiverse.mcp.server.InitialRequest;
-import io.quarkiverse.mcp.server.McpConnection.Status;
 import io.quarkiverse.mcp.server.McpMethod;
 import io.quarkiverse.mcp.server.McpProtocolVersion;
 import io.quarkiverse.mcp.server.runtime.tracing.McpRequestInfo;
@@ -25,8 +24,6 @@ public abstract class McpRequestImpl<CONNECTION extends McpConnectionBase> imple
 
     // Tracing span - started by prepareTracing(), ended by contextEnd()
     private volatile McpTracingSpan tracingSpan;
-
-    private volatile McpProtocolVersion protocolVersion;
 
     public McpRequestImpl(String serverName, JsonObject message, CONNECTION connection, Sender sender,
             SecuritySupport securitySupport,
@@ -124,15 +121,10 @@ public abstract class McpRequestImpl<CONNECTION extends McpConnectionBase> imple
 
     @Override
     public McpProtocolVersion protocolVersion() {
-        McpProtocolVersion ret = protocolVersion;
-        if (ret == null) {
-            if ((connection.status() == Status.IN_OPERATION || connection.status() == Status.INITIALIZING)
-                    && connection.initialRequest() != null) {
-                ret = McpProtocolVersion.from(connection.initialRequest().protocolVersion());
-                protocolVersion = ret;
-            }
+        if (connection.initialRequest() != null) {
+            return connection.initialRequest().protocolVersion();
         }
-        return ret;
+        return null;
     }
 
 }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/MessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/MessageHandler.java
@@ -1,10 +1,19 @@
 package io.quarkiverse.mcp.server.runtime;
 
+import java.util.Map;
+
 import org.jboss.logging.Logger;
 
 import io.quarkiverse.mcp.server.Cancellation;
+import io.quarkiverse.mcp.server.InputRequiredException;
+import io.quarkiverse.mcp.server.InputRequiredException.ElicitationInputRequest;
+import io.quarkiverse.mcp.server.InputRequiredException.InputRequestEntry;
+import io.quarkiverse.mcp.server.InputRequiredException.RootsInputRequest;
+import io.quarkiverse.mcp.server.InputRequiredException.SamplingInputRequest;
+import io.quarkiverse.mcp.server.InputRequiredException.UrlElicitationInputRequest;
 import io.quarkiverse.mcp.server.JsonRpcErrorCodes;
 import io.quarkiverse.mcp.server.McpException;
+import io.quarkiverse.mcp.server.McpMethod;
 import io.quarkiverse.mcp.server.UrlElicitationRequiredException;
 import io.quarkiverse.mcp.server.UrlElicitationRequiredException.ElicitationEntry;
 import io.vertx.core.Future;
@@ -17,7 +26,20 @@ public abstract class MessageHandler {
 
     protected Future<Void> handleFailure(Object requestId, Sender sender, McpRequest mcpRequest, Throwable cause,
             Logger logger, String errorMessage, String featureId) {
-        if (cause instanceof UrlElicitationRequiredException urlElicitation) {
+        if (cause instanceof InputRequiredException inputRequired) {
+            JsonObject result = new JsonObject().put("resultType", "input_required");
+            if (!inputRequired.inputRequests().isEmpty()) {
+                JsonObject inputRequests = new JsonObject();
+                for (Map.Entry<String, InputRequestEntry> e : inputRequired.inputRequests().entrySet()) {
+                    inputRequests.put(e.getKey(), serializeInputRequest(e.getValue()));
+                }
+                result.put("inputRequests", inputRequests);
+            }
+            if (inputRequired.requestState() != null) {
+                result.put("requestState", inputRequired.requestState());
+            }
+            return sender.sendResult(requestId, result);
+        } else if (cause instanceof UrlElicitationRequiredException urlElicitation) {
             mcpRequest.setTracingErrorResponse(false, urlElicitation.getJsonRpcErrorCode(), urlElicitation.getMessage());
             JsonArray elicitations = new JsonArray();
             for (ElicitationEntry entry : urlElicitation.elicitations()) {
@@ -45,5 +67,20 @@ public abstract class MessageHandler {
             mcpRequest.setTracingErrorResponse(false, JsonRpcErrorCodes.INTERNAL_ERROR, "Internal error");
             return sender.sendInternalError(requestId);
         }
+    }
+
+    private static JsonObject serializeInputRequest(InputRequestEntry entry) {
+        if (entry instanceof ElicitationInputRequest e) {
+            return ((ElicitationRequestImpl) e.request()).toInputRequestJson();
+        } else if (entry instanceof UrlElicitationInputRequest e) {
+            return ((UrlElicitationRequestImpl) e.request()).toInputRequestJson();
+        } else if (entry instanceof SamplingInputRequest e) {
+            return ((SamplingRequestImpl) e.request()).toInputRequestJson();
+        } else if (entry instanceof RootsInputRequest) {
+            return new JsonObject()
+                    .put("method", McpMethod.ROOTS_LIST.jsonRpcName())
+                    .put("params", new JsonObject());
+        }
+        throw new IllegalArgumentException("Unknown input request entry type: " + entry.getClass());
     }
 }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceManagerImpl.java
@@ -153,6 +153,7 @@ public class ResourceManagerImpl extends FeatureManagerBase<ResourceResponse, Re
 
     private void sendUpdateNotifications(String uri) {
         JsonObject updated = Messages.newNotification("notifications/resources/updated", new JsonObject().put("uri", uri));
+        // Old protocol: existing uriToSubscribers flow
         List<String> ids = uriToSubscribers.get(uri);
         if (ids != null) {
             for (String connectionId : ids) {
@@ -162,6 +163,12 @@ public class ResourceManagerImpl extends FeatureManagerBase<ResourceResponse, Re
                 } else {
                     unsubscribe(uri, connectionId);
                 }
+            }
+        }
+        // New protocol: route through subscription filters
+        for (McpConnectionBase c : connectionManager) {
+            if (c.supportsSubscriptionsListen()) {
+                c.sendNotification(updated, uri);
             }
         }
     }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/RootsImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/RootsImpl.java
@@ -8,6 +8,7 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.jboss.logging.Logger;
 
+import io.quarkiverse.mcp.server.InputResponses;
 import io.quarkiverse.mcp.server.McpConnection;
 import io.quarkiverse.mcp.server.McpMethod;
 import io.quarkiverse.mcp.server.Root;
@@ -22,10 +23,13 @@ class RootsImpl implements Roots {
     private static final Logger LOG = Logger.getLogger(Roots.class);
 
     static RootsImpl from(ArgumentProviders argProviders) {
+        JsonObject params = Messages.getParams(argProviders.rawMessage());
         return new RootsImpl(argProviders.connection(), argProviders.sender(),
                 argProviders.serverRequests(),
                 argProviders.serverRequests().getRootsTimeout(argProviders.serverName()),
-                argProviders.mcpTracing());
+                argProviders.mcpTracing(),
+                InputResponsesImpl.from(params),
+                params != null ? params.getString("requestState") : null);
     }
 
     private final McpConnection connection;
@@ -38,18 +42,39 @@ class RootsImpl implements Roots {
 
     private final McpTracing mcpTracing;
 
+    private final InputResponses inputResponses;
+
+    private final String requestState;
+
     RootsImpl(McpConnection connection, Sender sender, ServerRequests serverRequests, Duration timeout,
-            McpTracing mcpTracing) {
+            McpTracing mcpTracing, InputResponses inputResponses, String requestState) {
         this.connection = connection;
         this.sender = sender;
         this.serverRequests = serverRequests;
         this.timeout = timeout;
         this.mcpTracing = mcpTracing;
+        this.inputResponses = inputResponses;
+        this.requestState = requestState;
     }
 
     @Override
     public boolean isSupported() {
         return connection.initialRequest().supportsRoots();
+    }
+
+    @Override
+    public boolean isServerInitiatedRequestSupported() {
+        return !connection.initialRequest().protocolVersion().isStateless();
+    }
+
+    @Override
+    public InputResponses inputResponses() {
+        return inputResponses;
+    }
+
+    @Override
+    public String requestState() {
+        return requestState;
     }
 
     @Override
@@ -60,6 +85,10 @@ class RootsImpl implements Roots {
         if (!isSupported()) {
             throw new IllegalStateException(
                     "Client " + connection.initialRequest().implementation() + " does not support the `roots` capability");
+        }
+        if (!isServerInitiatedRequestSupported()) {
+            throw new IllegalStateException(
+                    "Server-initiated requests are not supported with stateless protocol versions; use InputRequiredException instead");
         }
         // Send a "roots/list" message to the client and register a handler
         // that will be called when a response arrives

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/SamplingImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/SamplingImpl.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 
+import io.quarkiverse.mcp.server.InputResponses;
 import io.quarkiverse.mcp.server.McpConnection;
 import io.quarkiverse.mcp.server.ModelPreferences;
 import io.quarkiverse.mcp.server.Sampling;
@@ -14,14 +15,18 @@ import io.quarkiverse.mcp.server.SamplingMessage;
 import io.quarkiverse.mcp.server.SamplingRequest;
 import io.quarkiverse.mcp.server.SamplingRequest.Builder;
 import io.quarkiverse.mcp.server.SamplingRequest.IncludeContext;
+import io.vertx.core.json.JsonObject;
 
 class SamplingImpl implements Sampling {
 
     static SamplingImpl from(ArgumentProviders argProviders) {
+        JsonObject params = Messages.getParams(argProviders.rawMessage());
         return new SamplingImpl(argProviders.connection(), argProviders.sender(),
                 argProviders.serverRequests(),
                 argProviders.serverRequests().getSamplingTimeout(argProviders.serverName()),
-                argProviders.mcpTracing());
+                argProviders.mcpTracing(),
+                InputResponsesImpl.from(params),
+                params != null ? params.getString("requestState") : null);
     }
 
     private final McpConnection connection;
@@ -34,18 +39,39 @@ class SamplingImpl implements Sampling {
 
     private final McpTracing mcpTracing;
 
+    private final InputResponses inputResponses;
+
+    private final String requestState;
+
     SamplingImpl(McpConnection connection, Sender sender, ServerRequests serverRequests, Duration timeout,
-            McpTracing mcpTracing) {
+            McpTracing mcpTracing, InputResponses inputResponses, String requestState) {
         this.connection = connection;
         this.sender = sender;
         this.serverRequests = serverRequests;
         this.timeout = timeout;
         this.mcpTracing = mcpTracing;
+        this.inputResponses = inputResponses;
+        this.requestState = requestState;
     }
 
     @Override
     public boolean isSupported() {
         return connection.initialRequest().supportsSampling();
+    }
+
+    @Override
+    public boolean isServerInitiatedRequestSupported() {
+        return !connection.initialRequest().protocolVersion().isStateless();
+    }
+
+    @Override
+    public InputResponses inputResponses() {
+        return inputResponses;
+    }
+
+    @Override
+    public String requestState() {
+        return requestState;
     }
 
     @Override
@@ -133,7 +159,8 @@ class SamplingImpl implements Sampling {
             }
             return new SamplingRequestImpl(maxTokens, List.copyOf(messages), temperature, systemPrompt, includeContext,
                     modelPreferences, metadata, stopSequences,
-                    sender, serverRequests, timeout, SamplingImpl.this.mcpTracing);
+                    sender, serverRequests, timeout, SamplingImpl.this.mcpTracing,
+                    SamplingImpl.this.connection.initialRequest().protocolVersion().isStateless());
         }
 
     }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/SamplingRequestImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/SamplingRequestImpl.java
@@ -44,11 +44,12 @@ public class SamplingRequestImpl implements SamplingRequest {
     private final ServerRequests serverRequests;
     private final Duration timeout;
     private final McpTracing mcpTracing;
+    private final boolean stateless;
 
     SamplingRequestImpl(long maxTokens, List<SamplingMessage> messages, BigDecimal temperature, String systemPrompt,
             IncludeContext includeContext, ModelPreferences modelPreferences, Map<String, Object> metadata,
             List<String> stopSequences, Sender sender,
-            ServerRequests serverRequests, Duration timeout, McpTracing mcpTracing) {
+            ServerRequests serverRequests, Duration timeout, McpTracing mcpTracing, boolean stateless) {
         this.maxTokens = maxTokens;
         this.messages = messages;
         this.temperature = temperature;
@@ -61,6 +62,7 @@ public class SamplingRequestImpl implements SamplingRequest {
         this.serverRequests = serverRequests;
         this.timeout = timeout;
         this.mcpTracing = mcpTracing;
+        this.stateless = stateless;
     }
 
     @JsonProperty
@@ -116,8 +118,21 @@ public class SamplingRequestImpl implements SamplingRequest {
         return meta;
     }
 
+    JsonObject toInputRequestJson() {
+        JsonObject params = JsonObject.mapFrom(this);
+        // Remove internal fields that are not part of the protocol
+        params.remove("_meta");
+        return new JsonObject()
+                .put("method", McpMethod.SAMPLING_CREATE_MESSAGE.jsonRpcName())
+                .put("params", params);
+    }
+
     @Override
     public Uni<SamplingResponse> send() {
+        if (stateless) {
+            throw new IllegalStateException(
+                    "Server-initiated requests are not supported with stateless protocol versions; use InputRequiredException instead");
+        }
         AtomicLong id = new AtomicLong();
         Uni<SamplingResponse> ret = Uni.createFrom().completionStage(() -> {
             CompletableFuture<SamplingResponse> future = new CompletableFuture<SamplingResponse>();

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/Subscription.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/Subscription.java
@@ -1,0 +1,19 @@
+package io.quarkiverse.mcp.server.runtime;
+
+/**
+ * Represents an active subscription opened via {@code subscriptions/listen}.
+ *
+ * @param subscriptionId the JSON-RPC request ID of the {@code subscriptions/listen} call
+ * @param filter the notification filter specifying which notification types the client subscribed to
+ */
+public record Subscription(Object subscriptionId, SubscriptionFilter filter) {
+
+    public Subscription {
+        if (subscriptionId == null) {
+            throw new IllegalArgumentException("subscriptionId must not be null");
+        }
+        if (filter == null) {
+            throw new IllegalArgumentException("filter must not be null");
+        }
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/SubscriptionFilter.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/SubscriptionFilter.java
@@ -1,0 +1,70 @@
+package io.quarkiverse.mcp.server.runtime;
+
+import java.util.List;
+import java.util.Set;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Captures the subset of notification types a client subscribed to via {@code subscriptions/listen}.
+ */
+public record SubscriptionFilter(boolean toolsListChanged, boolean promptsListChanged, boolean resourcesListChanged,
+        Set<String> resourceSubscriptions) {
+
+    public static SubscriptionFilter parse(JsonObject notifications) {
+        boolean tools = notifications.getBoolean("toolsListChanged", false);
+        boolean prompts = notifications.getBoolean("promptsListChanged", false);
+        boolean resources = notifications.getBoolean("resourcesListChanged", false);
+        Set<String> resourceSubs;
+        JsonArray arr = notifications.getJsonArray("resourceSubscriptions");
+        if (arr != null && !arr.isEmpty()) {
+            String[] uris = new String[arr.size()];
+            for (int i = 0; i < arr.size(); i++) {
+                uris[i] = arr.getString(i);
+            }
+            resourceSubs = Set.of(uris);
+        } else {
+            resourceSubs = Set.of();
+        }
+        return new SubscriptionFilter(tools, prompts, resources, resourceSubs);
+    }
+
+    /**
+     * @param notificationMethod the JSON-RPC method of the notification
+     * @param resourceUri the resource URI for {@code notifications/resources/updated}, or {@code null}
+     * @return {@code true} if this filter accepts the given notification
+     */
+    public boolean matches(String notificationMethod, String resourceUri) {
+        if (notificationMethod == null) {
+            return false;
+        }
+        return switch (notificationMethod) {
+            case "notifications/tools/list_changed" -> toolsListChanged;
+            case "notifications/prompts/list_changed" -> promptsListChanged;
+            case "notifications/resources/list_changed" -> resourcesListChanged;
+            case "notifications/resources/updated" -> resourceUri != null && resourceSubscriptions.contains(resourceUri);
+            default -> false;
+        };
+    }
+
+    /**
+     * @return the {@code notifications} object for the {@code notifications/subscriptions/acknowledged} response
+     */
+    public JsonObject toAcknowledgedJson() {
+        JsonObject ret = new JsonObject();
+        if (toolsListChanged) {
+            ret.put("toolsListChanged", true);
+        }
+        if (promptsListChanged) {
+            ret.put("promptsListChanged", true);
+        }
+        if (resourcesListChanged) {
+            ret.put("resourcesListChanged", true);
+        }
+        if (!resourceSubscriptions.isEmpty()) {
+            ret.put("resourceSubscriptions", new JsonArray(List.copyOf(resourceSubscriptions)));
+        }
+        return ret;
+    }
+}

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/UrlElicitationRequestImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/UrlElicitationRequestImpl.java
@@ -28,10 +28,11 @@ public class UrlElicitationRequestImpl implements UrlElicitationRequest {
     private final Duration completionTimeout;
     private final McpTracing mcpTracing;
     private final String connectionId;
+    private final boolean stateless;
 
     UrlElicitationRequestImpl(String message, String url, String elicitationId, Sender sender,
             ServerRequests serverRequests, Duration timeout, Duration completionTimeout,
-            McpTracing mcpTracing, String connectionId) {
+            McpTracing mcpTracing, String connectionId, boolean stateless) {
         this.message = message;
         this.url = url;
         this.elicitationId = elicitationId;
@@ -41,6 +42,7 @@ public class UrlElicitationRequestImpl implements UrlElicitationRequest {
         this.completionTimeout = completionTimeout;
         this.mcpTracing = mcpTracing;
         this.connectionId = connectionId;
+        this.stateless = stateless;
     }
 
     @Override
@@ -58,8 +60,23 @@ public class UrlElicitationRequestImpl implements UrlElicitationRequest {
         return elicitationId;
     }
 
+    JsonObject toInputRequestJson() {
+        JsonObject params = new JsonObject()
+                .put("mode", "url")
+                .put("message", message)
+                .put("url", url)
+                .put("elicitationId", elicitationId);
+        return new JsonObject()
+                .put("method", McpMethod.ELICITATION_CREATE.jsonRpcName())
+                .put("params", params);
+    }
+
     @Override
     public Uni<ElicitationResponse> send() {
+        if (stateless) {
+            throw new IllegalStateException(
+                    "Server-initiated requests are not supported with stateless protocol versions; use InputRequiredException instead");
+        }
         AtomicLong id = new AtomicLong();
         Uni<ElicitationResponse> ret = Uni.createFrom().completionStage(() -> {
             CompletableFuture<ElicitationResponse> future = new CompletableFuture<>();

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/tracing/McpRequestInfo.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/tracing/McpRequestInfo.java
@@ -5,6 +5,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import io.opentelemetry.context.Context;
 import io.quarkiverse.mcp.server.InitialRequest;
 import io.quarkiverse.mcp.server.McpMethod;
+import io.quarkiverse.mcp.server.McpProtocolVersion;
 import io.quarkiverse.mcp.server.runtime.McpRequest;
 import io.quarkiverse.mcp.server.runtime.Messages;
 import io.vertx.core.json.JsonObject;
@@ -55,7 +56,8 @@ public class McpRequestInfo {
     }
 
     public String getProtocolVersion() {
-        return mcpRequest.protocolVersion();
+        McpProtocolVersion pv = mcpRequest.protocolVersion();
+        return pv != null ? pv.version() : null;
     }
 
     public InitialRequest.Transport getTransport() {

--- a/core/runtime/src/test/java/io/quarkiverse/mcp/server/runtime/FilterContextImplTest.java
+++ b/core/runtime/src/test/java/io/quarkiverse/mcp/server/runtime/FilterContextImplTest.java
@@ -7,6 +7,7 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkiverse.mcp.server.InitialRequest;
 import io.quarkiverse.mcp.server.McpMethod;
+import io.quarkiverse.mcp.server.McpProtocolVersion;
 import io.quarkiverse.mcp.server.MetaKey;
 import io.vertx.core.json.JsonObject;
 
@@ -74,7 +75,7 @@ public class FilterContextImplTest {
             }
 
             @Override
-            public String protocolVersion() {
+            public McpProtocolVersion protocolVersion() {
                 throw new UnsupportedOperationException();
             }
 

--- a/core/runtime/src/test/java/io/quarkiverse/mcp/server/runtime/InitialRequestTest.java
+++ b/core/runtime/src/test/java/io/quarkiverse/mcp/server/runtime/InitialRequestTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 
 import io.quarkiverse.mcp.server.Implementation;
 import io.quarkiverse.mcp.server.InitialRequest;
+import io.quarkiverse.mcp.server.McpProtocolVersion;
 
 public class InitialRequestTest {
 
@@ -20,9 +21,11 @@ public class InitialRequestTest {
         assertEquals("protocolVersion must not be null",
                 assertThrows(IllegalArgumentException.class, () -> new InitialRequest(impl, null, null, null)).getMessage());
         assertEquals("clientCapabilities must not be null",
-                assertThrows(IllegalArgumentException.class, () -> new InitialRequest(impl, "1.0", null, null)).getMessage());
+                assertThrows(IllegalArgumentException.class,
+                        () -> new InitialRequest(impl, McpProtocolVersion.V_2024_11_05, null, null)).getMessage());
         assertEquals("transport must not be null",
-                assertThrows(IllegalArgumentException.class, () -> new InitialRequest(impl, "1.0", List.of(), null))
+                assertThrows(IllegalArgumentException.class,
+                        () -> new InitialRequest(impl, McpProtocolVersion.V_2024_11_05, List.of(), null))
                         .getMessage());
     }
 

--- a/core/runtime/src/test/java/io/quarkiverse/mcp/server/runtime/McpMessageHandlerTest.java
+++ b/core/runtime/src/test/java/io/quarkiverse/mcp/server/runtime/McpMessageHandlerTest.java
@@ -1,0 +1,65 @@
+package io.quarkiverse.mcp.server.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkiverse.mcp.server.JsonRpcErrorCodes;
+import io.quarkiverse.mcp.server.McpException;
+import io.quarkiverse.mcp.server.MetaKey;
+import io.vertx.core.json.JsonObject;
+
+public class McpMessageHandlerTest {
+
+    @Test
+    public void testIsStateless() {
+        assertThrows(IllegalArgumentException.class, () -> McpMessageHandler.isStateless(null));
+        assertFalse(McpMessageHandler.isStateless("2024-11-05"));
+        assertFalse(McpMessageHandler.isStateless("2025-03-26"));
+        assertFalse(McpMessageHandler.isStateless("2025-06-18"));
+        assertFalse(McpMessageHandler.isStateless("2025-11-25"));
+        assertTrue(McpMessageHandler.isStateless("2026-07-28"));
+        assertTrue(McpMessageHandler.isStateless("2027-01-15"));
+        assertTrue(McpMessageHandler.isStateless("2030-12-31"));
+    }
+
+    @Test
+    public void testValidateStatelessMetaNullMeta() {
+        McpException e = assertThrows(McpException.class, () -> McpMessageHandler.validateStatelessMeta(null));
+        assertEquals(JsonRpcErrorCodes.INVALID_PARAMS, e.getJsonRpcErrorCode());
+    }
+
+    @Test
+    public void testValidateStatelessMetaEmptyMeta() {
+        McpException e = assertThrows(McpException.class,
+                () -> McpMessageHandler.validateStatelessMeta(new JsonObject()));
+        assertEquals(JsonRpcErrorCodes.INVALID_PARAMS, e.getJsonRpcErrorCode());
+        assertTrue(e.getMessage().contains(MetaKey.PROTOCOL_VERSION.toString()));
+        assertTrue(e.getMessage().contains(MetaKey.CLIENT_INFO.toString()));
+        assertTrue(e.getMessage().contains(MetaKey.CLIENT_CAPABILITIES.toString()));
+    }
+
+    @Test
+    public void testValidateStatelessMetaMissingClientInfo() {
+        JsonObject meta = new JsonObject()
+                .put(MetaKey.PROTOCOL_VERSION.toString(), "2026-07-28")
+                .put(MetaKey.CLIENT_CAPABILITIES.toString(), new JsonObject());
+        McpException e = assertThrows(McpException.class, () -> McpMessageHandler.validateStatelessMeta(meta));
+        assertEquals(JsonRpcErrorCodes.INVALID_PARAMS, e.getJsonRpcErrorCode());
+        assertTrue(e.getMessage().contains(MetaKey.CLIENT_INFO.toString()));
+        assertFalse(e.getMessage().contains(MetaKey.PROTOCOL_VERSION.toString()));
+    }
+
+    @Test
+    public void testValidateStatelessMetaValid() {
+        JsonObject meta = new JsonObject()
+                .put(MetaKey.PROTOCOL_VERSION.toString(), "2026-07-28")
+                .put(MetaKey.CLIENT_INFO.toString(), new JsonObject().put("name", "test").put("version", "1.0"))
+                .put(MetaKey.CLIENT_CAPABILITIES.toString(), new JsonObject());
+        McpMessageHandler.validateStatelessMeta(meta);
+    }
+
+}

--- a/core/runtime/src/test/java/io/quarkiverse/mcp/server/runtime/MetaKeyTest.java
+++ b/core/runtime/src/test/java/io/quarkiverse/mcp/server/runtime/MetaKeyTest.java
@@ -43,6 +43,14 @@ public class MetaKeyTest {
         MetaKey k = MetaKey.from("foo-bar.baz/name");
         assertEquals("foo-bar.baz/", k.prefix());
         assertEquals("name", k.name());
+        assertEquals("foo-bar.baz/name", k.toString());
+
+        MetaKey simple = MetaKey.from("myKey");
+        assertEquals("myKey", simple.name());
+        assertEquals("myKey", simple.toString());
+
+        assertThrows(IllegalArgumentException.class, () -> MetaKey.from(null));
+        assertThrows(IllegalArgumentException.class, () -> MetaKey.from(""));
     }
 
     @Test

--- a/core/runtime/src/test/java/io/quarkiverse/mcp/server/runtime/SubscriptionFilterTest.java
+++ b/core/runtime/src/test/java/io/quarkiverse/mcp/server/runtime/SubscriptionFilterTest.java
@@ -1,0 +1,143 @@
+package io.quarkiverse.mcp.server.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+public class SubscriptionFilterTest {
+
+    @Test
+    public void testParseAllFields() {
+        JsonObject notifications = new JsonObject()
+                .put("toolsListChanged", true)
+                .put("promptsListChanged", true)
+                .put("resourcesListChanged", true)
+                .put("resourceSubscriptions", new JsonArray().add("file:///a.txt").add("file:///b.txt"));
+
+        SubscriptionFilter filter = SubscriptionFilter.parse(notifications);
+
+        assertTrue(filter.toolsListChanged());
+        assertTrue(filter.promptsListChanged());
+        assertTrue(filter.resourcesListChanged());
+        assertEquals(2, filter.resourceSubscriptions().size());
+        assertTrue(filter.resourceSubscriptions().contains("file:///a.txt"));
+        assertTrue(filter.resourceSubscriptions().contains("file:///b.txt"));
+    }
+
+    @Test
+    public void testParsePartialFields() {
+        JsonObject notifications = new JsonObject()
+                .put("toolsListChanged", true);
+
+        SubscriptionFilter filter = SubscriptionFilter.parse(notifications);
+
+        assertTrue(filter.toolsListChanged());
+        assertFalse(filter.promptsListChanged());
+        assertFalse(filter.resourcesListChanged());
+        assertTrue(filter.resourceSubscriptions().isEmpty());
+    }
+
+    @Test
+    public void testParseEmpty() {
+        SubscriptionFilter filter = SubscriptionFilter.parse(new JsonObject());
+
+        assertFalse(filter.toolsListChanged());
+        assertFalse(filter.promptsListChanged());
+        assertFalse(filter.resourcesListChanged());
+        assertTrue(filter.resourceSubscriptions().isEmpty());
+    }
+
+    @Test
+    public void testMatchesToolsListChanged() {
+        SubscriptionFilter filter = SubscriptionFilter.parse(
+                new JsonObject().put("toolsListChanged", true));
+
+        assertTrue(filter.matches("notifications/tools/list_changed", null));
+        assertFalse(filter.matches("notifications/prompts/list_changed", null));
+        assertFalse(filter.matches("notifications/resources/list_changed", null));
+    }
+
+    @Test
+    public void testMatchesPromptsListChanged() {
+        SubscriptionFilter filter = SubscriptionFilter.parse(
+                new JsonObject().put("promptsListChanged", true));
+
+        assertFalse(filter.matches("notifications/tools/list_changed", null));
+        assertTrue(filter.matches("notifications/prompts/list_changed", null));
+    }
+
+    @Test
+    public void testMatchesResourcesListChanged() {
+        SubscriptionFilter filter = SubscriptionFilter.parse(
+                new JsonObject().put("resourcesListChanged", true));
+
+        assertTrue(filter.matches("notifications/resources/list_changed", null));
+        assertFalse(filter.matches("notifications/tools/list_changed", null));
+    }
+
+    @Test
+    public void testMatchesResourceUpdated() {
+        SubscriptionFilter filter = SubscriptionFilter.parse(
+                new JsonObject().put("resourceSubscriptions",
+                        new JsonArray().add("file:///a.txt")));
+
+        assertTrue(filter.matches("notifications/resources/updated", "file:///a.txt"));
+        assertFalse(filter.matches("notifications/resources/updated", "file:///b.txt"));
+        assertFalse(filter.matches("notifications/resources/updated", null));
+    }
+
+    @Test
+    public void testMatchesUnknownMethod() {
+        SubscriptionFilter filter = SubscriptionFilter.parse(
+                new JsonObject().put("toolsListChanged", true));
+
+        assertFalse(filter.matches("notifications/unknown", null));
+        assertFalse(filter.matches(null, null));
+    }
+
+    @Test
+    public void testNoMatchWhenNotSubscribed() {
+        SubscriptionFilter filter = SubscriptionFilter.parse(new JsonObject());
+
+        assertFalse(filter.matches("notifications/tools/list_changed", null));
+        assertFalse(filter.matches("notifications/prompts/list_changed", null));
+        assertFalse(filter.matches("notifications/resources/list_changed", null));
+        assertFalse(filter.matches("notifications/resources/updated", "file:///a.txt"));
+    }
+
+    @Test
+    public void testToAcknowledgedJson() {
+        JsonObject input = new JsonObject()
+                .put("toolsListChanged", true)
+                .put("resourcesListChanged", true)
+                .put("resourceSubscriptions", new JsonArray().add("file:///a.txt"));
+
+        SubscriptionFilter filter = SubscriptionFilter.parse(input);
+        JsonObject ack = filter.toAcknowledgedJson();
+
+        assertNotNull(ack);
+        assertTrue(ack.getBoolean("toolsListChanged"));
+        assertFalse(ack.containsKey("promptsListChanged"));
+        assertTrue(ack.getBoolean("resourcesListChanged"));
+        JsonArray subs = ack.getJsonArray("resourceSubscriptions");
+        assertNotNull(subs);
+        assertEquals(1, subs.size());
+        assertEquals("file:///a.txt", subs.getString(0));
+    }
+
+    @Test
+    public void testToAcknowledgedJsonEmpty() {
+        SubscriptionFilter filter = SubscriptionFilter.parse(new JsonObject());
+        JsonObject ack = filter.toAcknowledgedJson();
+
+        assertNotNull(ack);
+        assertTrue(ack.isEmpty());
+    }
+
+}

--- a/docs/modules/ROOT/pages/concepts-architecture.adoc
+++ b/docs/modules/ROOT/pages/concepts-architecture.adoc
@@ -147,8 +147,8 @@ The resource manager:
 
 * Stores resource metadata (URI, description)
 * Routes `resources/list` and `resources/read` requests
-* Manages subscriptions (`resources/subscribe`, `resources/unsubscribe`)
-* Sends update notifications to subscribers
+* Manages subscriptions (`resources/subscribe`, `resources/unsubscribe` for stateful clients; `subscriptions/listen` for stateless clients)
+* Sends update notifications to subscribers and subscription streams
 * Encodes return values to `ResourceResponse`
 
 === PromptManager

--- a/docs/modules/ROOT/pages/concepts-mcp-protocol.adoc
+++ b/docs/modules/ROOT/pages/concepts-mcp-protocol.adoc
@@ -387,6 +387,53 @@ sequenceDiagram
     Server-->>Client: tools/call response (result)
 ----
 
+=== Subscription Notifications (Stateless)
+
+With stateless protocol versions, `resources/subscribe` and `resources/unsubscribe` are not available.
+Instead, stateless clients use `subscriptions/listen` to open a notification stream filtered by notification type.
+
+[mermaid,mcp-subscriptions-listen-flow,svg]
+----
+sequenceDiagram
+    participant Client
+    participant Server
+
+    Client->>Server: 1. subscriptions/listen (+filter)
+    Server-->>Client: 2. notifications/subscriptions/acknowledged
+    Note over Server: Server-side event<br/>(e.g. tool registered)
+    Server-->>Client: 3. notifications/tools/list_changed<br/>(+subscriptionId in _meta)
+    Note over Server: Resource updated
+    Server-->>Client: 4. notifications/resources/updated<br/>(+subscriptionId in _meta)
+----
+
+The `subscriptions/listen` request specifies a filter in the `notifications` field of the `params` object:
+
+[source,json]
+----
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "subscriptions/listen",
+  "params": {
+    "notifications": {
+      "toolsListChanged": true,
+      "promptsListChanged": true,
+      "resourcesListChanged": true,
+      "resourceSubscriptions": ["file:///status.txt"]
+    },
+    "_meta": {
+      "io.modelcontextprotocol/protocolVersion": "2026-07-28",
+      "io.modelcontextprotocol/clientInfo": { "name": "my-client", "version": "1.0" }
+    }
+  }
+}
+----
+
+The server acknowledges the subscription immediately with `notifications/subscriptions/acknowledged`.
+Subsequent matching notifications include the `io.modelcontextprotocol/subscriptionId` field in `_meta`, set to the original request ID (in this case `1`).
+
+See xref:concepts-transports.adoc#_stateless_mode[Stateless Mode] for details on how subscriptions work with stateless connections.
+
 === Multi Round-Trip Request (MRTR)
 
 With stateless protocol versions, the server cannot send server-initiated requests (such as sampling or elicitation).

--- a/docs/modules/ROOT/pages/concepts-mcp-protocol.adoc
+++ b/docs/modules/ROOT/pages/concepts-mcp-protocol.adoc
@@ -171,6 +171,49 @@ MCP uses capability negotiation to establish what features are available between
 }
 ----
 
+=== Stateless Discovery
+
+Starting with protocol version `2026-07-28`, stateless clients use `server/discover` instead of the `initialize`/`initialized` handshake:
+
+[source,json]
+----
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "method": "server/discover",
+  "params": {
+    "_meta": {
+      "io.modelcontextprotocol/protocolVersion": "2026-07-28"
+    }
+  }
+}
+----
+
+The server responds with its supported versions, capabilities, and server info:
+
+[source,json]
+----
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "supportedVersions": ["2026-07-28", "2025-11-25", "2025-06-18", "2025-03-26", "2024-11-05"],
+    "capabilities": {
+      "tools": {},
+      "resources": {},
+      "prompts": {}
+    },
+    "serverInfo": {
+      "name": "acme-quarkus-server",
+      "version": "1.0.0"
+    }
+  }
+}
+----
+
+No `initialized` notification is sent. Each subsequent request is self-contained.
+See xref:concepts-transports.adoc#_stateless_mode[Stateless Mode] for details on required headers and `_meta` fields.
+
 === Capability Checking
 
 After initialization, both parties know what features are available:
@@ -217,9 +260,10 @@ NOTE: The exact sequence is not strictly enforced by the protocol, but this is t
 * No explicit shutdown request needed
 
 **HTTP Transports**::
-* Connections are session-based
-* Each session maintains separate state
-* Explicit `shutdown` request recommended for clean termination
+* Stateful connections are session-based; each session maintains separate state
+* Stateless clients (protocol version `2026-07-28`+) use transient connections — created per-request with no session
+* `McpConnection.isTransient()` returns `true` for transient connections
+* Explicit `shutdown` request recommended for clean termination of stateful sessions
 * SSE connections require keep-alive mechanism
 
 **WebSocket Transport** (custom transport)::
@@ -307,6 +351,23 @@ sequenceDiagram
     Note over Server: Tool executes
     Server-->>Client: 7. notifications/progress (optional)
     Server-->>Client: 8. tools/call response (result)
+----
+
+=== Tool Call Flow (Stateless)
+
+[mermaid,mcp-tool-call-flow-stateless,svg]
+----
+sequenceDiagram
+    participant Client
+    participant Server
+
+    Client->>Server: 1. server/discover
+    Server-->>Client: 2. discover response (capabilities, versions)
+    Client->>Server: 3. tools/list (+headers, +_meta)
+    Server-->>Client: 4. tools/list response
+    Client->>Server: 5. tools/call (+headers, +_meta)
+    Note over Server: Tool executes<br/>(transient connection)
+    Server-->>Client: 6. tools/call response (result)
 ----
 
 === Server-to-Client Request (Sampling)

--- a/docs/modules/ROOT/pages/concepts-mcp-protocol.adoc
+++ b/docs/modules/ROOT/pages/concepts-mcp-protocol.adoc
@@ -387,6 +387,27 @@ sequenceDiagram
     Server-->>Client: tools/call response (result)
 ----
 
+=== Multi Round-Trip Request (MRTR)
+
+With stateless protocol versions, the server cannot send server-initiated requests (such as sampling or elicitation).
+Instead, it uses the Multi Round-Trip Requests (MRTR) pattern: the server returns an `input_required` result, and the client retries with the gathered input.
+
+[mermaid,mcp-mrtr-flow,svg]
+----
+sequenceDiagram
+    participant Client
+    participant Server
+
+    Client->>Server: 1. tools/call (name: "analyze")
+    Note over Server: Tool needs input<br/>Throws InputRequiredException
+    Server-->>Client: 2. result (resultType: "input_required",<br/>inputRequests, requestState)
+    Note over Client: Client gathers input<br/>(UI form, LLM, etc.)
+    Client->>Server: 3. tools/call (name: "analyze",<br/>inputResponses, requestState)
+    Note over Server: Tool reads responses<br/>and completes
+    Server-->>Client: 4. tools/call response (result)
+----
+
+See xref:concepts-transports.adoc#_stateless_mode[Stateless Mode] for details on which protocol versions use this pattern.
 
 == See Also
 

--- a/docs/modules/ROOT/pages/concepts-transports.adoc
+++ b/docs/modules/ROOT/pages/concepts-transports.adoc
@@ -81,6 +81,8 @@ Instead, each request is self-contained — the client provides its identity, pr
 * The server creates a transient connection for each request — no session is established and no `Mcp-Session-Id` header is returned.
 * Stateless connections are transient (`McpConnection.isTransient()` returns `true`).
 * The following methods are not available for stateless clients and will be rejected with a `METHOD_NOT_FOUND` error: `ping`, `logging/setLevel`, `initialize`, `notifications/initialized`, and `notifications/roots/list_changed`.
+* GET requests (subsidiary SSE streams) and DELETE requests (session termination) return HTTP `405 Method Not Allowed` for stateless clients.
+* Server-initiated requests (sampling, elicitation, roots) are not available for stateless clients. The Multi Round-Trip Requests (MRTR) pattern is used instead — see xref:concepts-mcp-protocol.adoc#_multi_round_trip_request_mrtr[Multi Round-Trip Request (MRTR)].
 
 **Per-request log level**::
 Since `logging/setLevel` is not available for stateless clients, the log level can be set per-request using the `io.modelcontextprotocol/logLevel` `_meta` field.

--- a/docs/modules/ROOT/pages/concepts-transports.adoc
+++ b/docs/modules/ROOT/pages/concepts-transports.adoc
@@ -61,6 +61,33 @@ The `\{rootPath}` is set to `mcp` by default, but it can be changed with the `qu
 
 NOTE: The https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#resumability-and-redelivery[Resumability and Redelivery] for the Streamable HTTP is not supported yet.
 
+=== Stateless Mode
+
+Starting with protocol version `2026-07-28`, MCP supports a stateless communication mode.
+The server automatically detects whether a client is stateless or stateful and handles both paradigms simultaneously on the same endpoint.
+
+**Stateless vs. Stateful**::
+In the stateful mode (protocol versions `2025-11-25` and earlier), the client performs an `initialize`/`initialized` handshake, the server assigns a session via the `Mcp-Session-Id` header, and both sides maintain state across requests.
+In the stateless mode, there is no handshake and no session.
+Instead, each request is self-contained — the client provides its identity, protocol version, and capabilities via `_meta` fields and required HTTP headers.
+
+**How it works**::
+* A stateless client sends `server/discover` (instead of `initialize`) to learn the server's capabilities, supported protocol versions, and server info.
+* Every subsequent request includes:
+** `MCP-Protocol-Version` header with the protocol version
+** `Mcp-Method` header matching the JSON-RPC method in the body
+** `Mcp-Name` header for `tools/call`, `prompts/get`, and `resources/read` (the tool name, prompt name, or resource URI)
+** `_meta` fields: `io.modelcontextprotocol/protocolVersion`, `io.modelcontextprotocol/clientInfo`, and optionally `io.modelcontextprotocol/clientCapabilities`
+* The server creates a transient connection for each request — no session is established and no `Mcp-Session-Id` header is returned.
+* Stateless connections are transient (`McpConnection.isTransient()` returns `true`).
+* The following methods are not available for stateless clients and will be rejected with a `METHOD_NOT_FOUND` error: `ping`, `logging/setLevel`, `initialize`, `notifications/initialized`, and `notifications/roots/list_changed`.
+
+**Per-request log level**::
+Since `logging/setLevel` is not available for stateless clients, the log level can be set per-request using the `io.modelcontextprotocol/logLevel` `_meta` field.
+The value must be a valid log level string (e.g. `debug`, `info`, `warning`, `error`).
+The server returns an `INVALID_PARAMS` error (`-32602`) if the value is not recognized.
+The `McpConnection.logLevel()` method returns this per-request value for transient connections.
+
 See xref:getting-started-http.adoc[Getting Started with HTTP] for a complete tutorial.
 
 == WebSocket Transport

--- a/docs/modules/ROOT/pages/concepts-transports.adoc
+++ b/docs/modules/ROOT/pages/concepts-transports.adoc
@@ -80,9 +80,10 @@ Instead, each request is self-contained — the client provides its identity, pr
 ** `_meta` fields: `io.modelcontextprotocol/protocolVersion`, `io.modelcontextprotocol/clientInfo`, and optionally `io.modelcontextprotocol/clientCapabilities`
 * The server creates a transient connection for each request — no session is established and no `Mcp-Session-Id` header is returned.
 * Stateless connections are transient (`McpConnection.isTransient()` returns `true`).
-* The following methods are not available for stateless clients and will be rejected with a `METHOD_NOT_FOUND` error: `ping`, `logging/setLevel`, `initialize`, `notifications/initialized`, and `notifications/roots/list_changed`.
+* The following methods are not available for stateless clients and will be rejected with a `METHOD_NOT_FOUND` error: `ping`, `logging/setLevel`, `initialize`, `notifications/initialized`, `notifications/roots/list_changed`, `resources/subscribe`, and `resources/unsubscribe`.
 * GET requests (subsidiary SSE streams) and DELETE requests (session termination) return HTTP `405 Method Not Allowed` for stateless clients.
 * Server-initiated requests (sampling, elicitation, roots) are not available for stateless clients. The Multi Round-Trip Requests (MRTR) pattern is used instead — see xref:concepts-mcp-protocol.adoc#_multi_round_trip_request_mrtr[Multi Round-Trip Request (MRTR)].
+* Stateless clients use `subscriptions/listen` instead of `resources/subscribe`/`resources/unsubscribe` to receive notifications. The client specifies a filter for the notification types it wants (e.g. `toolsListChanged`, `resourceSubscriptions`), and the server delivers matching notifications on the subscription stream. See xref:concepts-mcp-protocol.adoc#_subscription_notifications_stateless[Subscription Notifications].
 
 **Per-request log level**::
 Since `logging/setLevel` is not available for stateless clients, the log level can be set per-request using the `io.modelcontextprotocol/logLevel` `_meta` field.

--- a/docs/modules/ROOT/pages/guides-client-integration.adoc
+++ b/docs/modules/ROOT/pages/guides-client-integration.adoc
@@ -6,6 +6,10 @@ include::includes/attributes.adoc[]
 This guide covers integration with MCP client features like sampling, elicitation, and roots.
 These features allow your MCP server to request services from the client.
 
+NOTE: With stateless protocol versions (`2026-07-28`+), server-initiated requests are not supported.
+Instead, use the xref:#_multi_round_trip_requests_mrtr[Multi Round-Trip Requests (MRTR)] pattern — throw an `InputRequiredException` from the feature method, and the client retries with the gathered input.
+Use `isServerInitiatedRequestSupported()` on `Sampling`, `Elicitation`, or `Roots` to detect which pattern to use.
+
 == Sampling
 
 Sampling allows the server to request LLM responses from the client.
@@ -774,6 +778,205 @@ public class RootsManager {
 <2> Store the initial roots.
 <3> Called when the client's roots change.
 <4> Update the cached roots.
+
+== Multi Round-Trip Requests (MRTR)
+
+With stateless protocol versions, the server cannot send server-initiated requests (sampling, elicitation, roots) to the client.
+Instead, it uses the Multi Round-Trip Requests (MRTR) pattern: the server throws an `InputRequiredException` from the feature method, and the client retries the original request with the gathered input.
+
+The `Sampling`, `Elicitation`, and `Roots` interfaces all implement `MrtrRequest`, which provides:
+
+* `isServerInitiatedRequestSupported()` — returns `true` for stateful clients, `false` for stateless
+* `inputRequired()` — returns an `InputRequiredException.Builder` (throws if the client is stateful)
+* `inputResponses()` — provides typed access to client responses on retry (never `null`, but may be empty on the initial request)
+* `requestState()` — the opaque state string echoed back by the client
+
+=== Detecting the Protocol Mode
+
+Use `isServerInitiatedRequestSupported()` to branch between the server-initiated request API and the MRTR pattern:
+
+[source,java]
+----
+import io.quarkiverse.mcp.server.Sampling;
+import io.quarkiverse.mcp.server.SamplingMessage;
+import io.quarkiverse.mcp.server.Tool;
+
+public class MyTools {
+
+    @Tool(description = "Ask the AI a question")
+    String askAI(String question, Sampling sampling) {
+        if (!sampling.isSupported()) {
+            return "Sampling not supported";
+        }
+
+        if (sampling.isServerInitiatedRequestSupported()) { // <1>
+            return sampling.requestBuilder()
+                .setMaxTokens(100)
+                .addMessage(SamplingMessage.withUserRole(question))
+                .build()
+                .sendAndAwait()
+                .content().asText().text();
+        }
+
+        // Stateless client — use MRTR pattern
+        if (sampling.inputResponses().isEmpty()) { // <2>
+            throw sampling.inputRequired() // <3>
+                .addSamplingRequest("answer",
+                    sampling.requestBuilder()
+                        .setMaxTokens(100)
+                        .addMessage(SamplingMessage.withUserRole(question))
+                        .build())
+                .build();
+        }
+
+        return sampling.inputResponses() // <4>
+            .getSamplingResponse("answer")
+            .content().asText().text();
+    }
+}
+----
+<1> Check if the client supports server-initiated requests (stateful protocol).
+<2> On the initial request, `inputResponses()` is empty — the server has not yet asked for input.
+<3> Throw `InputRequiredException` with a sampling request keyed by `"answer"`. The framework converts this to a `resultType: "input_required"` result.
+<4> On the retry, the client provides the sampling response. Access it by the same key.
+
+=== Elicitation with MRTR
+
+[source,java]
+----
+import io.quarkiverse.mcp.server.Elicitation;
+import io.quarkiverse.mcp.server.ElicitationRequest.StringSchema;
+import io.quarkiverse.mcp.server.Tool;
+
+public class MyTools {
+
+    @Tool(description = "Get user info")
+    String getUserInfo(Elicitation elicitation) {
+        if (!elicitation.isFormModeSupported()) {
+            return "Elicitation not supported";
+        }
+
+        if (elicitation.isServerInitiatedRequestSupported()) {
+            var response = elicitation.requestBuilder()
+                .setMessage("Enter your name:")
+                .addSchemaProperty("name", new StringSchema(true))
+                .build()
+                .sendAndAwait();
+            return response.actionAccepted()
+                ? "Hello " + response.content().getString("name")
+                : "Cancelled";
+        }
+
+        // Stateless — MRTR
+        if (elicitation.inputResponses().isEmpty()) {
+            throw elicitation.inputRequired()
+                .addElicitationRequest("userInput",
+                    elicitation.requestBuilder()
+                        .setMessage("Enter your name:")
+                        .addSchemaProperty("name", new StringSchema(true))
+                        .build())
+                .setRequestState("get-user-info") // <1>
+                .build();
+        }
+
+        var response = elicitation.inputResponses()
+            .getElicitationResponse("userInput");
+        return response.actionAccepted()
+            ? "Hello " + response.content().getString("name")
+            : "Cancelled";
+    }
+}
+----
+<1> The request state is an opaque string echoed back by the client. Use it to identify the retry context.
+
+=== Combining Multiple Input Requests
+
+A single `InputRequiredException` can request multiple inputs at once:
+
+[source,java]
+----
+import io.quarkiverse.mcp.server.Elicitation;
+import io.quarkiverse.mcp.server.ElicitationRequest.StringSchema;
+import io.quarkiverse.mcp.server.Sampling;
+import io.quarkiverse.mcp.server.SamplingMessage;
+import io.quarkiverse.mcp.server.Tool;
+
+public class MyTools {
+
+    @Tool(description = "Analyze with context")
+    String analyzeWithContext(String topic, Elicitation elicitation, Sampling sampling) {
+        if (elicitation.inputResponses().isEmpty()) {
+            var builder = elicitation.inputRequired();
+
+            builder.addElicitationRequest("prefs", // <1>
+                elicitation.requestBuilder()
+                    .setMessage("What style of analysis do you prefer?")
+                    .addSchemaProperty("style", new StringSchema(true))
+                    .build());
+
+            builder.addSamplingRequest("summary", // <2>
+                sampling.requestBuilder()
+                    .setMaxTokens(200)
+                    .addMessage(SamplingMessage.withUserRole(
+                        "Summarize the topic: " + topic))
+                    .build());
+
+            throw builder.build();
+        }
+
+        var prefs = elicitation.inputResponses().getElicitationResponse("prefs");
+        var summary = sampling.inputResponses().getSamplingResponse("summary"); // <3>
+        String style = prefs.content().getString("style");
+        String text = summary.content().asText().text();
+        return "Analysis (" + style + "): " + text;
+    }
+}
+----
+<1> Add an elicitation request with key `"prefs"`.
+<2> Add a sampling request with key `"summary"` to the same builder.
+<3> `InputResponses` is available from any of the `MrtrRequest` objects — they all share the same responses.
+
+=== Roots with MRTR
+
+[source,java]
+----
+import io.quarkiverse.mcp.server.Root;
+import io.quarkiverse.mcp.server.Roots;
+import io.quarkiverse.mcp.server.Tool;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class MyTools {
+
+    @Tool(description = "List project roots")
+    String listRoots(Roots roots) {
+        if (!roots.isSupported()) {
+            return "Roots not supported";
+        }
+
+        if (roots.isServerInitiatedRequestSupported()) {
+            return formatRoots(roots.listAndAwait());
+        }
+
+        // Stateless — MRTR
+        if (roots.inputResponses().isEmpty()) {
+            throw roots.inputRequired()
+                .addRootsRequest("projectRoots")
+                .build();
+        }
+
+        List<Root> rootList = roots.inputResponses()
+            .getRootsResponse("projectRoots");
+        return formatRoots(rootList);
+    }
+
+    private String formatRoots(List<Root> roots) {
+        return roots.stream()
+            .map(r -> r.name() + ": " + r.uri())
+            .collect(Collectors.joining("\n"));
+    }
+}
+----
 
 == Configuration
 

--- a/docs/modules/ROOT/pages/guides-implementing-resources.adoc
+++ b/docs/modules/ROOT/pages/guides-implementing-resources.adoc
@@ -255,6 +255,13 @@ public class MyResources {
 
 When `sendUpdateAndForget()` is called, all clients that have subscribed to the resource will be notified and can re-fetch the updated content.
 
+=== Stateless Clients
+
+Stateless clients (protocol version `2026-07-28`+) cannot use `resources/subscribe` and `resources/unsubscribe`.
+Instead, they use `subscriptions/listen` to open a notification stream with a filter that specifies resource URIs via the `resourceSubscriptions` field.
+When `sendUpdateAndForget()` is called, matching `notifications/resources/updated` messages are delivered to all subscription streams that include the resource URI in their filter.
+See xref:concepts-mcp-protocol.adoc#_subscription_notifications_stateless[Subscription Notifications] for details on the protocol flow.
+
 == Completion API
 
 Arguments of a `@ResourceTemplate` method may be auto-completed through the completion API.

--- a/docs/modules/ROOT/pages/release-notes.adoc
+++ b/docs/modules/ROOT/pages/release-notes.adoc
@@ -31,6 +31,7 @@ include::./includes/attributes.adoc[]
 * [2.0.0] Multi Round-Trip Requests (MRTR) support for stateless clients. Server feature methods can throw `InputRequiredException` to request additional input (elicitation, sampling, or roots) from the client. The client retries the original request with the gathered input via `InputResponses`. See xref:concepts-mcp-protocol.adoc#_multi_round_trip_request_mrtr[Multi Round-Trip Request (MRTR)]. (https://github.com/quarkiverse/quarkus-mcp-server/issues/824[#824])
 * [2.0.0] New `MrtrRequest` interface implemented by `Elicitation`, `Sampling`, and `Roots` — provides `isServerInitiatedRequestSupported()`, `inputResponses()`, `requestState()`, and `inputRequired()` builder.
 * [2.0.0] HTTP GET (SSE stream) and DELETE (session termination) requests from stateless clients now return `405 Method Not Allowed`.
+* [2.0.0] `subscriptions/listen` support for stateless clients. Replaces `resources/subscribe`/`resources/unsubscribe` for protocol version `2026-07-28`+. Clients specify a notification filter (tools, prompts, resources list changes, and resource URI subscriptions) and receive matching notifications on the subscription stream. Supported on all transports (HTTP, WebSocket, stdio). See xref:concepts-mcp-protocol.adoc#_subscription_notifications_stateless[Subscription Notifications]. (https://github.com/quarkiverse/quarkus-mcp-server/issues/824[#824])
 
 [[version-1-13]]
 == 1.13.x

--- a/docs/modules/ROOT/pages/release-notes.adoc
+++ b/docs/modules/ROOT/pages/release-notes.adoc
@@ -28,6 +28,9 @@ include::./includes/attributes.adoc[]
 * [2.0.0] New `McpProtocolVersion` enum as the public API for protocol version handling, with `isStateless()`, `from(String)`, and semantic constants (`FIRST_STATELESS`, `LATEST_STATEFUL`, `DEFAULT_ASSUMED`).
 * [2.0.0] Per-request log level via `_meta` field `io.modelcontextprotocol/logLevel` for stateless clients.
 * [2.0.0] New `MetaKey.LOG_LEVEL` and `MetaKey.PROTOCOL_VERSION` constants.
+* [2.0.0] Multi Round-Trip Requests (MRTR) support for stateless clients. Server feature methods can throw `InputRequiredException` to request additional input (elicitation, sampling, or roots) from the client. The client retries the original request with the gathered input via `InputResponses`. See xref:concepts-mcp-protocol.adoc#_multi_round_trip_request_mrtr[Multi Round-Trip Request (MRTR)]. (https://github.com/quarkiverse/quarkus-mcp-server/issues/824[#824])
+* [2.0.0] New `MrtrRequest` interface implemented by `Elicitation`, `Sampling`, and `Roots` — provides `isServerInitiatedRequestSupported()`, `inputResponses()`, `requestState()`, and `inputRequired()` builder.
+* [2.0.0] HTTP GET (SSE stream) and DELETE (session termination) requests from stateless clients now return `405 Method Not Allowed`.
 
 [[version-1-13]]
 == 1.13.x

--- a/docs/modules/ROOT/pages/release-notes.adoc
+++ b/docs/modules/ROOT/pages/release-notes.adoc
@@ -18,6 +18,16 @@ include::./includes/attributes.adoc[]
 
 * [2.0.0] The Maven artifact relocations and configuration property fallbacks for the old `quarkus-mcp-server-sse` artifact (renamed to `quarkus-mcp-server-http` in <<version-1-8,1.8.0>>) have been removed. Users still referencing `quarkus-mcp-server-sse` must switch to `quarkus-mcp-server-http`, and any configuration properties using the `sse.` prefix (e.g. `quarkus.mcp.server.sse.root-path`) must be updated to use the `http.` prefix (e.g. `quarkus.mcp.server.http.root-path`). (https://github.com/quarkiverse/quarkus-mcp-server/issues/826[#826])
 * [2.0.0] JSON-RPC batching support has been removed. Batching was added in MCP 2025-03-26 and removed in 2025-06-18. The server now rejects batch (JSON array) messages with a parse error. The `whenBatch()` method has been removed from the `McpAssured` test API. (https://github.com/quarkiverse/quarkus-mcp-server/issues/723[#723])
+* [2.0.0] `McpRequest.protocolVersion()` now returns `McpProtocolVersion` instead of `String`.
+
+[[version-2-0-features]]
+=== New Features
+
+* [2.0.0] Stateless MCP protocol support (protocol version `2026-07-28`). The server supports both stateful and stateless clients simultaneously. Stateless clients use `server/discover` instead of the `initialize`/`initialized` handshake. See xref:concepts-transports.adoc#_stateless_mode[Stateless Mode]. (https://github.com/quarkiverse/quarkus-mcp-server/issues/824[#824])
+* [2.0.0] New `McpConnection.isTransient()` method to check if a connection is transient (per-request, not tracked on the server).
+* [2.0.0] New `McpProtocolVersion` enum as the public API for protocol version handling, with `isStateless()`, `from(String)`, and semantic constants (`FIRST_STATELESS`, `LATEST_STATEFUL`, `DEFAULT_ASSUMED`).
+* [2.0.0] Per-request log level via `_meta` field `io.modelcontextprotocol/logLevel` for stateless clients.
+* [2.0.0] New `MetaKey.LOG_LEVEL` and `MetaKey.PROTOCOL_VERSION` constants.
 
 [[version-1-13]]
 == 1.13.x

--- a/schema-validator/runtime/src/main/java/io/quarkiverse/mcp/server/schema/validator/JsonSchemaValidator.java
+++ b/schema-validator/runtime/src/main/java/io/quarkiverse/mcp/server/schema/validator/JsonSchemaValidator.java
@@ -20,6 +20,7 @@ import org.jboss.logging.Logger;
 
 import io.quarkiverse.mcp.server.JsonRpcErrorCodes;
 import io.quarkiverse.mcp.server.McpMethod;
+import io.quarkiverse.mcp.server.McpProtocolVersion;
 import io.quarkiverse.mcp.server.runtime.McpRequest;
 import io.quarkiverse.mcp.server.runtime.McpRequestValidator;
 import io.quarkiverse.mcp.server.runtime.Messages;
@@ -83,7 +84,7 @@ public class JsonSchemaValidator implements McpRequestValidator {
                     mcpRequest.connection().id());
             return SUCCEEDED_FUTURE;
         }
-        String protocolVersion = mcpRequest.protocolVersion();
+        McpProtocolVersion protocolVersion = mcpRequest.protocolVersion();
         if (protocolVersion == null) {
             LOG.warnf("Unable to validate schema - no protocol version [server: %s, connection: %s]", mcpRequest.serverName(),
                     mcpRequest.connection().id());
@@ -92,7 +93,7 @@ public class JsonSchemaValidator implements McpRequestValidator {
         return vertx.executeBlocking(new Callable<>() {
             @Override
             public Boolean call() throws Exception {
-                Validator validator = validators.computeIfAbsent(new ValidatorKey(method, protocolVersion),
+                Validator validator = validators.computeIfAbsent(new ValidatorKey(method, protocolVersion.version()),
                         JsonSchemaValidator.this::newValidator);
                 OutputUnit result = validator.validate(message);
                 if (!result.getValid()) {

--- a/test/src/main/java/io/quarkiverse/mcp/server/test/McpAssured.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/McpAssured.java
@@ -1095,6 +1095,30 @@ public class McpAssured {
             ToolsCallMessage<ASSERT> withErrorAssert(Consumer<McpError> errorAssertFunction);
 
             /**
+             * Assert the raw JSON-RPC response. Useful for non-standard results like {@code InputRequiredResult}.
+             *
+             * @param rawAssertFunction
+             * @return self
+             */
+            ToolsCallMessage<ASSERT> withRawAssert(Consumer<JsonObject> rawAssertFunction);
+
+            /**
+             * Set the {@code inputResponses} for an MRTR retry request.
+             *
+             * @param inputResponses
+             * @return self
+             */
+            ToolsCallMessage<ASSERT> withInputResponses(JsonObject inputResponses);
+
+            /**
+             * Set the {@code requestState} for an MRTR retry request.
+             *
+             * @param requestState
+             * @return self
+             */
+            ToolsCallMessage<ASSERT> withRequestState(String requestState);
+
+            /**
              * Send the message.
              * <p>
              * The assert function is not used until the {@link #thenAssertResults()} method is called.
@@ -1180,6 +1204,30 @@ public class McpAssured {
              * @return self
              */
             PromptsGetMessage<ASSERT> withErrorAssert(Consumer<McpError> errorAssertFunction);
+
+            /**
+             * Assert the raw JSON-RPC response.
+             *
+             * @param rawAssertFunction
+             * @return self
+             */
+            PromptsGetMessage<ASSERT> withRawAssert(Consumer<JsonObject> rawAssertFunction);
+
+            /**
+             * Set the {@code inputResponses} for an MRTR retry request.
+             *
+             * @param inputResponses
+             * @return self
+             */
+            PromptsGetMessage<ASSERT> withInputResponses(JsonObject inputResponses);
+
+            /**
+             * Set the {@code requestState} for an MRTR retry request.
+             *
+             * @param requestState
+             * @return self
+             */
+            PromptsGetMessage<ASSERT> withRequestState(String requestState);
 
             /**
              * Send the message.
@@ -1409,6 +1457,30 @@ public class McpAssured {
              * @return self
              */
             ResourcesReadMessage<ASSERT> withErrorAssert(Consumer<McpError> errorAssertFunction);
+
+            /**
+             * Assert the raw JSON-RPC response.
+             *
+             * @param rawAssertFunction
+             * @return self
+             */
+            ResourcesReadMessage<ASSERT> withRawAssert(Consumer<JsonObject> rawAssertFunction);
+
+            /**
+             * Set the {@code inputResponses} for an MRTR retry request.
+             *
+             * @param inputResponses
+             * @return self
+             */
+            ResourcesReadMessage<ASSERT> withInputResponses(JsonObject inputResponses);
+
+            /**
+             * Set the {@code requestState} for an MRTR retry request.
+             *
+             * @param requestState
+             * @return self
+             */
+            ResourcesReadMessage<ASSERT> withRequestState(String requestState);
 
             /**
              * Send the message.

--- a/test/src/main/java/io/quarkiverse/mcp/server/test/McpAssured.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/McpAssured.java
@@ -119,6 +119,43 @@ public class McpAssured {
         return newStdioClient().build().connect();
     }
 
+    /**
+     * Injects the stateless protocol metadata ({@code _meta}) into the given JSON-RPC message with empty client capabilities.
+     *
+     * @param message the JSON-RPC message to inject metadata into
+     * @see #injectStatelessMeta(JsonObject, JsonObject)
+     */
+    public static void injectStatelessMeta(JsonObject message) {
+        injectStatelessMeta(message, new JsonObject());
+    }
+
+    /**
+     * Injects the stateless protocol metadata ({@code _meta}) into the given JSON-RPC message.
+     * <p>
+     * Use this for manually constructed messages that need to be recognized as stateless by the server
+     * (e.g. {@code subscriptions/listen}).
+     *
+     * @param message the JSON-RPC message to inject metadata into
+     * @param clientCapabilities the client capabilities object
+     */
+    public static void injectStatelessMeta(JsonObject message, JsonObject clientCapabilities) {
+        JsonObject params = message.getJsonObject("params");
+        if (params == null) {
+            params = new JsonObject();
+            message.put("params", params);
+        }
+        JsonObject meta = params.getJsonObject("_meta");
+        if (meta == null) {
+            meta = new JsonObject();
+            params.put("_meta", meta);
+        }
+        meta.put("io.modelcontextprotocol/protocolVersion", McpProtocolVersion.FIRST_STATELESS.version());
+        meta.put("io.modelcontextprotocol/clientInfo", new JsonObject()
+                .put("name", "test-client")
+                .put("version", "1.0"));
+        meta.put("io.modelcontextprotocol/clientCapabilities", clientCapabilities);
+    }
+
     public interface McpTestClient<ASSERT extends McpAssert<ASSERT>, CLIENT extends McpTestClient<ASSERT, CLIENT>>
             extends AutoCloseable {
 

--- a/test/src/main/java/io/quarkiverse/mcp/server/test/McpAssured.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/McpAssured.java
@@ -14,6 +14,7 @@ import io.quarkiverse.mcp.server.Content;
 import io.quarkiverse.mcp.server.Icon;
 import io.quarkiverse.mcp.server.Implementation;
 import io.quarkiverse.mcp.server.McpMethod;
+import io.quarkiverse.mcp.server.McpProtocolVersion;
 import io.quarkiverse.mcp.server.PromptResponse;
 import io.quarkiverse.mcp.server.ResourceResponse;
 import io.quarkiverse.mcp.server.ToolResponse;
@@ -40,6 +41,7 @@ public class McpAssured {
     public static final String RESOURCES_TEMPLATES_LIST = "resources/templates/list";
     public static final String RESOURCES_READ = "resources/read";
     public static final String COMPLETION_COMPLETE = "completion/complete";
+    public static final String SERVER_DISCOVER = "server/discover";
 
     /**
      * The base URI is used by HTTP-based client implementations.
@@ -127,6 +129,7 @@ public class McpAssured {
         boolean isConnected();
 
         /**
+         * For stateless clients, this returns the result of the {@code server/discover} operation.
          *
          * @return the result of the {@code initialize} operation or {@code null} if not connected
          */
@@ -134,6 +137,10 @@ public class McpAssured {
 
         /**
          * Connect the client and perform the MCP initialization.
+         * <p>
+         * For stateless clients, the {@code server/discover} method is used instead of the {@code initialize}/{@code
+         * notifications/initialized} handshake. No session is established and {@link McpStreamableTestClient#mcpSessionId()}
+         * returns {@code null}.
          *
          * @return the client
          */
@@ -143,6 +150,10 @@ public class McpAssured {
 
         /**
          * Connect the client and perform the MCP initialization.
+         * <p>
+         * For stateless clients, the {@code server/discover} method is used instead of the {@code initialize}/{@code
+         * notifications/initialized} handshake. No session is established and {@link McpStreamableTestClient#mcpSessionId()}
+         * returns {@code null}.
          *
          * @param assertFunction
          * @return the client
@@ -256,11 +267,19 @@ public class McpAssured {
             BUILDER setVersion(String clientVersion);
 
             /**
+             * @param protocolVersion
+             * @return self
+             * @deprecated use {@link #setProtocolVersion(McpProtocolVersion)} instead
+             */
+            @Deprecated(forRemoval = true)
+            BUILDER setProtocolVersion(String protocolVersion);
+
+            /**
              *
              * @param protocolVersion
              * @return self
              */
-            BUILDER setProtocolVersion(String protocolVersion);
+            BUILDER setProtocolVersion(McpProtocolVersion protocolVersion);
 
             /**
              *
@@ -313,6 +332,16 @@ public class McpAssured {
              * @return self
              */
             BUILDER setTracing(io.opentelemetry.api.OpenTelemetry openTelemetry);
+
+            /**
+             * Sets the client to stateless mode using the first stateless protocol version.
+             *
+             * @return self
+             */
+            @SuppressWarnings("unchecked")
+            default BUILDER setStateless() {
+                return (BUILDER) setProtocolVersion(McpProtocolVersion.FIRST_STATELESS);
+            }
 
         }
 

--- a/test/src/main/java/io/quarkiverse/mcp/server/test/McpStdioTestClientImpl.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/McpStdioTestClientImpl.java
@@ -139,6 +139,47 @@ class McpStdioTestClientImpl extends McpTestClientBase<McpStdioAssert, McpStdioT
             }
         });
 
+        if (protocolVersion.isStateless()) {
+            return connectStateless(assertFunction);
+        }
+        return connectStateful(assertFunction);
+    }
+
+    private McpStdioTestClient connectStateless(Consumer<InitResult> assertFunction) {
+        JsonObject discoverMessage = newRequest(McpAssured.SERVER_DISCOVER);
+        injectStatelessMeta(discoverMessage);
+        sendAndForget(discoverMessage);
+
+        JsonObject discoverResponse = state.waitForResponse(discoverMessage);
+        JsonObject discoverResult = assertResultResponse(discoverMessage, discoverResponse);
+        assertNotNull(discoverResult);
+
+        JsonObject serverInfo = discoverResult.getJsonObject("serverInfo");
+        JsonObject discoverCapabilities = discoverResult.getJsonObject("capabilities");
+        List<ServerCapability> capabilities = new ArrayList<>();
+        if (discoverCapabilities != null) {
+            for (String capability : discoverCapabilities.fieldNames()) {
+                capabilities.add(new ServerCapability(capability, discoverCapabilities.getJsonObject(capability).getMap()));
+            }
+        }
+        Implementation implementation = Messages.decodeImplementation(serverInfo);
+        InitResult r = new InitResult(null,
+                implementation.name(),
+                implementation.title(),
+                implementation.version(),
+                capabilities,
+                discoverResult.getString("instructions"),
+                implementation,
+                discoverResult.getJsonObject("_meta"));
+        if (assertFunction != null) {
+            assertFunction.accept(r);
+        }
+        this.initResult = r;
+        connected.set(true);
+        return this;
+    }
+
+    private McpStdioTestClient connectStateful(Consumer<InitResult> assertFunction) {
         if (autoPong) {
             requestConsumer.set(m -> {
                 String method = m.getString("method");

--- a/test/src/main/java/io/quarkiverse/mcp/server/test/McpStreamableTestClientImpl.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/McpStreamableTestClientImpl.java
@@ -61,6 +61,55 @@ class McpStreamableTestClientImpl extends McpTestClientBase<McpStreamableAssert,
         if (client == null) {
             client = new McpStreamableClient(mcpEndpoint);
         }
+        if (protocolVersion.isStateless()) {
+            return connectStateless(assertFunction);
+        }
+        return connectStateful(assertFunction);
+    }
+
+    private McpStreamableTestClient connectStateless(Consumer<InitResult> assertFunction) {
+        // Stateless clients send server/discover instead of initialize
+        JsonObject discoverMessage = newRequest(McpAssured.SERVER_DISCOVER);
+        injectStatelessMeta(discoverMessage);
+        MultiMap headers = additionalHeaders(discoverMessage);
+        addAuthorizationHeader(headers, clientAuthorization);
+        HttpResponse<String> response;
+        try (TracingHandle ignored = startTracingSpan(discoverMessage, headers)) {
+            response = client.sendSync(discoverMessage.encode(), headers);
+        }
+        assertEquals(200, response.statusCode(), "Invalid HTTP response status: " + response.statusCode());
+
+        JsonObject discoverResponse = new JsonObject(response.body());
+        client.state.addResponse(discoverResponse);
+        JsonObject discoverResult = assertResultResponse(discoverMessage, discoverResponse);
+        assertNotNull(discoverResult);
+
+        JsonObject serverInfo = discoverResult.getJsonObject("serverInfo");
+        JsonObject discoverCapabilities = discoverResult.getJsonObject("capabilities");
+        List<ServerCapability> capabilities = new ArrayList<>();
+        if (discoverCapabilities != null) {
+            for (String capability : discoverCapabilities.fieldNames()) {
+                capabilities.add(new ServerCapability(capability, discoverCapabilities.getJsonObject(capability).getMap()));
+            }
+        }
+        Implementation implementation = Messages.decodeImplementation(serverInfo);
+        InitResult r = new InitResult(null,
+                implementation.name(),
+                implementation.title(),
+                implementation.version(),
+                capabilities,
+                discoverResult.getString("instructions"),
+                implementation,
+                discoverResult.getJsonObject("_meta"));
+        if (assertFunction != null) {
+            assertFunction.accept(r);
+        }
+        this.initResult = r;
+        connected.set(true);
+        return this;
+    }
+
+    private McpStreamableTestClient connectStateful(Consumer<InitResult> assertFunction) {
         JsonObject initMessage = newInitMessage();
         MultiMap initHeaders = additionalHeaders.apply(initMessage);
         addAuthorizationHeader(initHeaders, clientAuthorization);
@@ -144,7 +193,30 @@ class McpStreamableTestClientImpl extends McpTestClientBase<McpStreamableAssert,
 
     private MultiMap additionalHeaders(JsonObject message) {
         MultiMap ret = additionalHeaders.apply(message);
-        if (mcpSessionId != null) {
+        if (protocolVersion.isStateless()) {
+            ret.add("MCP-Protocol-Version", protocolVersion.version());
+            if (message != null) {
+                String method = message.getString("method");
+                if (method != null) {
+                    ret.add("Mcp-Method", method);
+                }
+                JsonObject params = message.getJsonObject("params");
+                if (params != null) {
+                    // Mcp-Name for tools/call and prompts/get (name), resources/read (uri)
+                    if ("tools/call".equals(method) || "prompts/get".equals(method)) {
+                        String name = params.getString("name");
+                        if (name != null) {
+                            ret.add("Mcp-Name", name);
+                        }
+                    } else if ("resources/read".equals(method)) {
+                        String uri = params.getString("uri");
+                        if (uri != null) {
+                            ret.add("Mcp-Name", uri);
+                        }
+                    }
+                }
+            }
+        } else if (mcpSessionId != null) {
             ret.add("Mcp-Session-Id", mcpSessionId);
         }
         return ret;
@@ -159,6 +231,9 @@ class McpStreamableTestClientImpl extends McpTestClientBase<McpStreamableAssert,
 
     @Override
     public void terminateSession() {
+        if (protocolVersion.isStateless()) {
+            return;
+        }
         MultiMap headers = MultiMap.caseInsensitiveMultiMap();
         if (mcpSessionId != null) {
             headers.add("Mcp-Session-Id", mcpSessionId);
@@ -230,12 +305,13 @@ class McpStreamableTestClientImpl extends McpTestClientBase<McpStreamableAssert,
         }
 
         protected TracingHandle doSend(JsonObject message) {
-            try (TracingHandle tracingHandle = startTracingSpan(message, additionalHeaders(message))) {
+            try (TracingHandle tracingHandle = startTracingSpan(message,
+                    McpStreamableTestClientImpl.this.additionalHeaders(message))) {
                 Authorization authorization = this.authorization.get();
                 if (authorization == null) {
                     authorization = clientAuthorization;
                 }
-                send(message, additionalHeaders(message), authorization);
+                send(message, McpStreamableTestClientImpl.this.additionalHeaders(message), authorization);
             }
             return null;
         }

--- a/test/src/main/java/io/quarkiverse/mcp/server/test/McpTestClientBase.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/McpTestClientBase.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -25,6 +26,8 @@ import io.quarkiverse.mcp.server.ClientCapability;
 import io.quarkiverse.mcp.server.CompletionResponse;
 import io.quarkiverse.mcp.server.Content;
 import io.quarkiverse.mcp.server.Icon;
+import io.quarkiverse.mcp.server.McpProtocolVersion;
+import io.quarkiverse.mcp.server.MetaKey;
 import io.quarkiverse.mcp.server.PromptMessage;
 import io.quarkiverse.mcp.server.PromptResponse;
 import io.quarkiverse.mcp.server.ResourceContents;
@@ -60,7 +63,7 @@ abstract class McpTestClientBase<ASSERT extends McpAssert<ASSERT>, CLIENT extend
 
     protected final String name;
     protected final String version;
-    protected final String protocolVersion;
+    protected final McpProtocolVersion protocolVersion;
     protected final Set<ClientCapability> clientCapabilities;
     protected final Function<JsonObject, MultiMap> additionalHeaders;
     protected final boolean autoPong;
@@ -75,7 +78,7 @@ abstract class McpTestClientBase<ASSERT extends McpAssert<ASSERT>, CLIENT extend
     protected String websiteUrl;
     protected Set<Icon> icons;
 
-    McpTestClientBase(String name, String version, String protocolVersion, Set<ClientCapability> clientCapabilities,
+    McpTestClientBase(String name, String version, McpProtocolVersion protocolVersion, Set<ClientCapability> clientCapabilities,
             Function<JsonObject, MultiMap> additionalHeaders, boolean autoPong, Authorization clientAuthorization,
             String title, String description, String websiteUrl, Set<Icon> icons, OpenTelemetry openTelemetry) {
         this.name = name;
@@ -175,28 +178,100 @@ abstract class McpTestClientBase<ASSERT extends McpAssert<ASSERT>, CLIENT extend
     }
 
     protected JsonObject newToolsCallMessage(String toolName, Map<String, Object> arguments, Map<String, Object> meta) {
-        return newRequest(McpAssured.TOOLS_CALL, p -> {
+        JsonObject message = newRequest(McpAssured.TOOLS_CALL, p -> {
             p.put("name", toolName);
             addMeta(p, meta);
             if (!arguments.isEmpty()) {
                 p.put("arguments", arguments);
             }
         });
+        injectStatelessMeta(message);
+        return message;
     }
 
     protected JsonObject newListMessage(String method, Map<String, Object> meta, String cursor) {
-        return newRequest(method, p -> {
+        JsonObject message = newRequest(method, p -> {
             addMeta(p, meta);
             if (cursor != null) {
                 p.put("cursor", cursor);
             }
         });
+        injectStatelessMeta(message);
+        return message;
+    }
+
+    protected JsonObject newPromptsGetMessage(String promptName, Map<String, String> args, Map<String, Object> meta) {
+        JsonObject message = newRequest(McpAssured.PROMPTS_GET, p -> {
+            p.put("name", promptName);
+            addMeta(p, meta);
+            if (!args.isEmpty()) {
+                p.put("arguments", args);
+            }
+        });
+        injectStatelessMeta(message);
+        return message;
+    }
+
+    protected JsonObject newCompleteMessage(String refType, String refName, String argumentName, String argumentValue,
+            Map<String, String> contextArgs, Map<String, Object> meta) {
+        JsonObject message = newRequest(McpAssured.COMPLETION_COMPLETE, p -> {
+            JsonObject ref = new JsonObject().put("type", refType);
+            if (Messages.isPromptRef(refType)) {
+                ref.put("name", refName);
+            } else if (Messages.isResourceRef(refType)) {
+                ref.put("uri", refName);
+            }
+            addMeta(p, meta);
+            p.put("ref", ref);
+            p.put("argument", new JsonObject()
+                    .put("name", argumentName)
+                    .put("value", argumentValue));
+            if (contextArgs != null) {
+                p.put("context", new JsonObject().put("arguments", contextArgs));
+            }
+        });
+        injectStatelessMeta(message);
+        return message;
+    }
+
+    protected JsonObject newResourcesReadMessage(String uri, Map<String, Object> meta) {
+        JsonObject message = newRequest(McpAssured.RESOURCES_READ, p -> {
+            p.put("uri", uri);
+            addMeta(p, meta);
+        });
+        injectStatelessMeta(message);
+        return message;
     }
 
     protected void addMeta(JsonObject params, Map<String, Object> meta) {
         if (!meta.isEmpty()) {
+            params.put("_meta", new JsonObject(new HashMap<>(meta)));
+        }
+    }
+
+    protected void injectStatelessMeta(JsonObject message) {
+        if (!protocolVersion.isStateless()) {
+            return;
+        }
+        JsonObject params = message.getJsonObject("params");
+        if (params == null) {
+            params = new JsonObject();
+            message.put("params", params);
+        }
+        JsonObject meta = params.getJsonObject("_meta");
+        if (meta == null) {
+            meta = new JsonObject();
             params.put("_meta", meta);
         }
+        meta.put(MetaKey.PROTOCOL_VERSION.toString(), protocolVersion.version());
+        meta.put(MetaKey.CLIENT_INFO.toString(), new JsonObject()
+                .put("name", name)
+                .put("version", version));
+        JsonObject capabilities = new JsonObject();
+        for (var capability : clientCapabilities) {
+            capabilities.put(capability.name(), capability.properties());
+        }
+        meta.put(MetaKey.CLIENT_CAPABILITIES.toString(), capabilities);
     }
 
     /**
@@ -268,43 +343,6 @@ abstract class McpTestClientBase<ASSERT extends McpAssert<ASSERT>, CLIENT extend
         }
     }
 
-    protected JsonObject newPromptsGetMessage(String promptName, Map<String, String> args, Map<String, Object> meta) {
-        return newRequest(McpAssured.PROMPTS_GET, p -> {
-            p.put("name", promptName);
-            addMeta(p, meta);
-            if (!args.isEmpty()) {
-                p.put("arguments", args);
-            }
-        });
-    }
-
-    protected JsonObject newCompleteMessage(String refType, String refName, String argumentName, String argumentValue,
-            Map<String, String> contextArgs, Map<String, Object> meta) {
-        return newRequest(McpAssured.COMPLETION_COMPLETE, p -> {
-            JsonObject ref = new JsonObject().put("type", refType);
-            if (Messages.isPromptRef(refType)) {
-                ref.put("name", refName);
-            } else if (Messages.isResourceRef(refType)) {
-                ref.put("uri", refName);
-            }
-            addMeta(p, meta);
-            p.put("ref", ref);
-            p.put("argument", new JsonObject()
-                    .put("name", argumentName)
-                    .put("value", argumentValue));
-            if (contextArgs != null) {
-                p.put("context", new JsonObject().put("arguments", contextArgs));
-            }
-        });
-    }
-
-    protected JsonObject newResourcesReadMessage(String uri, Map<String, Object> meta) {
-        return newRequest(McpAssured.RESOURCES_READ, p -> {
-            p.put("uri", uri);
-            addMeta(p, meta);
-        });
-    }
-
     @Override
     public JsonObject newInitMessage() {
         JsonObject initMessage = newRequest("initialize");
@@ -340,7 +378,7 @@ abstract class McpTestClientBase<ASSERT extends McpAssert<ASSERT>, CLIENT extend
         }
         JsonObject params = new JsonObject()
                 .put("clientInfo", clientInfo)
-                .put("protocolVersion", protocolVersion);
+                .put("protocolVersion", protocolVersion.version());
         if (!clientCapabilities.isEmpty()) {
             JsonObject capabilities = new JsonObject();
             for (ClientCapability capability : clientCapabilities) {
@@ -532,6 +570,7 @@ abstract class McpTestClientBase<ASSERT extends McpAssert<ASSERT>, CLIENT extend
             @Override
             public ASSERT send() {
                 JsonObject message = newRequest(McpAssured.PING);
+                injectStatelessMeta(message);
                 tracingHandles.add(doSend(message));
                 if (pongAssert) {
                     asserts.add(new PongAssert(message));

--- a/test/src/main/java/io/quarkiverse/mcp/server/test/McpTestClientBase.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/McpTestClientBase.java
@@ -639,6 +639,9 @@ abstract class McpTestClientBase<ASSERT extends McpAssert<ASSERT>, CLIENT extend
             private Map<String, Object> meta = Map.of();
             private Consumer<ResourceResponse> assertFunction;
             private Consumer<McpError> errorAssertFunction;
+            private Consumer<JsonObject> rawAssertFunction;
+            private JsonObject inputResponses;
+            private String requestState;
 
             ResourcesReadMessageImpl(String uri) {
                 this.uri = uri;
@@ -672,13 +675,48 @@ abstract class McpTestClientBase<ASSERT extends McpAssert<ASSERT>, CLIENT extend
             }
 
             @Override
+            public ResourcesReadMessage<ASSERT> withRawAssert(Consumer<JsonObject> rawAssertFunction) {
+                if (rawAssertFunction == null) {
+                    throw mustNotBeNull("rawAssertFunction");
+                }
+                this.rawAssertFunction = rawAssertFunction;
+                return this;
+            }
+
+            @Override
+            public ResourcesReadMessage<ASSERT> withInputResponses(JsonObject inputResponses) {
+                if (inputResponses == null) {
+                    throw mustNotBeNull("inputResponses");
+                }
+                this.inputResponses = inputResponses;
+                return this;
+            }
+
+            @Override
+            public ResourcesReadMessage<ASSERT> withRequestState(String requestState) {
+                if (requestState == null) {
+                    throw mustNotBeNull("requestState");
+                }
+                this.requestState = requestState;
+                return this;
+            }
+
+            @Override
             public ASSERT send() {
                 JsonObject message = newResourcesReadMessage(uri, meta);
+                if (inputResponses != null) {
+                    message.getJsonObject("params").put("inputResponses", inputResponses);
+                }
+                if (requestState != null) {
+                    message.getJsonObject("params").put("requestState", requestState);
+                }
                 tracingHandles.add(doSend(message));
                 if (assertFunction != null) {
                     asserts.add(new ResourcesReadAssert(message, assertFunction));
                 } else if (errorAssertFunction != null) {
                     asserts.add(new ErrorAssert(message, errorAssertFunction));
+                } else if (rawAssertFunction != null) {
+                    asserts.add(new MessageAssert(message, rawAssertFunction));
                 }
                 return self();
             }
@@ -692,6 +730,9 @@ abstract class McpTestClientBase<ASSERT extends McpAssert<ASSERT>, CLIENT extend
             private Map<String, Object> meta = Map.of();
             private Consumer<PromptResponse> assertFunction;
             private Consumer<McpError> errorAssertFunction;
+            private Consumer<JsonObject> rawAssertFunction;
+            private JsonObject inputResponses;
+            private String requestState;
 
             PromptsGetMessageImpl(String promptName) {
                 this.promptName = promptName;
@@ -731,13 +772,48 @@ abstract class McpTestClientBase<ASSERT extends McpAssert<ASSERT>, CLIENT extend
             }
 
             @Override
+            public PromptsGetMessage<ASSERT> withRawAssert(Consumer<JsonObject> rawAssertFunction) {
+                if (rawAssertFunction == null) {
+                    throw mustNotBeNull("rawAssertFunction");
+                }
+                this.rawAssertFunction = rawAssertFunction;
+                return this;
+            }
+
+            @Override
+            public PromptsGetMessage<ASSERT> withInputResponses(JsonObject inputResponses) {
+                if (inputResponses == null) {
+                    throw mustNotBeNull("inputResponses");
+                }
+                this.inputResponses = inputResponses;
+                return this;
+            }
+
+            @Override
+            public PromptsGetMessage<ASSERT> withRequestState(String requestState) {
+                if (requestState == null) {
+                    throw mustNotBeNull("requestState");
+                }
+                this.requestState = requestState;
+                return this;
+            }
+
+            @Override
             public ASSERT send() {
                 JsonObject message = newPromptsGetMessage(promptName, args, meta);
+                if (inputResponses != null) {
+                    message.getJsonObject("params").put("inputResponses", inputResponses);
+                }
+                if (requestState != null) {
+                    message.getJsonObject("params").put("requestState", requestState);
+                }
                 tracingHandles.add(doSend(message));
                 if (assertFunction != null) {
                     asserts.add(new PromptsGetAssert(message, assertFunction));
                 } else if (errorAssertFunction != null) {
                     asserts.add(new ErrorAssert(message, errorAssertFunction));
+                } else if (rawAssertFunction != null) {
+                    asserts.add(new MessageAssert(message, rawAssertFunction));
                 }
                 return self();
             }
@@ -903,6 +979,9 @@ abstract class McpTestClientBase<ASSERT extends McpAssert<ASSERT>, CLIENT extend
             private Map<String, Object> meta = Map.of();
             private Consumer<ToolResponse> assertFunction;
             private Consumer<McpError> errorAssertFunction;
+            private Consumer<JsonObject> rawAssertFunction;
+            private JsonObject inputResponses;
+            private String requestState;
 
             ToolsCallMessageImpl(String toolName) {
                 this.toolName = toolName;
@@ -945,13 +1024,48 @@ abstract class McpTestClientBase<ASSERT extends McpAssert<ASSERT>, CLIENT extend
             }
 
             @Override
+            public ToolsCallMessage<ASSERT> withRawAssert(Consumer<JsonObject> rawAssertFunction) {
+                if (rawAssertFunction == null) {
+                    throw mustNotBeNull("rawAssertFunction");
+                }
+                this.rawAssertFunction = rawAssertFunction;
+                return this;
+            }
+
+            @Override
+            public ToolsCallMessage<ASSERT> withInputResponses(JsonObject inputResponses) {
+                if (inputResponses == null) {
+                    throw mustNotBeNull("inputResponses");
+                }
+                this.inputResponses = inputResponses;
+                return this;
+            }
+
+            @Override
+            public ToolsCallMessage<ASSERT> withRequestState(String requestState) {
+                if (requestState == null) {
+                    throw mustNotBeNull("requestState");
+                }
+                this.requestState = requestState;
+                return this;
+            }
+
+            @Override
             public ASSERT send() {
                 JsonObject message = newToolsCallMessage(toolName, args, meta);
+                if (inputResponses != null) {
+                    message.getJsonObject("params").put("inputResponses", inputResponses);
+                }
+                if (requestState != null) {
+                    message.getJsonObject("params").put("requestState", requestState);
+                }
                 tracingHandles.add(doSend(message));
                 if (assertFunction != null) {
                     asserts.add(new ToolsCallAssert(message, assertFunction));
                 } else if (errorAssertFunction != null) {
                     asserts.add(new ErrorAssert(message, errorAssertFunction));
+                } else if (rawAssertFunction != null) {
+                    asserts.add(new MessageAssert(message, rawAssertFunction));
                 }
                 return self();
             }

--- a/test/src/main/java/io/quarkiverse/mcp/server/test/McpTestClientBuilder.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/McpTestClientBuilder.java
@@ -9,14 +9,14 @@ import java.util.Set;
 import io.opentelemetry.api.OpenTelemetry;
 import io.quarkiverse.mcp.server.ClientCapability;
 import io.quarkiverse.mcp.server.Icon;
-import io.quarkiverse.mcp.server.runtime.McpMessageHandler;
+import io.quarkiverse.mcp.server.McpProtocolVersion;
 import io.quarkiverse.mcp.server.test.McpAssured.McpTestClient.Builder;
 
 abstract class McpTestClientBuilder<BUILDER extends Builder<BUILDER>> implements McpAssured.McpTestClient.Builder<BUILDER> {
 
     protected String name = "test-client";
     protected String version = "1.0";
-    protected String protocolVersion = McpMessageHandler.SUPPORTED_PROTOCOL_VERSIONS.get(0);
+    protected McpProtocolVersion protocolVersion = McpProtocolVersion.LATEST_STATEFUL;
     protected String title;
     protected String description;
     protected String websiteUrl;
@@ -43,8 +43,22 @@ abstract class McpTestClientBuilder<BUILDER extends Builder<BUILDER>> implements
         return self();
     }
 
+    @SuppressWarnings("removal")
     @Override
     public BUILDER setProtocolVersion(String protocolVersion) {
+        if (protocolVersion == null) {
+            throw mustNotBeNull("protocolVersion");
+        }
+        McpProtocolVersion v = McpProtocolVersion.from(protocolVersion);
+        if (v == null) {
+            throw new IllegalArgumentException("Unknown protocol version: " + protocolVersion);
+        }
+        this.protocolVersion = v;
+        return self();
+    }
+
+    @Override
+    public BUILDER setProtocolVersion(McpProtocolVersion protocolVersion) {
         if (protocolVersion == null) {
             throw mustNotBeNull("protocolVersion");
         }

--- a/test/src/main/java/io/quarkiverse/mcp/server/test/McpWebSocketTestClientImpl.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/McpWebSocketTestClientImpl.java
@@ -62,6 +62,47 @@ class McpWebSocketTestClientImpl extends McpTestClientBase<McpWebSocketAssert, M
 
             client = new McpWebSocketClient(endpointUri, vertx, headers);
         }
+        if (protocolVersion.isStateless()) {
+            return connectStateless(assertFunction);
+        }
+        return connectStateful(assertFunction);
+    }
+
+    private McpWebSocketTestClient connectStateless(Consumer<InitResult> assertFunction) {
+        JsonObject discoverMessage = newRequest(McpAssured.SERVER_DISCOVER);
+        injectStatelessMeta(discoverMessage);
+        sendAndForget(discoverMessage);
+
+        JsonObject discoverResponse = client.state.waitForResponse(discoverMessage);
+        JsonObject discoverResult = assertResultResponse(discoverMessage, discoverResponse);
+        assertNotNull(discoverResult);
+
+        JsonObject serverInfo = discoverResult.getJsonObject("serverInfo");
+        JsonObject discoverCapabilities = discoverResult.getJsonObject("capabilities");
+        List<ServerCapability> capabilities = new ArrayList<>();
+        if (discoverCapabilities != null) {
+            for (String capability : discoverCapabilities.fieldNames()) {
+                capabilities.add(new ServerCapability(capability, discoverCapabilities.getJsonObject(capability).getMap()));
+            }
+        }
+        Implementation implementation = Messages.decodeImplementation(serverInfo);
+        InitResult r = new InitResult(null,
+                implementation.name(),
+                implementation.title(),
+                implementation.version(),
+                capabilities,
+                discoverResult.getString("instructions"),
+                implementation,
+                discoverResult.getJsonObject("_meta"));
+        if (assertFunction != null) {
+            assertFunction.accept(r);
+        }
+        this.initResult = r;
+        connected.set(true);
+        return this;
+    }
+
+    private McpWebSocketTestClient connectStateful(Consumer<InitResult> assertFunction) {
         if (autoPong) {
             client.setRequestConsumer(m -> {
                 String method = m.getString("method");

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/dummyinit/AutoInitMetaTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/dummyinit/AutoInitMetaTest.java
@@ -186,7 +186,7 @@ public class AutoInitMetaTest extends McpServerTest {
         Uni<String> info(McpConnection connection, Sampling sampling) {
             String prefix = connection.initialRequest().implementation().name()
                     + ":" + connection.initialRequest().implementation().version()
-                    + ":" + connection.initialRequest().protocolVersion()
+                    + ":" + connection.initialRequest().protocolVersion().version()
                     + ":";
             if (sampling.isSupported()) {
                 SamplingRequest request = sampling.requestBuilder()

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/initrequest/InitialRequestTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/initrequest/InitialRequestTest.java
@@ -15,8 +15,8 @@ import io.quarkiverse.mcp.server.Icon.Theme;
 import io.quarkiverse.mcp.server.InitialRequest;
 import io.quarkiverse.mcp.server.InitialRequest.Transport;
 import io.quarkiverse.mcp.server.McpConnection;
+import io.quarkiverse.mcp.server.McpProtocolVersion;
 import io.quarkiverse.mcp.server.Tool;
-import io.quarkiverse.mcp.server.runtime.McpMessageHandler;
 import io.quarkiverse.mcp.server.test.McpAssured;
 import io.quarkiverse.mcp.server.test.McpAssured.McpSseTestClient;
 import io.quarkiverse.mcp.server.test.McpServerTest;
@@ -59,7 +59,7 @@ public class InitialRequestTest extends McpServerTest {
         String testInitRequest(McpConnection connection) {
             InitialRequest initRequest = connection.initialRequest();
             if (initRequest != null) {
-                if (!initRequest.protocolVersion().equals(McpMessageHandler.SUPPORTED_PROTOCOL_VERSIONS.get(0))) {
+                if (!initRequest.protocolVersion().equals(McpProtocolVersion.LATEST_STATEFUL.version())) {
                     throw new IllegalStateException();
                 }
                 if (!initRequest.implementation().name().equals("test-client")) {

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/initrequest/InitialRequestTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/initrequest/InitialRequestTest.java
@@ -59,7 +59,7 @@ public class InitialRequestTest extends McpServerTest {
         String testInitRequest(McpConnection connection) {
             InitialRequest initRequest = connection.initialRequest();
             if (initRequest != null) {
-                if (!initRequest.protocolVersion().equals(McpProtocolVersion.LATEST_STATEFUL.version())) {
+                if (initRequest.protocolVersion() != McpProtocolVersion.LATEST_STATEFUL) {
                     throw new IllegalStateException();
                 }
                 if (!initRequest.implementation().name().equals("test-client")) {

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/mrtr/InputRequiredTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/mrtr/InputRequiredTest.java
@@ -1,0 +1,399 @@
+package io.quarkiverse.mcp.server.test.mrtr;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.List;
+import java.util.Map;
+
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.ClientCapability;
+import io.quarkiverse.mcp.server.Elicitation;
+import io.quarkiverse.mcp.server.ElicitationRequest;
+import io.quarkiverse.mcp.server.ElicitationRequest.StringSchema;
+import io.quarkiverse.mcp.server.ElicitationResponse;
+import io.quarkiverse.mcp.server.InputResponses;
+import io.quarkiverse.mcp.server.Root;
+import io.quarkiverse.mcp.server.Roots;
+import io.quarkiverse.mcp.server.Sampling;
+import io.quarkiverse.mcp.server.SamplingMessage;
+import io.quarkiverse.mcp.server.SamplingRequest;
+import io.quarkiverse.mcp.server.SamplingResponse;
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkiverse.mcp.server.test.McpAssured.McpStreamableTestClient;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+public class InputRequiredTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .withApplicationRoot(root -> root.addClass(MyTools.class));
+
+    @Test
+    public void testElicitationInputRequired() {
+        McpStreamableTestClient client = McpAssured.newStreamableClient()
+                .setStateless()
+                .setClientCapabilities(new ClientCapability(ClientCapability.ELICITATION, Map.of()))
+                .build()
+                .connect();
+
+        // 1. First call — no inputResponses, tool throws InputRequiredException
+        client.when()
+                .toolsCall("elicitationMrtr")
+                .withRawAssert(firstResponse -> {
+                    JsonObject result = firstResponse.getJsonObject("result");
+                    assertNotNull(result);
+                    assertEquals("input_required", result.getString("resultType"));
+
+                    JsonObject inputRequests = result.getJsonObject("inputRequests");
+                    assertNotNull(inputRequests);
+
+                    JsonObject userInput = inputRequests.getJsonObject("userInput");
+                    assertNotNull(userInput);
+                    assertEquals("elicitation/create", userInput.getString("method"));
+                    JsonObject params = userInput.getJsonObject("params");
+                    assertEquals("form", params.getString("mode"));
+                    assertEquals("Please provide your name", params.getString("message"));
+                    JsonObject schema = params.getJsonObject("requestedSchema");
+                    assertNotNull(schema);
+                    assertEquals("string", schema.getJsonObject("properties").getJsonObject("name").getString("type"));
+                    assertEquals("name", schema.getJsonArray("required").getString(0));
+
+                    assertEquals("some-state", result.getString("requestState"));
+                })
+                .send()
+                .thenAssertResults();
+
+        // 2. Second call — with inputResponses and requestState, tool returns result
+        client.when()
+                .toolsCall("elicitationMrtr")
+                .withInputResponses(new JsonObject()
+                        .put("userInput", new JsonObject()
+                                .put("action", "accept")
+                                .put("content", new JsonObject()
+                                        .put("name", "Alice"))))
+                .withRequestState("some-state")
+                .withAssert(r -> {
+                    assertFalse(r.isError());
+                    assertEquals("Hello Alice! [some-state]", r.firstContent().asText().text());
+                })
+                .send()
+                .thenAssertResults();
+
+        client.disconnect();
+    }
+
+    @Test
+    public void testSamplingInputRequired() {
+        McpStreamableTestClient client = McpAssured.newStreamableClient()
+                .setStateless()
+                .setClientCapabilities(new ClientCapability(ClientCapability.SAMPLING, Map.of()))
+                .build()
+                .connect();
+
+        // 1. First call — tool throws InputRequiredException with sampling request
+        client.when()
+                .toolsCall("samplingMrtr")
+                .withRawAssert(firstResponse -> {
+                    JsonObject result = firstResponse.getJsonObject("result");
+                    assertNotNull(result);
+                    assertEquals("input_required", result.getString("resultType"));
+
+                    JsonObject inputRequests = result.getJsonObject("inputRequests");
+                    assertNotNull(inputRequests);
+
+                    JsonObject llmInput = inputRequests.getJsonObject("llmInput");
+                    assertNotNull(llmInput);
+                    assertEquals("sampling/createMessage", llmInput.getString("method"));
+                    JsonObject params = llmInput.getJsonObject("params");
+                    assertNotNull(params);
+                    assertEquals(100, params.getInteger("maxTokens"));
+                    JsonArray messages = params.getJsonArray("messages");
+                    assertNotNull(messages);
+                    assertEquals(1, messages.size());
+                    assertEquals("user", messages.getJsonObject(0).getString("role"));
+
+                    assertNull(result.getString("requestState"));
+                })
+                .send()
+                .thenAssertResults();
+
+        // 2. Second call — with sampling inputResponse
+        client.when()
+                .toolsCall("samplingMrtr")
+                .withInputResponses(new JsonObject()
+                        .put("llmInput", new JsonObject()
+                                .put("role", "assistant")
+                                .put("model", "test-model")
+                                .put("content", new JsonObject()
+                                        .put("type", "text")
+                                        .put("text", "The answer is 42"))))
+                .withAssert(r -> {
+                    assertFalse(r.isError());
+                    assertEquals("LLM said: The answer is 42", r.firstContent().asText().text());
+                })
+                .send()
+                .thenAssertResults();
+
+        client.disconnect();
+    }
+
+    @Test
+    public void testRootsInputRequired() {
+        McpStreamableTestClient client = McpAssured.newStreamableClient()
+                .setStateless()
+                .setClientCapabilities(new ClientCapability(ClientCapability.ROOTS, Map.of()))
+                .build()
+                .connect();
+
+        // 1. First call — tool throws InputRequiredException with roots request
+        client.when()
+                .toolsCall("rootsMrtr")
+                .withRawAssert(firstResponse -> {
+                    JsonObject result = firstResponse.getJsonObject("result");
+                    assertNotNull(result);
+                    assertEquals("input_required", result.getString("resultType"));
+
+                    JsonObject inputRequests = result.getJsonObject("inputRequests");
+                    assertNotNull(inputRequests);
+
+                    JsonObject rootsInput = inputRequests.getJsonObject("rootsInput");
+                    assertNotNull(rootsInput);
+                    assertEquals("roots/list", rootsInput.getString("method"));
+                    assertNotNull(rootsInput.getJsonObject("params"));
+                })
+                .send()
+                .thenAssertResults();
+
+        // 2. Second call — with roots inputResponse
+        client.when()
+                .toolsCall("rootsMrtr")
+                .withInputResponses(new JsonObject()
+                        .put("rootsInput", new JsonObject()
+                                .put("roots", new JsonArray()
+                                        .add(new JsonObject()
+                                                .put("name", "project")
+                                                .put("uri", "file:///home/user/project"))
+                                        .add(new JsonObject()
+                                                .put("name", "docs")
+                                                .put("uri", "file:///home/user/docs")))))
+                .withAssert(r -> {
+                    assertFalse(r.isError());
+                    assertEquals("Roots: project, docs", r.firstContent().asText().text());
+                })
+                .send()
+                .thenAssertResults();
+
+        client.disconnect();
+    }
+
+    @Test
+    public void testCombinedInputRequired() {
+        McpStreamableTestClient client = McpAssured.newStreamableClient()
+                .setStateless()
+                .setClientCapabilities(
+                        new ClientCapability(ClientCapability.ELICITATION, Map.of()),
+                        new ClientCapability(ClientCapability.SAMPLING, Map.of()))
+                .build()
+                .connect();
+
+        // 1. First call — tool throws InputRequiredException with both elicitation and sampling requests
+        client.when()
+                .toolsCall("combinedMrtr")
+                .withRawAssert(firstResponse -> {
+                    JsonObject result = firstResponse.getJsonObject("result");
+                    assertNotNull(result);
+                    assertEquals("input_required", result.getString("resultType"));
+
+                    JsonObject inputRequests = result.getJsonObject("inputRequests");
+                    assertNotNull(inputRequests);
+
+                    // Elicitation request
+                    JsonObject userInput = inputRequests.getJsonObject("userInput");
+                    assertNotNull(userInput);
+                    assertEquals("elicitation/create", userInput.getString("method"));
+
+                    // Sampling request
+                    JsonObject llmInput = inputRequests.getJsonObject("llmInput");
+                    assertNotNull(llmInput);
+                    assertEquals("sampling/createMessage", llmInput.getString("method"));
+                })
+                .send()
+                .thenAssertResults();
+
+        // 2. Second call — with both inputResponses
+        client.when()
+                .toolsCall("combinedMrtr")
+                .withInputResponses(new JsonObject()
+                        .put("userInput", new JsonObject()
+                                .put("action", "accept")
+                                .put("content", new JsonObject()
+                                        .put("name", "Bob")))
+                        .put("llmInput", new JsonObject()
+                                .put("role", "assistant")
+                                .put("model", "test-model")
+                                .put("content", new JsonObject()
+                                        .put("type", "text")
+                                        .put("text", "Hi Bob!"))))
+                .withAssert(r -> {
+                    assertFalse(r.isError());
+                    assertEquals("Bob heard: Hi Bob!", r.firstContent().asText().text());
+                })
+                .send()
+                .thenAssertResults();
+
+        client.disconnect();
+    }
+
+    @Test
+    public void testIsServerInitiatedRequestSupported() {
+        // Stateless client: isServerInitiatedRequestSupported() should return false
+        McpStreamableTestClient statelessClient = McpAssured.newStreamableClient()
+                .setStateless()
+                .setClientCapabilities(new ClientCapability(ClientCapability.ELICITATION, Map.of()))
+                .build()
+                .connect();
+
+        statelessClient.when()
+                .toolsCall("checkSupport", r -> {
+                    assertFalse(r.isError());
+                    assertEquals("false", r.firstContent().asText().text());
+                })
+                .thenAssertResults();
+        statelessClient.disconnect();
+
+        // Stateful client: isServerInitiatedRequestSupported() should return true
+        McpStreamableTestClient statefulClient = McpAssured.newStreamableClient()
+                .setClientCapabilities(new ClientCapability(ClientCapability.ELICITATION, Map.of()))
+                .build()
+                .connect();
+
+        statefulClient.when()
+                .toolsCall("checkSupport", r -> {
+                    assertFalse(r.isError());
+                    assertEquals("true", r.firstContent().asText().text());
+                })
+                .thenAssertResults();
+        statefulClient.disconnect();
+    }
+
+    @Test
+    public void testInputResponsesEmptyOnInitialRequest() {
+        McpStreamableTestClient client = McpAssured.newStreamableClient()
+                .setStateless()
+                .setClientCapabilities(new ClientCapability(ClientCapability.ELICITATION, Map.of()))
+                .build()
+                .connect();
+
+        client.when()
+                .toolsCall("checkInputResponses", r -> {
+                    assertFalse(r.isError());
+                    assertEquals("true", r.firstContent().asText().text());
+                })
+                .thenAssertResults();
+        client.disconnect();
+    }
+
+    @Singleton
+    public static class MyTools {
+
+        @Tool
+        String elicitationMrtr(Elicitation elicitation) {
+            InputResponses inputResponses = elicitation.inputResponses();
+            if (!inputResponses.isEmpty() && inputResponses.has("userInput")) {
+                ElicitationResponse response = inputResponses.getElicitationResponse("userInput");
+                if (response.actionAccepted()) {
+                    String state = elicitation.requestState() != null ? " [" + elicitation.requestState() + "]" : "";
+                    return "Hello " + response.content().getString("name") + "!" + state;
+                }
+                return "Declined";
+            }
+
+            ElicitationRequest request = elicitation.requestBuilder()
+                    .setMessage("Please provide your name")
+                    .addSchemaProperty("name", new StringSchema(true))
+                    .build();
+            throw elicitation.inputRequired()
+                    .addElicitationRequest("userInput", request)
+                    .setRequestState("some-state")
+                    .build();
+        }
+
+        @Tool
+        String samplingMrtr(Sampling sampling) {
+            InputResponses inputResponses = sampling.inputResponses();
+            if (!inputResponses.isEmpty() && inputResponses.has("llmInput")) {
+                SamplingResponse response = inputResponses.getSamplingResponse("llmInput");
+                return "LLM said: " + response.content().asText().text();
+            }
+
+            SamplingRequest request = sampling.requestBuilder()
+                    .addMessage(SamplingMessage.withUserRole("What is the meaning of life?"))
+                    .setMaxTokens(100)
+                    .build();
+            throw sampling.inputRequired()
+                    .addSamplingRequest("llmInput", request)
+                    .build();
+        }
+
+        @Tool
+        String rootsMrtr(Roots roots) {
+            InputResponses inputResponses = roots.inputResponses();
+            if (!inputResponses.isEmpty() && inputResponses.has("rootsInput")) {
+                List<Root> rootList = inputResponses.getRootsResponse("rootsInput");
+                String names = rootList.stream().map(Root::name).reduce((a, b) -> a + ", " + b).orElse("");
+                return "Roots: " + names;
+            }
+
+            throw roots.inputRequired()
+                    .addRootsRequest("rootsInput")
+                    .build();
+        }
+
+        @Tool
+        String combinedMrtr(Elicitation elicitation, Sampling sampling) {
+            InputResponses inputResponses = elicitation.inputResponses();
+            if (!inputResponses.isEmpty() && inputResponses.has("userInput") && inputResponses.has("llmInput")) {
+                ElicitationResponse elicitationResponse = inputResponses.getElicitationResponse("userInput");
+                SamplingResponse samplingResponse = inputResponses.getSamplingResponse("llmInput");
+                String name = elicitationResponse.content().getString("name");
+                String llmText = samplingResponse.content().asText().text();
+                return name + " heard: " + llmText;
+            }
+
+            ElicitationRequest elicitationRequest = elicitation.requestBuilder()
+                    .setMessage("What is your name?")
+                    .addSchemaProperty("name", new StringSchema(true))
+                    .build();
+            SamplingRequest samplingRequest = sampling.requestBuilder()
+                    .addMessage(SamplingMessage.withUserRole("Greet the user"))
+                    .setMaxTokens(50)
+                    .build();
+            throw elicitation.inputRequired()
+                    .addElicitationRequest("userInput", elicitationRequest)
+                    .addSamplingRequest("llmInput", samplingRequest)
+                    .build();
+        }
+
+        @Tool
+        String checkSupport(Elicitation elicitation) {
+            return String.valueOf(elicitation.isServerInitiatedRequestSupported());
+        }
+
+        @Tool
+        String checkInputResponses(Elicitation elicitation) {
+            return String.valueOf(elicitation.inputResponses().isEmpty());
+        }
+    }
+
+}

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/stateless/StatelessTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/stateless/StatelessTest.java
@@ -1,0 +1,189 @@
+package io.quarkiverse.mcp.server.test.stateless;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.JsonRpcErrorCodes;
+import io.quarkiverse.mcp.server.McpConnection;
+import io.quarkiverse.mcp.server.McpLog.LogLevel;
+import io.quarkiverse.mcp.server.McpProtocolVersion;
+import io.quarkiverse.mcp.server.MetaKey;
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.runtime.ConnectionManager;
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkiverse.mcp.server.test.McpAssured.McpStreamableTestClient;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.json.JsonObject;
+
+public class StatelessTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .withApplicationRoot(root -> root.addClass(MyTools.class));
+
+    @Inject
+    ConnectionManager connectionManager;
+
+    @Test
+    public void testServerDiscover() {
+        McpStreamableTestClient client = McpAssured.newStreamableClient()
+                .setStateless()
+                .build()
+                .connect(initResult -> {
+                    assertNotNull(initResult);
+                    assertNotNull(initResult.capabilities());
+                    assertNotNull(initResult.implementation());
+                });
+        assertTrue(client.isConnected());
+        assertNull(client.mcpSessionId());
+        client.disconnect();
+    }
+
+    @Test
+    public void testToolsList() {
+        McpStreamableTestClient client = McpAssured.newStreamableClient()
+                .setStateless()
+                .build()
+                .connect();
+
+        client.when()
+                .toolsList(tools -> {
+                    assertNotNull(tools);
+                    assertEquals(3, tools.size());
+                    assertNotNull(tools.findByName("echo"));
+                })
+                .thenAssertResults();
+        client.disconnect();
+    }
+
+    @Test
+    public void testToolsCall() {
+        McpStreamableTestClient client = McpAssured.newStreamableClient()
+                .setStateless()
+                .build()
+                .connect();
+
+        client.when()
+                .toolsCall("echo", Map.of("message", "hello stateless"), r -> {
+                    // Verify no persistent connection was created
+                    assertFalse(connectionManager.iterator().hasNext());
+                    assertFalse(r.isError());
+                    assertEquals("hello stateless", r.firstContent().asText().text());
+                })
+                .thenAssertResults();
+
+        // Verify no persistent connection was created
+        assertFalse(connectionManager.iterator().hasNext());
+        client.disconnect();
+    }
+
+    @Test
+    public void testToolCallWithConnectionAccess() {
+        McpStreamableTestClient client = McpAssured.newStreamableClient()
+                .setStateless()
+                .build()
+                .connect();
+
+        client.when()
+                .toolsCall("protocolInfo", r -> {
+                    assertFalse(r.isError());
+                    assertEquals(McpProtocolVersion.FIRST_STATELESS.version() + ":true:true",
+                            r.firstContent().asText().text());
+                })
+                .thenAssertResults();
+        client.disconnect();
+    }
+
+    @Test
+    public void testPerRequestLogLevel() {
+        McpStreamableTestClient client = McpAssured.newStreamableClient()
+                .setStateless()
+                .build()
+                .connect();
+
+        client.when()
+                .toolsCall("logLevelInfo")
+                .withMetadata(Map.of("io.modelcontextprotocol/logLevel", "warning"))
+                .withAssert(r -> {
+                    assertFalse(r.isError());
+                    assertEquals(LogLevel.WARNING.name(), r.firstContent().asText().text());
+                })
+                .send()
+                .thenAssertResults();
+        client.disconnect();
+    }
+
+    @Test
+    public void testPingRejected() {
+        McpStreamableTestClient client = McpAssured.newStreamableClient()
+                .setStateless()
+                .build()
+                .connect();
+
+        client.when()
+                .ping()
+                .withErrorAssert(error -> {
+                    assertEquals(-32601, error.code());
+                })
+                .send()
+                .thenAssertResults();
+        client.disconnect();
+    }
+
+    @Test
+    public void testMissingMetaFieldsRejected() {
+        McpStreamableTestClient client = McpAssured.newStreamableClient()
+                .setStateless()
+                .build()
+                .connect();
+
+        // Send a request with only protocolVersion in _meta, missing clientInfo and clientCapabilities
+        JsonObject message = client.newRequest("tools/list");
+        message.put("params", new JsonObject()
+                .put("_meta", new JsonObject()
+                        .put(MetaKey.PROTOCOL_VERSION.toString(), McpProtocolVersion.FIRST_STATELESS.version())));
+
+        client.when()
+                .message(message)
+                .withErrorAssert(error -> {
+                    assertEquals(JsonRpcErrorCodes.INVALID_PARAMS, error.code());
+                    assertTrue(error.message().contains(MetaKey.CLIENT_INFO.toString()));
+                    assertTrue(error.message().contains(MetaKey.CLIENT_CAPABILITIES.toString()));
+                })
+                .send()
+                .thenAssertResults();
+        client.disconnect();
+    }
+
+    public static class MyTools {
+
+        @Tool
+        String echo(String message) {
+            return message;
+        }
+
+        @Tool
+        String protocolInfo(McpConnection connection) {
+            String version = connection.initialRequest().protocolVersion();
+            boolean stateless = McpProtocolVersion.isStateless(version);
+            return version + ":" + stateless + ":" + connection.isTransient();
+        }
+
+        @Tool
+        String logLevelInfo(McpConnection connection) {
+            return connection.logLevel().name();
+        }
+    }
+
+}

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/stateless/StatelessTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/stateless/StatelessTest.java
@@ -175,9 +175,8 @@ public class StatelessTest extends McpServerTest {
 
         @Tool
         String protocolInfo(McpConnection connection) {
-            String version = connection.initialRequest().protocolVersion();
-            boolean stateless = McpProtocolVersion.isStateless(version);
-            return version + ":" + stateless + ":" + connection.isTransient();
+            McpProtocolVersion version = connection.initialRequest().protocolVersion();
+            return version.version() + ":" + version.isStateless() + ":" + connection.isTransient();
         }
 
         @Tool

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/subscription/SubscriptionsListenTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/subscription/SubscriptionsListenTest.java
@@ -1,0 +1,207 @@
+package io.quarkiverse.mcp.server.test.subscription;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.RequestUri;
+import io.quarkiverse.mcp.server.Resource;
+import io.quarkiverse.mcp.server.ResourceManager;
+import io.quarkiverse.mcp.server.TextContent;
+import io.quarkiverse.mcp.server.TextResourceContents;
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolManager;
+import io.quarkiverse.mcp.server.ToolResponse;
+import io.quarkiverse.mcp.server.runtime.ConnectionManager;
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkiverse.mcp.server.test.McpAssured.McpStreamableTestClient;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+public class SubscriptionsListenTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .withApplicationRoot(root -> root.addClasses(MyTools.class, MyResources.class));
+
+    @Inject
+    ToolManager toolManager;
+
+    @Inject
+    ResourceManager resourceManager;
+
+    @Inject
+    ConnectionManager connectionManager;
+
+    @Test
+    public void testToolsListChanged() {
+        McpStreamableTestClient client = McpAssured.newStreamableClient()
+                .setStateless()
+                .build()
+                .connect();
+
+        // Send subscriptions/listen with toolsListChanged filter
+        JsonObject listenRequest = client.newRequest("subscriptions/listen");
+        listenRequest.put("params", new JsonObject()
+                .put("notifications", new JsonObject().put("toolsListChanged", true)));
+        McpAssured.injectStatelessMeta(listenRequest);
+        client.sendAndForget(listenRequest);
+
+        // Wait for the acknowledged notification
+        List<JsonObject> notifications = client.waitForNotifications(1).notifications();
+        JsonObject ack = notifications.get(0);
+        assertEquals("notifications/subscriptions/acknowledged", ack.getString("method"));
+        JsonObject ackParams = ack.getJsonObject("params");
+        assertNotNull(ackParams);
+        assertTrue(ackParams.getJsonObject("notifications").getBoolean("toolsListChanged"));
+        // Verify subscriptionId in _meta
+        JsonObject meta = ackParams.getJsonObject("_meta");
+        assertNotNull(meta);
+        assertNotNull(meta.getValue("io.modelcontextprotocol/subscriptionId"));
+
+        // Transient connection should be registered in ConnectionManager
+        assertTrue(connectionManager.iterator().hasNext());
+
+        // Register a new tool to trigger notifications/tools/list_changed
+        toolManager.newTool("dynamic")
+                .setDescription("A dynamically registered tool")
+                .setHandler(args -> ToolResponse.success(new TextContent("dynamic")))
+                .register();
+
+        // Wait for the list_changed notification
+        notifications = client.waitForNotifications(2).notifications();
+        JsonObject listChanged = notifications.get(1);
+        assertEquals("notifications/tools/list_changed", listChanged.getString("method"));
+        // Verify subscriptionId is injected
+        JsonObject listChangedParams = listChanged.getJsonObject("params");
+        assertNotNull(listChangedParams);
+        JsonObject listChangedMeta = listChangedParams.getJsonObject("_meta");
+        assertNotNull(listChangedMeta);
+        assertEquals(listenRequest.getValue("id"),
+                listChangedMeta.getValue("io.modelcontextprotocol/subscriptionId"));
+
+        client.disconnect();
+    }
+
+    @Test
+    public void testResourceUpdated() {
+        String uri = "file:///file1.txt";
+
+        McpStreamableTestClient client = McpAssured.newStreamableClient()
+                .setStateless()
+                .build()
+                .connect();
+
+        // Subscribe to resource updates
+        JsonObject listenRequest = client.newRequest("subscriptions/listen");
+        listenRequest.put("params", new JsonObject()
+                .put("notifications", new JsonObject()
+                        .put("resourceSubscriptions", new JsonArray().add(uri))));
+        McpAssured.injectStatelessMeta(listenRequest);
+        client.sendAndForget(listenRequest);
+
+        // Wait for acknowledged
+        client.waitForNotifications(1);
+
+        // Trigger resource update
+        resourceManager.getResource(uri).sendUpdateAndForget();
+
+        // Wait for resource updated notification
+        List<JsonObject> notifications = client.waitForNotifications(2).notifications();
+        JsonObject updated = notifications.get(1);
+        assertEquals("notifications/resources/updated", updated.getString("method"));
+        assertEquals(uri, updated.getJsonObject("params").getString("uri"));
+        // Verify subscriptionId
+        JsonObject meta = updated.getJsonObject("params").getJsonObject("_meta");
+        assertNotNull(meta);
+        assertEquals(listenRequest.getValue("id"),
+                meta.getValue("io.modelcontextprotocol/subscriptionId"));
+
+        client.disconnect();
+    }
+
+    @Test
+    public void testFilteringNonMatching() {
+        McpStreamableTestClient client = McpAssured.newStreamableClient()
+                .setStateless()
+                .build()
+                .connect();
+
+        // Subscribe only to promptsListChanged
+        JsonObject listenRequest = client.newRequest("subscriptions/listen");
+        listenRequest.put("params", new JsonObject()
+                .put("notifications", new JsonObject().put("promptsListChanged", true)));
+        McpAssured.injectStatelessMeta(listenRequest);
+        client.sendAndForget(listenRequest);
+
+        // Wait for acknowledged
+        client.waitForNotifications(1);
+
+        // Trigger a tools list change — should NOT be delivered
+        toolManager.newTool("filteredTool")
+                .setDescription("Should not trigger notification on this subscription")
+                .setHandler(args -> ToolResponse.success(new TextContent("filtered")))
+                .register();
+
+        // Give some time for any notification to arrive (it shouldn't)
+        try {
+            Thread.sleep(500);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        // Should still only have the acknowledged notification
+        assertEquals(1, client.snapshot().notifications().size());
+
+        client.disconnect();
+    }
+
+    @Test
+    public void testOldSubscribeBlockedForDraftProtocol() {
+        McpStreamableTestClient client = McpAssured.newStreamableClient()
+                .setStateless()
+                .build()
+                .connect();
+
+        // resources/subscribe should be blocked for stateless protocol
+        JsonObject subscribeRequest = client.newRequest("resources/subscribe");
+        subscribeRequest.put("params", new JsonObject().put("uri", "file:///file1.txt"));
+        McpAssured.injectStatelessMeta(subscribeRequest);
+
+        client.when()
+                .message(subscribeRequest)
+                .withErrorAssert(error -> {
+                    assertEquals(-32601, error.code());
+                })
+                .send()
+                .thenAssertResults();
+
+        client.disconnect();
+    }
+
+    public static class MyTools {
+
+        @Tool
+        String echo(String message) {
+            return message;
+        }
+    }
+
+    public static class MyResources {
+
+        @Resource(uri = "file:///file1.txt")
+        TextResourceContents file1(RequestUri uri) {
+            return new TextResourceContents(uri.value(), "File 1", null);
+        }
+    }
+
+}

--- a/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/HttpMcpServerRecorder.java
+++ b/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/HttpMcpServerRecorder.java
@@ -170,7 +170,6 @@ public class HttpMcpServerRecorder {
                 SseMcpConnection connection = new SseMcpConnection(id, serverConfig, serverName, response);
                 connectionManager.add(connection);
 
-                // TODO we cannot override the close handler set/used by Quarkus HTTP
                 setCloseHandler(ctx.request(), id, connectionManager);
 
                 // By default /mcp/messages/{generatedId}
@@ -209,10 +208,20 @@ public class HttpMcpServerRecorder {
             if (connectionManager.remove(connectionId)) {
                 LOG.debugf("Connection %s closed", connectionId);
             }
-            // Connection may have been removed earlier...
         }, "client should close the connection [%s] explicitly".formatted(connectionId));
     }
 
+    /**
+     * Sets a close handler on the underlying HTTP connection by chaining it after the existing close handler set by
+     * Quarkus HTTP. This is necessary because {@link HttpConnection#closeHandler(Handler)} replaces the previous handler,
+     * and Quarkus sets its own handler internally. This method uses {@link VarHandle} to read the current handler from
+     * {@link ConnectionBase} and wrap it, ensuring both the original and the new {@code closeAction} run when the connection
+     * closes.
+     *
+     * @param request the HTTP server request whose connection should be monitored
+     * @param closeAction the action to run when the connection closes
+     * @param errorMessage a message logged if the close handler cannot be set
+     */
     static void setCloseHandler(HttpServerRequest request, Runnable closeAction, String errorMessage) {
         HttpConnection connection = request.connection();
         if (connection instanceof ConnectionBase base) {

--- a/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/StreamableHttpMcpConnection.java
+++ b/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/StreamableHttpMcpConnection.java
@@ -20,7 +20,12 @@ class StreamableHttpMcpConnection extends McpConnectionBase {
     private final List<SubsidiarySse> sseStreams;
 
     StreamableHttpMcpConnection(String id, McpServerRuntimeConfig serverConfig, String serverName) {
-        super(id, Objects.requireNonNull(serverConfig), serverName);
+        this(id, serverConfig, serverName, false);
+    }
+
+    StreamableHttpMcpConnection(String id, McpServerRuntimeConfig serverConfig, String serverName,
+            boolean transientConnection) {
+        super(id, Objects.requireNonNull(serverConfig), serverName, transientConnection);
         this.sseStreams = new CopyOnWriteArrayList<>();
     }
 

--- a/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/StreamableHttpMcpConnection.java
+++ b/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/StreamableHttpMcpConnection.java
@@ -18,7 +18,7 @@ class StreamableHttpMcpConnection extends McpConnectionBase {
 
     private static final Logger LOG = Logger.getLogger(StreamableHttpMcpConnection.class);
 
-    private final List<SseStream> sseStreams;
+    private volatile List<SseStream> sseStreams;
 
     StreamableHttpMcpConnection(String id, McpServerRuntimeConfig serverConfig, String serverName) {
         this(id, serverConfig, serverName, false);
@@ -27,20 +27,36 @@ class StreamableHttpMcpConnection extends McpConnectionBase {
     StreamableHttpMcpConnection(String id, McpServerRuntimeConfig serverConfig, String serverName,
             boolean transientConnection) {
         super(id, Objects.requireNonNull(serverConfig), serverName, transientConnection);
-        this.sseStreams = new CopyOnWriteArrayList<>();
     }
 
     void addSse(SseStream sse) {
-        sseStreams.add(sse);
+        List<SseStream> streams = this.sseStreams;
+        if (streams == null) {
+            synchronized (this) {
+                streams = this.sseStreams;
+                if (streams == null) {
+                    streams = new CopyOnWriteArrayList<>();
+                    this.sseStreams = streams;
+                }
+            }
+        }
+        streams.add(sse);
     }
 
     boolean removeSse(String id) {
-        return sseStreams.removeIf(e -> e.id().equals(id));
+        List<SseStream> streams = this.sseStreams;
+        if (streams == null) {
+            return false;
+        }
+        return streams.removeIf(e -> e.id().equals(id));
     }
 
     @Override
     public boolean close() {
-        sseStreams.clear();
+        List<SseStream> streams = this.sseStreams;
+        if (streams != null) {
+            streams.clear();
+        }
         return super.close();
     }
 
@@ -49,29 +65,35 @@ class StreamableHttpMcpConnection extends McpConnectionBase {
         if (message == null) {
             return Future.succeededFuture();
         }
-        // Pick the first legacy stream (no subscription filter) for non-subscription messages
-        SseStream sse = null;
-        for (SseStream s : sseStreams) {
-            if (s.subscription() == null) {
-                sse = s;
-                break;
-            }
-        }
-        if (sse == null) {
+        List<SseStream> streams = this.sseStreams;
+        if (streams == null) {
             Object id = Messages.getId(message);
             String method = message.getString("method");
             LOG.debugf("Discarding message [id=%s,method=%s] - no SSE streams open yet", id, method);
             return Future.succeededFuture();
-        } else {
-            messageSent(message);
-            return sse.sendEvent("message", message.encode());
         }
+        // Pick the first legacy stream (no subscription filter) for non-subscription messages
+        for (SseStream s : streams) {
+            if (s.subscription() == null) {
+                messageSent(message);
+                return s.sendEvent("message", message.encode());
+            }
+        }
+        Object id = Messages.getId(message);
+        String method = message.getString("method");
+        LOG.debugf("Discarding message [id=%s,method=%s] - no SSE streams open yet", id, method);
+        return Future.succeededFuture();
     }
 
     @Override
     protected void deliverSubscriptionNotification(JsonObject notification, Subscription subscription) {
+        List<SseStream> streams = this.sseStreams;
+        if (streams == null) {
+            LOG.debugf("Subscription stream not found, notification dropped [%s]", id());
+            return;
+        }
         String targetId = String.valueOf(subscription.subscriptionId());
-        for (SseStream stream : sseStreams) {
+        for (SseStream stream : streams) {
             if (stream.subscription() != null
                     && stream.id().equals(targetId)) {
                 messageSent(notification);

--- a/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/StreamableHttpMcpConnection.java
+++ b/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/StreamableHttpMcpConnection.java
@@ -8,6 +8,7 @@ import org.jboss.logging.Logger;
 
 import io.quarkiverse.mcp.server.runtime.McpConnectionBase;
 import io.quarkiverse.mcp.server.runtime.Messages;
+import io.quarkiverse.mcp.server.runtime.Subscription;
 import io.quarkiverse.mcp.server.runtime.config.McpServerRuntimeConfig;
 import io.vertx.core.Future;
 import io.vertx.core.http.HttpServerResponse;
@@ -17,7 +18,7 @@ class StreamableHttpMcpConnection extends McpConnectionBase {
 
     private static final Logger LOG = Logger.getLogger(StreamableHttpMcpConnection.class);
 
-    private final List<SubsidiarySse> sseStreams;
+    private final List<SseStream> sseStreams;
 
     StreamableHttpMcpConnection(String id, McpServerRuntimeConfig serverConfig, String serverName) {
         this(id, serverConfig, serverName, false);
@@ -29,7 +30,7 @@ class StreamableHttpMcpConnection extends McpConnectionBase {
         this.sseStreams = new CopyOnWriteArrayList<>();
     }
 
-    void addSse(SubsidiarySse sse) {
+    void addSse(SseStream sse) {
         sseStreams.add(sse);
     }
 
@@ -48,17 +49,18 @@ class StreamableHttpMcpConnection extends McpConnectionBase {
         if (message == null) {
             return Future.succeededFuture();
         }
-        SubsidiarySse sse = null;
-        if (!sseStreams.isEmpty()) {
-            try {
-                sse = sseStreams.get(0);
-            } catch (IndexOutOfBoundsException expected) {
+        // Pick the first legacy stream (no subscription filter) for non-subscription messages
+        SseStream sse = null;
+        for (SseStream s : sseStreams) {
+            if (s.subscription() == null) {
+                sse = s;
+                break;
             }
         }
         if (sse == null) {
             Object id = Messages.getId(message);
             String method = message.getString("method");
-            LOG.debugf("Discarding message [id=%s,method=%s] - no 'subsidiary' SSE streams open yet", id, method);
+            LOG.debugf("Discarding message [id=%s,method=%s] - no SSE streams open yet", id, method);
             return Future.succeededFuture();
         } else {
             messageSent(message);
@@ -66,9 +68,27 @@ class StreamableHttpMcpConnection extends McpConnectionBase {
         }
     }
 
-    record SubsidiarySse(String id, HttpServerResponse response) {
+    @Override
+    protected void deliverSubscriptionNotification(JsonObject notification, Subscription subscription) {
+        String targetId = String.valueOf(subscription.subscriptionId());
+        for (SseStream stream : sseStreams) {
+            if (stream.subscription() != null
+                    && stream.id().equals(targetId)) {
+                messageSent(notification);
+                stream.sendEvent("message", notification.encode());
+                return;
+            }
+        }
+        LOG.debugf("Subscription stream [%s] not found, notification dropped [%s]", targetId, id());
+    }
 
-        public SubsidiarySse {
+    record SseStream(String id, HttpServerResponse response, Subscription subscription) {
+
+        SseStream(String id, HttpServerResponse response) {
+            this(id, response, null);
+        }
+
+        public SseStream {
             if (id == null) {
                 throw new IllegalArgumentException("id must not be null");
             }

--- a/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/StreamableHttpMcpMessageHandler.java
+++ b/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/StreamableHttpMcpMessageHandler.java
@@ -352,7 +352,7 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
     }
 
     private StreamableHttpMcpConnection createTransientConnection(String serverName) {
-        String id = ConnectionManager.connectionId();
+        String id = ConnectionManager.transientConnectionId();
         LOG.debugf("Stateless transient connection created [%s]", id);
         McpServerRuntimeConfig serverConfig = config.servers().get(serverName);
         return new StreamableHttpMcpConnection(id, serverConfig, serverName, true);

--- a/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/StreamableHttpMcpMessageHandler.java
+++ b/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/StreamableHttpMcpMessageHandler.java
@@ -16,9 +16,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
-import jakarta.enterprise.inject.Instance;
-import jakarta.inject.Singleton;
-
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
@@ -32,8 +29,10 @@ import io.quarkiverse.mcp.server.InitialRequest;
 import io.quarkiverse.mcp.server.InitialRequest.Transport;
 import io.quarkiverse.mcp.server.InitialResponseInfo;
 import io.quarkiverse.mcp.server.JsonRpcErrorCodes;
+import io.quarkiverse.mcp.server.McpException;
 import io.quarkiverse.mcp.server.McpLog;
 import io.quarkiverse.mcp.server.McpMethod;
+import io.quarkiverse.mcp.server.McpProtocolVersion;
 import io.quarkiverse.mcp.server.MetaKey;
 import io.quarkiverse.mcp.server.PromptManager.PromptInfo;
 import io.quarkiverse.mcp.server.ResourceManager;
@@ -87,6 +86,8 @@ import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Singleton;
 
 @Singleton
 public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRequest> implements Handler<RoutingContext> {
@@ -97,10 +98,11 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
 
     public static final String MCP_SESSION_ID_HEADER = "Mcp-Session-Id";
     public static final String MCP_PROTOCOL_VERSION_HEADER = "Mcp-Protocol-Version";
+    public static final String MCP_METHOD_HEADER = "Mcp-Method";
+    public static final String MCP_NAME_HEADER = "Mcp-Name";
     public static final String AUTO_INIT_IMPL_NAME = "quarkus.mcp.http.streamable.dummy";
     private static final Implementation AUTO_INIT_IMPLEMENTATION = new Implementation(AUTO_INIT_IMPL_NAME, "1", null);
 
-    private final McpMetadata metadata;
     private final CurrentVertxRequest currentVertxRequest;
     private final CurrentIdentityAssociation currentIdentityAssociation;
     private final McpHttpServersRuntimeConfig httpConfig;
@@ -139,7 +141,6 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
                 vertx, initialChecks, initialResponseInfos, metrics.isResolvable() ? metrics.get() : null,
                 tracing.isResolvable() ? tracing.get() : null,
                 mcpRequestValidator.isResolvable() ? mcpRequestValidator.get() : null, cancellationRequests);
-        this.metadata = metadata;
         this.currentVertxRequest = currentVertxRequest;
         this.currentIdentityAssociation = currentIdentityAssociation.isResolvable() ? currentIdentityAssociation.get() : null;
         this.httpConfig = runtimeConfig;
@@ -190,6 +191,173 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
             return;
         }
 
+        JsonObject message;
+        try {
+            message = (JsonObject) Json.decodeValue(ctx.body().buffer());
+        } catch (Exception e) {
+            String msg = "Unable to parse the JSON message";
+            LOG.warnf(e, msg);
+            ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+            ctx.end(newError(null, JsonRpcErrorCodes.PARSE_ERROR, msg).toBuffer());
+            return;
+        }
+
+        String mcpProtocolVersion = request.getHeader(MCP_PROTOCOL_VERSION_HEADER);
+        JsonObject meta = findMeta(message);
+        if (isStatelessRequest(mcpProtocolVersion, message, meta)) {
+            handleStateless(ctx, serverName, request, message, mcpProtocolVersion, meta);
+        } else {
+            handleStateful(ctx, serverName, request, message, mcpProtocolVersion);
+        }
+    }
+
+    private boolean isStatelessRequest(String mcpProtocolVersion, JsonObject message, JsonObject meta) {
+        if (mcpProtocolVersion != null && isStateless(mcpProtocolVersion)) {
+            return true;
+        }
+        return isStatelessMessage(message, meta);
+    }
+
+    private void handleStateless(RoutingContext ctx, String serverName, HttpServerRequest request,
+            JsonObject message, String mcpProtocolVersion, JsonObject meta) {
+
+        // Validate required headers for stateless clients
+        if (!validateStatelessHeaders(ctx, message, mcpProtocolVersion, meta)) {
+            return;
+        }
+
+        // Validate protocol version is supported
+        if (mcpProtocolVersion != null && !McpProtocolVersion.SUPPORTED_VERSIONS.contains(mcpProtocolVersion)) {
+            ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+            ctx.response().setStatusCode(400);
+            ctx.end(newError(null, JsonRpcErrorCodes.UNSUPPORTED_PROTOCOL_VERSION,
+                    "Unsupported protocol version",
+                    new JsonObject().put("supported", McpProtocolVersion.SUPPORTED_VERSIONS).put("requested",
+                            mcpProtocolVersion))
+                    .toBuffer());
+            return;
+        }
+
+        // Create a transient connection — not registered in ConnectionManager
+        StreamableHttpMcpConnection connection = createTransientConnection(serverName);
+
+        // Build InitialRequest from _meta and auto-initialize
+        InitialRequest initialRequest;
+        try {
+            initialRequest = buildStatelessInitialRequest(meta, mcpProtocolVersion,
+                    Transport.STREAMABLE_HTTP);
+            applyMetaLogLevel(meta, connection);
+        } catch (McpException e) {
+            ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+            ctx.response().setStatusCode(400);
+            ctx.end(newError(Messages.getId(message), e.getJsonRpcErrorCode(), e.getMessage()).toBuffer());
+            return;
+        }
+        connection.initialize(initialRequest);
+        connection.setInitialized();
+
+        QuarkusHttpUser user = (QuarkusHttpUser) ctx.user();
+        SecuritySupport securitySupport = createSecuritySupport(ctx, user);
+        ContextSupport contextSupport = createContextSupport(ctx);
+
+        boolean lazySseInit = computeLazySseInit(serverName, message);
+        HttpMcpRequest mcpRequest = new HttpMcpRequest(serverName, message, connection, securitySupport, ctx.response(),
+                true, contextSupport, currentIdentityAssociation, mcpProtocolVersion, lazySseInit);
+
+        try {
+            boolean containsRequest = scan(mcpRequest);
+            handle(mcpRequest).onComplete(ar -> {
+                completeResponse(ctx, mcpRequest, containsRequest, ar.succeeded());
+            });
+        } catch (Exception e) {
+            throw e;
+        }
+    }
+
+    private boolean validateStatelessHeaders(RoutingContext ctx, JsonObject message, String mcpProtocolVersion,
+            JsonObject meta) {
+        // Validate Mcp-Method header
+        String mcpMethodHeader = ctx.request().getHeader(MCP_METHOD_HEADER);
+        String bodyMethod = message.getString("method");
+        if (mcpMethodHeader == null) {
+            ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+            ctx.response().setStatusCode(400);
+            ctx.end(newError(null, JsonRpcErrorCodes.HEADER_MISMATCH,
+                    "Missing required header: " + MCP_METHOD_HEADER).toBuffer());
+            return false;
+        }
+        if (bodyMethod != null && !mcpMethodHeader.equals(bodyMethod)) {
+            ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+            ctx.response().setStatusCode(400);
+            ctx.end(newError(null, JsonRpcErrorCodes.HEADER_MISMATCH,
+                    "Header mismatch: " + MCP_METHOD_HEADER + " header value '" + mcpMethodHeader
+                            + "' does not match body value '" + bodyMethod + "'")
+                    .toBuffer());
+            return false;
+        }
+
+        // Validate Mcp-Name header for methods that require it
+        if ("tools/call".equals(bodyMethod) || "prompts/get".equals(bodyMethod)) {
+            JsonObject params = Messages.getParams(message);
+            String bodyName = params != null ? params.getString("name") : null;
+            if (!validateMcpNameHeader(ctx, bodyName)) {
+                return false;
+            }
+        } else if ("resources/read".equals(bodyMethod)) {
+            JsonObject params = Messages.getParams(message);
+            String bodyUri = params != null ? params.getString("uri") : null;
+            if (!validateMcpNameHeader(ctx, bodyUri)) {
+                return false;
+            }
+        }
+
+        // Validate MCP-Protocol-Version header matches _meta version
+        if (meta != null && mcpProtocolVersion != null) {
+            String metaVersion = meta.getString(MetaKey.PROTOCOL_VERSION.toString());
+            if (metaVersion != null && !mcpProtocolVersion.equals(metaVersion)) {
+                ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+                ctx.response().setStatusCode(400);
+                ctx.end(newError(null, JsonRpcErrorCodes.HEADER_MISMATCH,
+                        "Header mismatch: " + MCP_PROTOCOL_VERSION_HEADER + " header value '" + mcpProtocolVersion
+                                + "' does not match _meta value '" + metaVersion + "'")
+                        .toBuffer());
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private boolean validateMcpNameHeader(RoutingContext ctx, String expectedValue) {
+        String mcpNameHeader = ctx.request().getHeader(MCP_NAME_HEADER);
+        if (mcpNameHeader == null) {
+            ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+            ctx.response().setStatusCode(400);
+            ctx.end(newError(null, JsonRpcErrorCodes.HEADER_MISMATCH,
+                    "Missing required header: " + MCP_NAME_HEADER).toBuffer());
+            return false;
+        }
+        if (expectedValue != null && !mcpNameHeader.equals(expectedValue)) {
+            ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+            ctx.response().setStatusCode(400);
+            ctx.end(newError(null, JsonRpcErrorCodes.HEADER_MISMATCH,
+                    "Header mismatch: " + MCP_NAME_HEADER + " header value '" + mcpNameHeader
+                            + "' does not match body value '" + expectedValue + "'")
+                    .toBuffer());
+            return false;
+        }
+        return true;
+    }
+
+    private StreamableHttpMcpConnection createTransientConnection(String serverName) {
+        String id = ConnectionManager.connectionId();
+        LOG.debugf("Stateless transient connection created [%s]", id);
+        McpServerRuntimeConfig serverConfig = config.servers().get(serverName);
+        return new StreamableHttpMcpConnection(id, serverConfig, serverName, true);
+    }
+
+    private void handleStateful(RoutingContext ctx, String serverName, HttpServerRequest request,
+            JsonObject message, String mcpProtocolVersion) {
+
         StreamableHttpMcpConnection connection;
         String mcpSessionId = request.getHeader(MCP_SESSION_ID_HEADER);
         if (mcpSessionId == null) {
@@ -198,7 +366,6 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
             McpConnectionBase existing = connectionManager.get(mcpSessionId);
             if (existing == null) {
                 if (httpConfig.servers().get(serverName).http().streamable().autoInit()) {
-                    // We don't care about non-existent session when auto-init is enabled
                     connection = initConnection(serverName);
                 } else {
                     LOG.warnf("Mcp session not found: %s", mcpSessionId);
@@ -212,18 +379,34 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
             }
         }
 
-        JsonObject message;
-        try {
-            message = (JsonObject) Json.decodeValue(ctx.body().buffer());
-        } catch (Exception e) {
-            String msg = "Unable to parse the JSON message";
-            LOG.warnf(e, msg);
-            ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, "application/json");
-            ctx.end(newError(null, JsonRpcErrorCodes.PARSE_ERROR, msg).toBuffer());
+        if (mcpProtocolVersion != null
+                && !McpProtocolVersion.SUPPORTED_VERSIONS.contains(mcpProtocolVersion)) {
+            LOG.warnf("Invalid MCP protocol header: %s", mcpProtocolVersion);
+            ctx.fail(400);
             return;
         }
+
         QuarkusHttpUser user = (QuarkusHttpUser) ctx.user();
-        SecuritySupport securitySupport = new SecuritySupport() {
+        SecuritySupport securitySupport = createSecuritySupport(ctx, user);
+        ContextSupport contextSupport = createContextSupport(ctx);
+
+        boolean lazySseInit = computeLazySseInit(serverName, message);
+        HttpMcpRequest mcpRequest = new HttpMcpRequest(serverName, message, connection, securitySupport, ctx.response(),
+                mcpSessionId == null, contextSupport, currentIdentityAssociation, mcpProtocolVersion, lazySseInit);
+        try {
+            boolean containsRequest = scan(mcpRequest);
+            handle(mcpRequest).onComplete(ar -> {
+                completeResponse(ctx, mcpRequest, containsRequest, ar.succeeded());
+                removeAutoInitConnection(connection);
+            });
+        } catch (Exception e) {
+            removeAutoInitConnection(connection);
+            throw e;
+        }
+    }
+
+    private SecuritySupport createSecuritySupport(RoutingContext ctx, QuarkusHttpUser user) {
+        return new SecuritySupport() {
             @Override
             public void setCurrentIdentity(CurrentIdentityAssociation currentIdentityAssociation) {
                 if (user != null) {
@@ -234,52 +417,34 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
                 }
             }
         };
-        ContextSupport contextSupport = new ContextSupport() {
+    }
+
+    private ContextSupport createContextSupport(RoutingContext ctx) {
+        return new ContextSupport() {
             @Override
             public void requestContextActivated() {
                 currentVertxRequest.setCurrent(ctx);
             }
         };
+    }
 
-        String mcpProtocolVersion = request.getHeader(MCP_PROTOCOL_VERSION_HEADER);
-        if (mcpProtocolVersion != null
-                && !SUPPORTED_PROTOCOL_VERSIONS.contains(mcpProtocolVersion)) {
-            LOG.warnf("Invalid MCP protocol header: %s", mcpProtocolVersion);
-            ctx.fail(400);
-            return;
-        }
-        boolean lazySseInit = computeLazySseInit(serverName, message);
-        HttpMcpRequest mcpRequest = new HttpMcpRequest(serverName, message, connection, securitySupport, ctx.response(),
-                mcpSessionId == null, contextSupport, currentIdentityAssociation, mcpProtocolVersion, lazySseInit);
-        try {
-            boolean containsRequest = scan(mcpRequest);
-            handle(mcpRequest).onComplete(ar -> {
-                if (ar.succeeded()) {
-                    if (mcpRequest.sse.get()) {
-                        // Just close the SSE stream
-                        ctx.response().end();
+    private void completeResponse(RoutingContext ctx, HttpMcpRequest mcpRequest, boolean containsRequest, boolean succeeded) {
+        if (succeeded) {
+            if (mcpRequest.sse.get()) {
+                ctx.response().end();
+            } else {
+                if (!ctx.response().ended()) {
+                    if (!containsRequest) {
+                        ctx.response().setStatusCode(202).end();
                     } else {
-                        if (!ctx.response().ended()) {
-                            if (!containsRequest) {
-                                // If the input consists solely of responses/notifications
-                                // then the server MUST return HTTP status 202
-                                ctx.response().setStatusCode(202).end();
-                            } else {
-                                ctx.end();
-                            }
-                        }
-                    }
-                } else {
-                    if (!ctx.response().ended()) {
-                        ctx.response().setStatusCode(500).end();
+                        ctx.end();
                     }
                 }
-
-                removeAutoInitConnection(connection);
-            });
-        } catch (Exception e) {
-            removeAutoInitConnection(connection);
-            throw e;
+            }
+        } else {
+            if (!ctx.response().ended()) {
+                ctx.response().setStatusCode(500).end();
+            }
         }
     }
 
@@ -354,7 +519,7 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
             // Note that this is inconsistent with initial handshake where the latest supported version is used
             String version = mcpRequest.mcpProtocolVersion;
             if (version == null) {
-                version = SUPPORTED_PROTOCOL_VERSIONS.get(2);
+                version = McpProtocolVersion.DEFAULT_ASSUMED.version();
             }
 
             // Try to find the clientInfo and clientCapabilities in _meta
@@ -386,14 +551,6 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
         return null;
     }
 
-    private static JsonObject findMeta(JsonObject message) {
-        JsonObject params = Messages.getParams(message);
-        if (params != null) {
-            return params.getJsonObject("_meta");
-        }
-        return null;
-    }
-
     public void terminateSession(RoutingContext ctx) {
         HttpServerRequest request = ctx.request();
         String mcpSessionId = request.getHeader(MCP_SESSION_ID_HEADER);
@@ -416,8 +573,15 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
 
     @Override
     protected void afterInitialize(HttpMcpRequest mcpRequest) {
-        // Add the "Mcp-Session-Id" header to the response to the "Initialize" request
-        mcpRequest.response.headers().add(MCP_SESSION_ID_HEADER, mcpRequest.connection().id());
+        if (!isStateless(mcpRequest.connection())) {
+            // Add the "Mcp-Session-Id" header to the response to the "Initialize" request
+            mcpRequest.response.headers().add(MCP_SESSION_ID_HEADER, mcpRequest.connection().id());
+        }
+    }
+
+    private static boolean isStateless(McpConnectionBase connection) {
+        InitialRequest ir = connection.initialRequest();
+        return ir != null && ir.protocolVersion() != null && isStateless(ir.protocolVersion());
     }
 
     @Override
@@ -681,9 +845,9 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
         }
 
         @Override
-        public String protocolVersion() {
-            String ret = super.protocolVersion();
-            return ret != null ? ret : mcpProtocolVersion;
+        public McpProtocolVersion protocolVersion() {
+            McpProtocolVersion ret = super.protocolVersion();
+            return ret != null ? ret : McpProtocolVersion.from(mcpProtocolVersion);
         }
 
     }

--- a/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/StreamableHttpMcpMessageHandler.java
+++ b/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/StreamableHttpMcpMessageHandler.java
@@ -42,7 +42,7 @@ import io.quarkiverse.mcp.server.ResourceManager;
 import io.quarkiverse.mcp.server.ResourceTemplateManager;
 import io.quarkiverse.mcp.server.ToolManager.ToolInfo;
 import io.quarkiverse.mcp.server.TransportHint;
-import io.quarkiverse.mcp.server.http.runtime.StreamableHttpMcpConnection.SubsidiarySse;
+import io.quarkiverse.mcp.server.http.runtime.StreamableHttpMcpConnection.SseStream;
 import io.quarkiverse.mcp.server.http.runtime.StreamableHttpMcpMessageHandler.HttpMcpRequest;
 import io.quarkiverse.mcp.server.http.runtime.config.McpHttpServerRuntimeConfig;
 import io.quarkiverse.mcp.server.http.runtime.config.McpHttpServersRuntimeConfig;
@@ -69,6 +69,7 @@ import io.quarkiverse.mcp.server.runtime.ResourceTemplateManagerImpl;
 import io.quarkiverse.mcp.server.runtime.SecuritySupport;
 import io.quarkiverse.mcp.server.runtime.Sender;
 import io.quarkiverse.mcp.server.runtime.ServerRequests;
+import io.quarkiverse.mcp.server.runtime.Subscription;
 import io.quarkiverse.mcp.server.runtime.ToolManagerImpl;
 import io.quarkiverse.mcp.server.runtime.TrafficLogger;
 import io.quarkiverse.mcp.server.runtime.config.McpServerRuntimeConfig;
@@ -262,7 +263,8 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
         ContextSupport contextSupport = createContextSupport(ctx);
 
         boolean lazySseInit = computeLazySseInit(serverName, message);
-        HttpMcpRequest mcpRequest = new HttpMcpRequest(serverName, message, connection, securitySupport, ctx.response(),
+        HttpMcpRequest mcpRequest = new HttpMcpRequest(serverName, message, connection, securitySupport,
+                ctx.request(), ctx.response(),
                 true, contextSupport, currentIdentityAssociation, mcpProtocolVersion, lazySseInit);
 
         try {
@@ -392,7 +394,8 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
         ContextSupport contextSupport = createContextSupport(ctx);
 
         boolean lazySseInit = computeLazySseInit(serverName, message);
-        HttpMcpRequest mcpRequest = new HttpMcpRequest(serverName, message, connection, securitySupport, ctx.response(),
+        HttpMcpRequest mcpRequest = new HttpMcpRequest(serverName, message, connection, securitySupport,
+                ctx.request(), ctx.response(),
                 mcpSessionId == null, contextSupport, currentIdentityAssociation, mcpProtocolVersion, lazySseInit);
         try {
             boolean containsRequest = scan(mcpRequest);
@@ -430,6 +433,9 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
     }
 
     private void completeResponse(RoutingContext ctx, HttpMcpRequest mcpRequest, boolean containsRequest, boolean succeeded) {
+        if (mcpRequest.subscriptionStream.get()) {
+            return;
+        }
         if (succeeded) {
             if (mcpRequest.sse.get()) {
                 ctx.response().end();
@@ -478,12 +484,12 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
         response.headers().add(HttpHeaders.CONTENT_TYPE, "text/event-stream");
 
         StreamableHttpMcpConnection streamableConnection = (StreamableHttpMcpConnection) connection;
-        SubsidiarySse sse = new SubsidiarySse(ConnectionManager.connectionId(), response);
+        SseStream sse = new SseStream(ConnectionManager.connectionId(), response);
         streamableConnection.addSse(sse);
 
         // Send log notification to the client
         JsonObject log = Messages.newNotification(McpMethod.NOTIFICATIONS_MESSAGE.jsonRpcName(),
-                Messages.newLog(McpLog.LogLevel.DEBUG, "SubsidiarySse",
+                Messages.newLog(McpLog.LogLevel.DEBUG, "SseStream",
                         "Subsidiary SSE opened [%s]".formatted(connection.id())));
 
         TrafficLogging trafficLogging = config.servers().get(serverName).trafficLogging();
@@ -595,6 +601,48 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
     private static boolean isStateless(McpConnectionBase connection) {
         InitialRequest ir = connection.initialRequest();
         return ir != null && ir.protocolVersion() != null && ir.protocolVersion().isStateless();
+    }
+
+    @Override
+    protected Future<Void> onSubscriptionOpened(JsonObject message, HttpMcpRequest mcpRequest,
+            Subscription subscription) {
+        StreamableHttpMcpConnection connection = mcpRequest.connection();
+
+        // Register transient connection so notification senders can find it
+        if (connection.isTransient()) {
+            connectionManager.add(connection);
+        }
+
+        mcpRequest.subscriptionStream.set(true);
+        mcpRequest.initiateSse();
+
+        String streamId = String.valueOf(subscription.subscriptionId());
+        SseStream sse = new SseStream(streamId, mcpRequest.response, subscription);
+        connection.addSse(sse);
+
+        HttpMcpServerRecorder.setCloseHandler(mcpRequest.request, () -> {
+            if (connection.removeSse(streamId)) {
+                connection.removeSubscription(subscription.subscriptionId());
+                LOG.debugf("Subscription stream [%s] closed [%s]", streamId, connection.id());
+            }
+            if (connection.isTransient() && connectionManager.remove(connection.id())) {
+                LOG.debugf("Transient subscription connection removed [%s]", connection.id());
+            }
+        }, "subscription stream will be cleaned up");
+
+        // Send acknowledged notification
+        JsonObject params = new JsonObject().put("notifications", subscription.filter().toAcknowledgedJson());
+        JsonObject acknowledged = Messages.newNotification(
+                McpMethod.NOTIFICATIONS_SUBSCRIPTIONS_ACKNOWLEDGED.jsonRpcName(), params);
+        McpConnectionBase.injectSubscriptionId(acknowledged, subscription.subscriptionId());
+
+        TrafficLogging trafficLogging = config.servers().get(mcpRequest.serverName()).trafficLogging();
+        if (trafficLogging.enabled()) {
+            TrafficLogger.messageSent(acknowledged, connection, trafficLogging.textLimit());
+        }
+
+        LOG.debugf("Subscription stream [%s] opened [%s]", streamId, connection.id());
+        return sse.sendEvent("message", acknowledged.encode());
     }
 
     @Override
@@ -793,20 +841,26 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
 
         final AtomicBoolean sse;
 
+        final HttpServerRequest request;
+
         final HttpServerResponse response;
 
         final String mcpProtocolVersion;
 
         final boolean lazySseInit;
 
+        final AtomicBoolean subscriptionStream = new AtomicBoolean(false);
+
         public HttpMcpRequest(String serverName, JsonObject message, StreamableHttpMcpConnection connection,
                 SecuritySupport securitySupport,
-                HttpServerResponse response, boolean newSession, ContextSupport contextSupport,
+                HttpServerRequest request, HttpServerResponse response, boolean newSession,
+                ContextSupport contextSupport,
                 CurrentIdentityAssociation currentIdentityAssociation, String mcpProtocolVersion,
                 boolean lazySseInit) {
             super(serverName, message, connection, null, securitySupport, contextSupport, currentIdentityAssociation);
             this.newSession = newSession;
             this.sse = new AtomicBoolean(false);
+            this.request = request;
             this.response = response;
             this.mcpProtocolVersion = mcpProtocolVersion;
             this.lazySseInit = lazySseInit;

--- a/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/StreamableHttpMcpMessageHandler.java
+++ b/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/StreamableHttpMcpMessageHandler.java
@@ -16,6 +16,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.stream.Stream;
 
+import jakarta.enterprise.inject.Instance;
+import jakarta.inject.Singleton;
+
 import org.eclipse.microprofile.config.Config;
 import org.eclipse.microprofile.config.ConfigProvider;
 import org.jboss.logging.Logger;
@@ -86,8 +89,6 @@ import io.vertx.core.http.HttpServerResponse;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
-import jakarta.enterprise.inject.Instance;
-import jakarta.inject.Singleton;
 
 @Singleton
 public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRequest> implements Handler<RoutingContext> {
@@ -517,9 +518,9 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
         if (config != null && config.http().streamable().autoInit()) {
             // "If the server does not receive an MCP-Protocol-Version header, the server SHOULD assume protocol version 2025-03-26"
             // Note that this is inconsistent with initial handshake where the latest supported version is used
-            String version = mcpRequest.mcpProtocolVersion;
-            if (version == null) {
-                version = McpProtocolVersion.DEFAULT_ASSUMED.version();
+            McpProtocolVersion protocolVersion = McpProtocolVersion.from(mcpRequest.mcpProtocolVersion);
+            if (protocolVersion == null) {
+                protocolVersion = McpProtocolVersion.DEFAULT_ASSUMED;
             }
 
             // Try to find the clientInfo and clientCapabilities in _meta
@@ -543,7 +544,7 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
 
             return new InitialRequest(
                     implementation,
-                    version,
+                    protocolVersion,
                     clientCapabilities,
                     Transport.STREAMABLE_HTTP,
                     true);
@@ -581,7 +582,7 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
 
     private static boolean isStateless(McpConnectionBase connection) {
         InitialRequest ir = connection.initialRequest();
-        return ir != null && ir.protocolVersion() != null && isStateless(ir.protocolVersion());
+        return ir != null && ir.protocolVersion() != null && ir.protocolVersion().isStateless();
     }
 
     @Override

--- a/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/StreamableHttpMcpMessageHandler.java
+++ b/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/StreamableHttpMcpMessageHandler.java
@@ -454,6 +454,12 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
             throw serverNameNotDefined();
         }
         HttpServerRequest request = ctx.request();
+        // Stateless protocol does not support the GET SSE stream
+        String mcpProtocolVersion = request.getHeader(MCP_PROTOCOL_VERSION_HEADER);
+        if (mcpProtocolVersion != null && isStateless(mcpProtocolVersion)) {
+            ctx.fail(405);
+            return;
+        }
         String mcpSessionId = request.getHeader(MCP_SESSION_ID_HEADER);
         if (mcpSessionId == null) {
             LOG.warnf("%s header not found", MCP_SESSION_ID_HEADER);
@@ -554,6 +560,12 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
 
     public void terminateSession(RoutingContext ctx) {
         HttpServerRequest request = ctx.request();
+        // Stateless protocol does not support session termination
+        String mcpProtocolVersion = request.getHeader(MCP_PROTOCOL_VERSION_HEADER);
+        if (mcpProtocolVersion != null && isStateless(mcpProtocolVersion)) {
+            ctx.fail(405);
+            return;
+        }
         String mcpSessionId = request.getHeader(MCP_SESSION_ID_HEADER);
         if (mcpSessionId == null) {
             LOG.warnf("Mcp session id header is missing: %s", ctx.normalizedPath());

--- a/transports/stdio/integration-tests/src/main/java/io/quarkiverse/mcp/server/stdio/it/ServerFeatures.java
+++ b/transports/stdio/integration-tests/src/main/java/io/quarkiverse/mcp/server/stdio/it/ServerFeatures.java
@@ -48,9 +48,8 @@ public class ServerFeatures {
 
     @Tool
     String protocolInfo(McpConnection connection) {
-        String version = connection.initialRequest().protocolVersion();
-        boolean stateless = McpProtocolVersion.isStateless(version);
-        return version + ":" + stateless + ":" + connection.isTransient();
+        McpProtocolVersion version = connection.initialRequest().protocolVersion();
+        return version.version() + ":" + version.isStateless() + ":" + connection.isTransient();
     }
 
     @Tool

--- a/transports/stdio/integration-tests/src/main/java/io/quarkiverse/mcp/server/stdio/it/ServerFeatures.java
+++ b/transports/stdio/integration-tests/src/main/java/io/quarkiverse/mcp/server/stdio/it/ServerFeatures.java
@@ -3,6 +3,8 @@ package io.quarkiverse.mcp.server.stdio.it;
 import jakarta.inject.Inject;
 
 import io.quarkiverse.mcp.server.BlobResourceContents;
+import io.quarkiverse.mcp.server.McpConnection;
+import io.quarkiverse.mcp.server.McpProtocolVersion;
 import io.quarkiverse.mcp.server.Prompt;
 import io.quarkiverse.mcp.server.PromptArg;
 import io.quarkiverse.mcp.server.PromptMessage;
@@ -42,6 +44,18 @@ public class ServerFeatures {
     @Resource(uri = "file:///project/alpha")
     BlobResourceContents alpha(RequestUri uri) {
         return BlobResourceContents.create(uri.value(), "data".getBytes());
+    }
+
+    @Tool
+    String protocolInfo(McpConnection connection) {
+        String version = connection.initialRequest().protocolVersion();
+        boolean stateless = McpProtocolVersion.isStateless(version);
+        return version + ":" + stateless + ":" + connection.isTransient();
+    }
+
+    @Tool
+    String logLevelInfo(McpConnection connection) {
+        return connection.logLevel().name();
     }
 
 }

--- a/transports/stdio/integration-tests/src/test/java/io/quarkiverse/mcp/server/stdio/it/ServerFeaturesIT.java
+++ b/transports/stdio/integration-tests/src/test/java/io/quarkiverse/mcp/server/stdio/it/ServerFeaturesIT.java
@@ -45,7 +45,7 @@ public class ServerFeaturesIT {
         try (McpStdioTestClient client = McpAssured.newConnectedStdioClient()) {
             client.when()
                     .toolsList(page -> {
-                        assertEquals(1, page.size());
+                        assertEquals(3, page.size());
                         var tool = page.findByName("toLowerCase");
                         assertNotNull(tool);
                         assertNotNull(tool.inputSchema());

--- a/transports/stdio/integration-tests/src/test/java/io/quarkiverse/mcp/server/stdio/it/StatelessIT.java
+++ b/transports/stdio/integration-tests/src/test/java/io/quarkiverse/mcp/server/stdio/it/StatelessIT.java
@@ -1,0 +1,102 @@
+package io.quarkiverse.mcp.server.stdio.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkiverse.mcp.server.McpLog.LogLevel;
+import io.quarkiverse.mcp.server.McpProtocolVersion;
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkiverse.mcp.server.test.McpAssured.McpStdioTestClient;
+
+public class StatelessIT {
+
+    @Test
+    public void testServerDiscover() {
+        try (McpStdioTestClient client = McpAssured.newStdioClient()
+                .setStateless()
+                .build()
+                .connect(initResult -> {
+                    assertNotNull(initResult);
+                    assertNotNull(initResult.capabilities());
+                    assertNotNull(initResult.implementation());
+                })) {
+            assertTrue(client.isConnected());
+        }
+    }
+
+    @Test
+    public void testToolsCall() {
+        try (McpStdioTestClient client = McpAssured.newStdioClient()
+                .setStateless()
+                .build()
+                .connect()) {
+
+            client.when()
+                    .toolsCall("toLowerCase", Map.of("value", "HELLO"), r -> {
+                        assertFalse(r.isError());
+                        assertEquals("hello", r.firstContent().asText().text());
+                    })
+                    .thenAssertResults();
+        }
+    }
+
+    @Test
+    public void testToolCallWithConnectionAccess() {
+        try (McpStdioTestClient client = McpAssured.newStdioClient()
+                .setStateless()
+                .build()
+                .connect()) {
+
+            client.when()
+                    .toolsCall("protocolInfo", r -> {
+                        assertFalse(r.isError());
+                        assertEquals(McpProtocolVersion.FIRST_STATELESS.version() + ":true:true",
+                                r.firstContent().asText().text());
+                    })
+                    .thenAssertResults();
+        }
+    }
+
+    @Test
+    public void testPerRequestLogLevel() {
+        try (McpStdioTestClient client = McpAssured.newStdioClient()
+                .setStateless()
+                .build()
+                .connect()) {
+
+            client.when()
+                    .toolsCall("logLevelInfo")
+                    .withMetadata(Map.of("io.modelcontextprotocol/logLevel", "warning"))
+                    .withAssert(r -> {
+                        assertFalse(r.isError());
+                        assertEquals(LogLevel.WARNING.name(), r.firstContent().asText().text());
+                    })
+                    .send()
+                    .thenAssertResults();
+        }
+    }
+
+    @Test
+    public void testRemovedMethodRejected() {
+        try (McpStdioTestClient client = McpAssured.newStdioClient()
+                .setStateless()
+                .build()
+                .connect()) {
+
+            client.when()
+                    .ping()
+                    .withErrorAssert(error -> {
+                        assertEquals(-32601, error.code());
+                    })
+                    .send()
+                    .thenAssertResults();
+        }
+    }
+
+}

--- a/transports/stdio/integration-tests/src/test/java/io/quarkiverse/mcp/server/stdio/it/SubscriptionsListenIT.java
+++ b/transports/stdio/integration-tests/src/test/java/io/quarkiverse/mcp/server/stdio/it/SubscriptionsListenIT.java
@@ -1,0 +1,62 @@
+package io.quarkiverse.mcp.server.stdio.it;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkiverse.mcp.server.test.McpAssured.McpStdioTestClient;
+import io.vertx.core.json.JsonObject;
+
+public class SubscriptionsListenIT {
+
+    @Test
+    public void testToolsListChanged() {
+        try (McpStdioTestClient client = McpAssured.newStdioClient()
+                .setStateless()
+                .build()
+                .connect()) {
+
+            // Send subscriptions/listen with toolsListChanged filter
+            JsonObject listenRequest = client.newRequest("subscriptions/listen");
+            listenRequest.put("params", new JsonObject()
+                    .put("notifications", new JsonObject().put("toolsListChanged", true)));
+            McpAssured.injectStatelessMeta(listenRequest);
+            client.sendAndForget(listenRequest);
+
+            // Wait for the acknowledged notification
+            List<JsonObject> notifications = client.waitForNotifications(1).notifications();
+            JsonObject ack = notifications.get(0);
+            assertEquals("notifications/subscriptions/acknowledged", ack.getString("method"));
+            JsonObject ackParams = ack.getJsonObject("params");
+            assertNotNull(ackParams);
+            JsonObject meta = ackParams.getJsonObject("_meta");
+            assertNotNull(meta);
+            assertNotNull(meta.getValue("io.modelcontextprotocol/subscriptionId"));
+
+            // Call toLowerCase — its handler registers a new tool, triggering list_changed
+            client.when()
+                    .toolsCall("toLowerCase", Map.of("value", "HELLO"), r -> {
+                        assertFalse(r.isError());
+                        assertEquals("hello", r.firstContent().asText().text());
+                    })
+                    .thenAssertResults();
+
+            // Wait for the tools/list_changed notification
+            notifications = client.waitForNotifications(2).notifications();
+            JsonObject listChanged = notifications.get(1);
+            assertEquals("notifications/tools/list_changed", listChanged.getString("method"));
+            // Verify subscriptionId is injected
+            JsonObject listChangedMeta = listChanged.getJsonObject("params").getJsonObject("_meta");
+            assertNotNull(listChangedMeta);
+            assertEquals(listenRequest.getValue("id"),
+                    listChangedMeta.getValue("io.modelcontextprotocol/subscriptionId"));
+        }
+    }
+
+}

--- a/transports/stdio/runtime/src/main/java/io/quarkiverse/mcp/server/stdio/runtime/StdioMcpConnection.java
+++ b/transports/stdio/runtime/src/main/java/io/quarkiverse/mcp/server/stdio/runtime/StdioMcpConnection.java
@@ -19,7 +19,12 @@ public class StdioMcpConnection extends McpConnectionBase {
     private final Vertx vertx;
 
     StdioMcpConnection(String id, McpServerRuntimeConfig serverConfig, PrintStream out, Vertx vertx) {
-        super(id, serverConfig, McpServer.DEFAULT);
+        this(id, serverConfig, out, vertx, false);
+    }
+
+    StdioMcpConnection(String id, McpServerRuntimeConfig serverConfig, PrintStream out, Vertx vertx,
+            boolean transientConnection) {
+        super(id, serverConfig, McpServer.DEFAULT, transientConnection);
         this.out = out;
         this.vertx = vertx;
     }

--- a/transports/stdio/runtime/src/main/java/io/quarkiverse/mcp/server/stdio/runtime/StdioMcpMessageHandler.java
+++ b/transports/stdio/runtime/src/main/java/io/quarkiverse/mcp/server/stdio/runtime/StdioMcpMessageHandler.java
@@ -19,10 +19,13 @@ import jakarta.inject.Singleton;
 import org.jboss.logging.Logger;
 
 import io.quarkiverse.mcp.server.InitialCheck;
+import io.quarkiverse.mcp.server.InitialRequest;
 import io.quarkiverse.mcp.server.InitialRequest.Transport;
 import io.quarkiverse.mcp.server.InitialResponseInfo;
 import io.quarkiverse.mcp.server.JsonRpcErrorCodes;
+import io.quarkiverse.mcp.server.McpException;
 import io.quarkiverse.mcp.server.McpServer;
+import io.quarkiverse.mcp.server.MetaKey;
 import io.quarkiverse.mcp.server.runtime.CancellationRequests;
 import io.quarkiverse.mcp.server.runtime.ConnectionManager;
 import io.quarkiverse.mcp.server.runtime.ContextSupport;
@@ -32,6 +35,7 @@ import io.quarkiverse.mcp.server.runtime.McpMetrics;
 import io.quarkiverse.mcp.server.runtime.McpRequestImpl;
 import io.quarkiverse.mcp.server.runtime.McpRequestValidator;
 import io.quarkiverse.mcp.server.runtime.McpTracing;
+import io.quarkiverse.mcp.server.runtime.Messages;
 import io.quarkiverse.mcp.server.runtime.NotificationManagerImpl;
 import io.quarkiverse.mcp.server.runtime.PromptCompletionManagerImpl;
 import io.quarkiverse.mcp.server.runtime.PromptManagerImpl;
@@ -125,9 +129,31 @@ public class StdioMcpMessageHandler extends McpMessageHandler<StdioMcpRequest> {
                             context.executeBlocking(new Callable<>() {
                                 @Override
                                 public Object call() throws Exception {
-                                    StdioMcpRequest mcpRequest = new StdioMcpRequest(McpServer.DEFAULT, message, connection,
-                                            connection, null, null,
-                                            null);
+                                    StdioMcpConnection requestConnection;
+                                    JsonObject meta = findMeta(message);
+                                    if (isStatelessMessage(message, meta)) {
+                                        requestConnection = new StdioMcpConnection(ConnectionManager.connectionId(),
+                                                serverConfig, stdout, vertx, true);
+                                        String metaVersion = meta != null
+                                                ? meta.getString(MetaKey.PROTOCOL_VERSION.toString())
+                                                : null;
+                                        InitialRequest initialRequest;
+                                        try {
+                                            initialRequest = buildStatelessInitialRequest(meta, metaVersion,
+                                                    Transport.STDIO);
+                                            applyMetaLogLevel(meta, requestConnection);
+                                        } catch (McpException e) {
+                                            requestConnection.sendError(Messages.getId(message), e.getJsonRpcErrorCode(),
+                                                    e.getMessage());
+                                            return null;
+                                        }
+                                        requestConnection.initialize(initialRequest);
+                                        requestConnection.setInitialized();
+                                    } else {
+                                        requestConnection = connection;
+                                    }
+                                    StdioMcpRequest mcpRequest = new StdioMcpRequest(McpServer.DEFAULT, message,
+                                            requestConnection, requestConnection, null, null, null);
                                     handle(mcpRequest);
                                     return null;
                                 }

--- a/transports/stdio/runtime/src/main/java/io/quarkiverse/mcp/server/stdio/runtime/StdioMcpMessageHandler.java
+++ b/transports/stdio/runtime/src/main/java/io/quarkiverse/mcp/server/stdio/runtime/StdioMcpMessageHandler.java
@@ -132,7 +132,7 @@ public class StdioMcpMessageHandler extends McpMessageHandler<StdioMcpRequest> {
                                     StdioMcpConnection requestConnection;
                                     JsonObject meta = findMeta(message);
                                     if (isStatelessMessage(message, meta)) {
-                                        requestConnection = new StdioMcpConnection(ConnectionManager.connectionId(),
+                                        requestConnection = new StdioMcpConnection(ConnectionManager.transientConnectionId(),
                                                 serverConfig, stdout, vertx, true);
                                         String metaVersion = meta != null
                                                 ? meta.getString(MetaKey.PROTOCOL_VERSION.toString())

--- a/transports/websocket/deployment/src/test/java/io/quarkiverse/mcp/server/websocket/test/stateless/StatelessTest.java
+++ b/transports/websocket/deployment/src/test/java/io/quarkiverse/mcp/server/websocket/test/stateless/StatelessTest.java
@@ -1,0 +1,154 @@
+package io.quarkiverse.mcp.server.websocket.test.stateless;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.McpConnection;
+import io.quarkiverse.mcp.server.McpLog.LogLevel;
+import io.quarkiverse.mcp.server.McpProtocolVersion;
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.runtime.ConnectionManager;
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkiverse.mcp.server.test.McpAssured.McpWebSocketTestClient;
+import io.quarkiverse.mcp.server.websocket.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class StatelessTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .withApplicationRoot(root -> root.addClass(MyTools.class));
+
+    @Inject
+    ConnectionManager connectionManager;
+
+    @Test
+    public void testServerDiscover() {
+        McpWebSocketTestClient client = McpAssured.newWebSocketClient()
+                .setStateless()
+                .build()
+                .connect(initResult -> {
+                    assertNotNull(initResult);
+                    assertNotNull(initResult.capabilities());
+                    assertNotNull(initResult.implementation());
+                });
+        assertTrue(client.isConnected());
+        client.disconnect();
+    }
+
+    @Test
+    public void testToolsList() {
+        McpWebSocketTestClient client = McpAssured.newWebSocketClient()
+                .setStateless()
+                .build()
+                .connect();
+
+        client.when()
+                .toolsList(tools -> {
+                    assertNotNull(tools);
+                    assertTrue(tools.size() > 0);
+                    assertNotNull(tools.findByName("echo"));
+                })
+                .thenAssertResults();
+        client.disconnect();
+    }
+
+    @Test
+    public void testToolsCall() {
+        McpWebSocketTestClient client = McpAssured.newWebSocketClient()
+                .setStateless()
+                .build()
+                .connect();
+
+        client.when()
+                .toolsCall("echo", Map.of("message", "hello stateless"), r -> {
+                    assertFalse(r.isError());
+                    assertEquals("hello stateless", r.firstContent().asText().text());
+                })
+                .thenAssertResults();
+        client.disconnect();
+    }
+
+    @Test
+    public void testToolCallWithConnectionAccess() {
+        McpWebSocketTestClient client = McpAssured.newWebSocketClient()
+                .setStateless()
+                .build()
+                .connect();
+
+        client.when()
+                .toolsCall("protocolInfo", r -> {
+                    assertFalse(r.isError());
+                    assertEquals(McpProtocolVersion.FIRST_STATELESS.version() + ":true:true",
+                            r.firstContent().asText().text());
+                })
+                .thenAssertResults();
+        client.disconnect();
+    }
+
+    @Test
+    public void testPerRequestLogLevel() {
+        McpWebSocketTestClient client = McpAssured.newWebSocketClient()
+                .setStateless()
+                .build()
+                .connect();
+
+        client.when()
+                .toolsCall("logLevelInfo")
+                .withMetadata(Map.of("io.modelcontextprotocol/logLevel", "warning"))
+                .withAssert(r -> {
+                    assertFalse(r.isError());
+                    assertEquals(LogLevel.WARNING.name(), r.firstContent().asText().text());
+                })
+                .send()
+                .thenAssertResults();
+        client.disconnect();
+    }
+
+    @Test
+    public void testRemovedMethodRejected() {
+        McpWebSocketTestClient client = McpAssured.newWebSocketClient()
+                .setStateless()
+                .build()
+                .connect();
+
+        client.when()
+                .ping()
+                .withErrorAssert(error -> {
+                    assertEquals(-32601, error.code());
+                })
+                .send()
+                .thenAssertResults();
+        client.disconnect();
+    }
+
+    public static class MyTools {
+
+        @Tool
+        String echo(String message) {
+            return message;
+        }
+
+        @Tool
+        String protocolInfo(McpConnection connection) {
+            String version = connection.initialRequest().protocolVersion();
+            boolean stateless = McpProtocolVersion.isStateless(version);
+            return version + ":" + stateless + ":" + connection.isTransient();
+        }
+
+        @Tool
+        String logLevelInfo(McpConnection connection) {
+            return connection.logLevel().name();
+        }
+    }
+
+}

--- a/transports/websocket/deployment/src/test/java/io/quarkiverse/mcp/server/websocket/test/stateless/StatelessTest.java
+++ b/transports/websocket/deployment/src/test/java/io/quarkiverse/mcp/server/websocket/test/stateless/StatelessTest.java
@@ -140,9 +140,8 @@ public class StatelessTest extends McpServerTest {
 
         @Tool
         String protocolInfo(McpConnection connection) {
-            String version = connection.initialRequest().protocolVersion();
-            boolean stateless = McpProtocolVersion.isStateless(version);
-            return version + ":" + stateless + ":" + connection.isTransient();
+            McpProtocolVersion version = connection.initialRequest().protocolVersion();
+            return version.version() + ":" + version.isStateless() + ":" + connection.isTransient();
         }
 
         @Tool

--- a/transports/websocket/deployment/src/test/java/io/quarkiverse/mcp/server/websocket/test/subscription/SubscriptionsListenTest.java
+++ b/transports/websocket/deployment/src/test/java/io/quarkiverse/mcp/server/websocket/test/subscription/SubscriptionsListenTest.java
@@ -1,0 +1,129 @@
+package io.quarkiverse.mcp.server.websocket.test.subscription;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.RequestUri;
+import io.quarkiverse.mcp.server.Resource;
+import io.quarkiverse.mcp.server.TextContent;
+import io.quarkiverse.mcp.server.TextResourceContents;
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolManager;
+import io.quarkiverse.mcp.server.ToolResponse;
+import io.quarkiverse.mcp.server.runtime.ConnectionManager;
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkiverse.mcp.server.test.McpAssured.McpWebSocketTestClient;
+import io.quarkiverse.mcp.server.websocket.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.json.JsonObject;
+
+public class SubscriptionsListenTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .withApplicationRoot(root -> root.addClasses(MyTools.class, MyResources.class));
+
+    @Inject
+    ToolManager toolManager;
+
+    @Inject
+    ConnectionManager connectionManager;
+
+    @Test
+    public void testToolsListChanged() {
+        McpWebSocketTestClient client = McpAssured.newWebSocketClient()
+                .setStateless()
+                .build()
+                .connect();
+
+        JsonObject listenRequest = client.newRequest("subscriptions/listen");
+        listenRequest.put("params", new JsonObject()
+                .put("notifications", new JsonObject().put("toolsListChanged", true)));
+        McpAssured.injectStatelessMeta(listenRequest);
+        client.sendAndForget(listenRequest);
+
+        List<JsonObject> notifications = client.waitForNotifications(1).notifications();
+        JsonObject ack = notifications.get(0);
+        assertEquals("notifications/subscriptions/acknowledged", ack.getString("method"));
+        JsonObject ackParams = ack.getJsonObject("params");
+        assertNotNull(ackParams);
+        assertTrue(ackParams.getJsonObject("notifications").getBoolean("toolsListChanged"));
+        JsonObject meta = ackParams.getJsonObject("_meta");
+        assertNotNull(meta);
+        assertNotNull(meta.getValue("io.modelcontextprotocol/subscriptionId"));
+
+        // Transient connection should be registered in ConnectionManager
+        assertTrue(connectionManager.iterator().hasNext());
+
+        toolManager.newTool("dynamic")
+                .setDescription("A dynamically registered tool")
+                .setHandler(args -> ToolResponse.success(new TextContent("dynamic")))
+                .register();
+
+        notifications = client.waitForNotifications(2).notifications();
+        JsonObject listChanged = notifications.get(1);
+        assertEquals("notifications/tools/list_changed", listChanged.getString("method"));
+        JsonObject listChangedMeta = listChanged.getJsonObject("params").getJsonObject("_meta");
+        assertNotNull(listChangedMeta);
+        assertEquals(listenRequest.getValue("id"),
+                listChangedMeta.getValue("io.modelcontextprotocol/subscriptionId"));
+
+        client.disconnect();
+    }
+
+    @Test
+    public void testFilteringNonMatching() {
+        McpWebSocketTestClient client = McpAssured.newWebSocketClient()
+                .setStateless()
+                .build()
+                .connect();
+
+        JsonObject listenRequest = client.newRequest("subscriptions/listen");
+        listenRequest.put("params", new JsonObject()
+                .put("notifications", new JsonObject().put("promptsListChanged", true)));
+        McpAssured.injectStatelessMeta(listenRequest);
+        client.sendAndForget(listenRequest);
+
+        client.waitForNotifications(1);
+
+        toolManager.newTool("filteredTool")
+                .setDescription("Should not trigger notification on this subscription")
+                .setHandler(args -> ToolResponse.success(new TextContent("filtered")))
+                .register();
+
+        try {
+            Thread.sleep(500);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        assertEquals(1, client.snapshot().notifications().size());
+
+        client.disconnect();
+    }
+
+    public static class MyTools {
+
+        @Tool
+        String echo(String message) {
+            return message;
+        }
+    }
+
+    public static class MyResources {
+
+        @Resource(uri = "file:///file1.txt")
+        TextResourceContents file1(RequestUri uri) {
+            return new TextResourceContents(uri.value(), "File 1", null);
+        }
+    }
+
+}

--- a/transports/websocket/runtime/src/main/java/io/quarkiverse/mcp/server/websocket/runtime/WebSocketMcpConnection.java
+++ b/transports/websocket/runtime/src/main/java/io/quarkiverse/mcp/server/websocket/runtime/WebSocketMcpConnection.java
@@ -12,7 +12,12 @@ public class WebSocketMcpConnection extends McpConnectionBase {
     private final WebSocketConnection connection;
 
     WebSocketMcpConnection(String id, McpServerRuntimeConfig serverConfig, String serverName, WebSocketConnection connection) {
-        super(id, serverConfig, serverName);
+        this(id, serverConfig, serverName, connection, false);
+    }
+
+    WebSocketMcpConnection(String id, McpServerRuntimeConfig serverConfig, String serverName, WebSocketConnection connection,
+            boolean transientConnection) {
+        super(id, serverConfig, serverName, transientConnection);
         this.connection = connection;
     }
 

--- a/transports/websocket/runtime/src/main/java/io/quarkiverse/mcp/server/websocket/runtime/WebSocketMcpConnection.java
+++ b/transports/websocket/runtime/src/main/java/io/quarkiverse/mcp/server/websocket/runtime/WebSocketMcpConnection.java
@@ -21,6 +21,10 @@ public class WebSocketMcpConnection extends McpConnectionBase {
         this.connection = connection;
     }
 
+    WebSocketConnection webSocketConnection() {
+        return connection;
+    }
+
     @Override
     public Future<Void> send(JsonObject message) {
         if (message == null) {

--- a/transports/websocket/runtime/src/main/java/io/quarkiverse/mcp/server/websocket/runtime/WebSocketMcpMessageHandler.java
+++ b/transports/websocket/runtime/src/main/java/io/quarkiverse/mcp/server/websocket/runtime/WebSocketMcpMessageHandler.java
@@ -116,7 +116,7 @@ public abstract class WebSocketMcpMessageHandler extends McpMessageHandler<WebSo
         WebSocketMcpConnection mcpConnection;
         JsonObject meta = findMeta(jsonMessage);
         if (isStatelessMessage(jsonMessage, meta)) {
-            mcpConnection = new WebSocketMcpConnection(ConnectionManager.connectionId(),
+            mcpConnection = new WebSocketMcpConnection(ConnectionManager.transientConnectionId(),
                     config.servers().get(serverName()), serverName(), connection, true);
             String metaVersion = meta != null ? meta.getString(MetaKey.PROTOCOL_VERSION.toString()) : null;
             InitialRequest initialRequest;

--- a/transports/websocket/runtime/src/main/java/io/quarkiverse/mcp/server/websocket/runtime/WebSocketMcpMessageHandler.java
+++ b/transports/websocket/runtime/src/main/java/io/quarkiverse/mcp/server/websocket/runtime/WebSocketMcpMessageHandler.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.mcp.server.websocket.runtime;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -17,6 +18,7 @@ import io.quarkiverse.mcp.server.MetaKey;
 import io.quarkiverse.mcp.server.runtime.CancellationRequests;
 import io.quarkiverse.mcp.server.runtime.ConnectionManager;
 import io.quarkiverse.mcp.server.runtime.ContextSupport;
+import io.quarkiverse.mcp.server.runtime.McpConnectionBase;
 import io.quarkiverse.mcp.server.runtime.McpMessageHandler;
 import io.quarkiverse.mcp.server.runtime.McpMetadata;
 import io.quarkiverse.mcp.server.runtime.McpMetrics;
@@ -143,6 +145,19 @@ public abstract class WebSocketMcpMessageHandler extends McpMessageHandler<WebSo
         if (mcpConnection != null) {
             connectionManager.remove(mcpConnection.id());
             LOG.debugf("MCP WebSocket connection closed [mcpId: %s, id: %s]", mcpConnection.id(), connection.id());
+        }
+        // Clean up any transient subscription connections registered for this WebSocket
+        List<String> toRemove = new ArrayList<>();
+        for (McpConnectionBase c : connectionManager) {
+            if (c instanceof WebSocketMcpConnection wsc
+                    && wsc.webSocketConnection().id().equals(connection.id())
+                    && wsc.isTransient()) {
+                toRemove.add(c.id());
+            }
+        }
+        for (String id : toRemove) {
+            connectionManager.remove(id);
+            LOG.debugf("Transient subscription connection removed [mcpId: %s, wsId: %s]", id, connection.id());
         }
     }
 

--- a/transports/websocket/runtime/src/main/java/io/quarkiverse/mcp/server/websocket/runtime/WebSocketMcpMessageHandler.java
+++ b/transports/websocket/runtime/src/main/java/io/quarkiverse/mcp/server/websocket/runtime/WebSocketMcpMessageHandler.java
@@ -9,8 +9,11 @@ import jakarta.enterprise.inject.Instance;
 import org.jboss.logging.Logger;
 
 import io.quarkiverse.mcp.server.InitialCheck;
+import io.quarkiverse.mcp.server.InitialRequest;
 import io.quarkiverse.mcp.server.InitialRequest.Transport;
 import io.quarkiverse.mcp.server.InitialResponseInfo;
+import io.quarkiverse.mcp.server.McpException;
+import io.quarkiverse.mcp.server.MetaKey;
 import io.quarkiverse.mcp.server.runtime.CancellationRequests;
 import io.quarkiverse.mcp.server.runtime.ConnectionManager;
 import io.quarkiverse.mcp.server.runtime.ContextSupport;
@@ -20,6 +23,7 @@ import io.quarkiverse.mcp.server.runtime.McpMetrics;
 import io.quarkiverse.mcp.server.runtime.McpRequestImpl;
 import io.quarkiverse.mcp.server.runtime.McpRequestValidator;
 import io.quarkiverse.mcp.server.runtime.McpTracing;
+import io.quarkiverse.mcp.server.runtime.Messages;
 import io.quarkiverse.mcp.server.runtime.NotificationManagerImpl;
 import io.quarkiverse.mcp.server.runtime.PromptCompletionManagerImpl;
 import io.quarkiverse.mcp.server.runtime.PromptManagerImpl;
@@ -92,7 +96,6 @@ public abstract class WebSocketMcpMessageHandler extends McpMessageHandler<WebSo
     @SuppressWarnings("unchecked")
     @OnTextMessage
     Uni<Void> consumeMessage(WebSocketConnection connection, String message) throws InterruptedException {
-        WebSocketMcpConnection mcpConnection = connections.computeIfAbsent(connection.id(), k -> newConnection(connection));
         JsonObject jsonMessage = (JsonObject) Json.decodeValue(message);
 
         SecuritySupport securitySupport;
@@ -106,6 +109,26 @@ public abstract class WebSocketMcpMessageHandler extends McpMessageHandler<WebSo
             };
         } else {
             securitySupport = null;
+        }
+
+        WebSocketMcpConnection mcpConnection;
+        JsonObject meta = findMeta(jsonMessage);
+        if (isStatelessMessage(jsonMessage, meta)) {
+            mcpConnection = new WebSocketMcpConnection(ConnectionManager.connectionId(),
+                    config.servers().get(serverName()), serverName(), connection, true);
+            String metaVersion = meta != null ? meta.getString(MetaKey.PROTOCOL_VERSION.toString()) : null;
+            InitialRequest initialRequest;
+            try {
+                initialRequest = buildStatelessInitialRequest(meta, metaVersion, Transport.WEBSOCKET);
+                applyMetaLogLevel(meta, mcpConnection);
+            } catch (McpException e) {
+                return (Uni<Void>) UniHelper
+                        .toUni(mcpConnection.sendError(Messages.getId(jsonMessage), e.getJsonRpcErrorCode(), e.getMessage()));
+            }
+            mcpConnection.initialize(initialRequest);
+            mcpConnection.setInitialized();
+        } else {
+            mcpConnection = connections.computeIfAbsent(connection.id(), k -> newConnection(connection));
         }
 
         WebSocketMcpRequest mcpRequest = new WebSocketMcpRequest(serverName(), jsonMessage, mcpConnection, securitySupport,


### PR DESCRIPTION
This pull request includes the initial support for various features/breaking changes introduced in the latest DRAFT of the spec (`2026-07-28-RC`+).

Our plan is to merge this as soon as possible and release 2.0.0.Beta1 to get some feedback from users.