### PR TITLE
Reflect quarkus.mcp-server.metrics.enabled in MicrometerMcpMetrics

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/MicrometerMcpMetrics.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/MicrometerMcpMetrics.java
@@ -12,6 +12,8 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
 import io.quarkiverse.mcp.server.McpMethod;
+import io.quarkiverse.mcp.server.runtime.config.McpServerRuntimeConfig;
+import io.quarkiverse.mcp.server.runtime.config.McpServersRuntimeConfig;
 import io.vertx.core.json.JsonObject;
 
 @Singleton
@@ -27,11 +29,13 @@ public class MicrometerMcpMetrics implements McpMetrics {
     private static final String NONE = "none";
 
     private final Map<McpMethod, String> mcpMethodNames;
+    private final McpServersRuntimeConfig config;
 
     @Inject
     MeterRegistry meterRegistry;
 
-    MicrometerMcpMetrics() {
+    MicrometerMcpMetrics(McpServersRuntimeConfig config) {
+        this.config = config;
         // Note that we can't use a timer with the same name but a different set of tags
         // https://docs.micrometer.io/micrometer/reference/implementations/prometheus.html#_limitation_on_same_name_with_different_set_of_tag_keys
         mcpMethodNames = new EnumMap<>(McpMethod.class);
@@ -42,12 +46,20 @@ public class MicrometerMcpMetrics implements McpMetrics {
 
     @Override
     public <T> void createMcpConnectionsGauge(T stateObject, ToDoubleFunction<T> valueFunction) {
-        meterRegistry.gauge(MCP_SERVER_CONNECTIONS_ACTIVE, stateObject, valueFunction);
+        for (McpServerRuntimeConfig serverConfig : config.servers().values()) {
+            if (serverConfig.metricsEnabled()) {
+                meterRegistry.gauge(MCP_SERVER_CONNECTIONS_ACTIVE, stateObject, valueFunction);
+                break;
+            }
+        }
     }
 
     @Override
     public void mcpRequestCompleted(McpMethod method, JsonObject message, McpRequest mcpRequest, long duration,
             Throwable failure) {
+        if (!config.servers().get(mcpRequest.serverName()).metricsEnabled()) {
+            return;
+        }
         Timer.builder(mcpMethodNames.get(method))
                 .tags(MCP_SERVER, mcpRequest.serverName(), FAILURE, failure(failure))
                 .tags(createTags(method, message, mcpRequest))

--- a/docs/modules/ROOT/pages/release-notes.adoc
+++ b/docs/modules/ROOT/pages/release-notes.adoc
@@ -19,6 +19,7 @@ include::./includes/attributes.adoc[]
 * [2.0.0] The Maven artifact relocations and configuration property fallbacks for the old `quarkus-mcp-server-sse` artifact (renamed to `quarkus-mcp-server-http` in <<version-1-8,1.8.0>>) have been removed. Users still referencing `quarkus-mcp-server-sse` must switch to `quarkus-mcp-server-http`, and any configuration properties using the `sse.` prefix (e.g. `quarkus.mcp.server.sse.root-path`) must be updated to use the `http.` prefix (e.g. `quarkus.mcp.server.http.root-path`). (https://github.com/quarkiverse/quarkus-mcp-server/issues/826[#826])
 * [2.0.0] JSON-RPC batching support has been removed. Batching was added in MCP 2025-03-26 and removed in 2025-06-18. The server now rejects batch (JSON array) messages with a parse error. The `whenBatch()` method has been removed from the `McpAssured` test API. (https://github.com/quarkiverse/quarkus-mcp-server/issues/723[#723])
 * [2.0.0] `McpRequest.protocolVersion()` now returns `McpProtocolVersion` instead of `String`.
+* [2.0.0] The `quarkus.mcp-server.metrics.enabled` config property is now read at runtime. Since it defaults to `false`, applications that rely on MCP metrics without explicitly setting `quarkus.mcp-server.metrics.enabled=true` will stop collecting them. (https://github.com/quarkiverse/quarkus-mcp-server/issues/844[#844])
 
 [[version-2-0-features]]
 === New Features

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/metrics/MetricsDisabledTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/metrics/MetricsDisabledTest.java
@@ -1,0 +1,58 @@
+package io.quarkiverse.mcp.server.test.metrics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolArg;
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkiverse.mcp.server.test.McpAssured.McpStreamableTestClient;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MetricsDisabledTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = defaultConfig()
+            .withApplicationRoot(root -> root
+                    .addClasses(MyFeatures.class));
+
+    @Inject
+    MeterRegistry registry;
+
+    @BeforeAll
+    static void addSimpleRegistry() {
+        Metrics.globalRegistry.add(new SimpleMeterRegistry());
+    }
+
+    @Test
+    void testMetricsDisabledByDefault() {
+        McpStreamableTestClient client = McpAssured.newConnectedStreamableClient();
+        client.when()
+                .toolsCall("alpha", toolResponse -> {
+                    assertEquals("20", toolResponse.firstContent().asText().text());
+                })
+                .thenAssertResults();
+
+        assertNull(registry.find("mcp.server.connections.active").gauge());
+        assertNull(registry.find("mcp.server.requests.tools.call").timer());
+    }
+
+    public static class MyFeatures {
+
+        @Tool
+        String alpha(@ToolArg(defaultValue = "10") int price) {
+            return "" + price * 2;
+        }
+    }
+
+}


### PR DESCRIPTION
- fixes #844
- quarkus.mcp-server.metrics.enabled was never read at runtime, so metrics were always recorded when Micrometer was present
- now MicrometerMcpMetrics checks the per-server config
- createMcpConnectionsGauge() registers the gauge only if at least one server has metrics enabled
- mcpRequestCompleted() skips recording for servers with metrics disabled
- compatibility note: metrics are disabled by default, so existing applications that rely on MCP metrics without explicitly setting quarkus.mcp-server.metrics.enabled=true will stop collecting them