### PR TITLE
Reflect quarkus.mcp-server.metrics.enabled in MicrometerMcpMetrics [1.10.x]

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/MicrometerMcpMetrics.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/MicrometerMcpMetrics.java
@@ -12,6 +12,8 @@ import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
 import io.quarkiverse.mcp.server.McpMethod;
+import io.quarkiverse.mcp.server.runtime.config.McpServerRuntimeConfig;
+import io.quarkiverse.mcp.server.runtime.config.McpServersRuntimeConfig;
 import io.vertx.core.json.JsonObject;
 
 @Singleton
@@ -27,11 +29,13 @@ public class MicrometerMcpMetrics implements McpMetrics {
     private static final String NONE = "none";
 
     private final Map<McpMethod, String> mcpMethodNames;
+    private final McpServersRuntimeConfig config;
 
     @Inject
     MeterRegistry meterRegistry;
 
-    MicrometerMcpMetrics() {
+    MicrometerMcpMetrics(McpServersRuntimeConfig config) {
+        this.config = config;
         // Note that we can't use a timer with the same name but a different set of tags
         // https://docs.micrometer.io/micrometer/reference/implementations/prometheus.html#_limitation_on_same_name_with_different_set_of_tag_keys
         mcpMethodNames = new EnumMap<>(McpMethod.class);
@@ -42,12 +46,20 @@ public class MicrometerMcpMetrics implements McpMetrics {
 
     @Override
     public <T> void createMcpConnectionsGauge(T stateObject, ToDoubleFunction<T> valueFunction) {
-        meterRegistry.gauge(MCP_SERVER_CONNECTIONS_ACTIVE, stateObject, valueFunction);
+        for (McpServerRuntimeConfig serverConfig : config.servers().values()) {
+            if (serverConfig.metricsEnabled()) {
+                meterRegistry.gauge(MCP_SERVER_CONNECTIONS_ACTIVE, stateObject, valueFunction);
+                break;
+            }
+        }
     }
 
     @Override
     public void mcpRequestCompleted(McpMethod method, JsonObject message, McpRequest mcpRequest, long duration,
             Throwable failure) {
+        if (!config.servers().get(mcpRequest.serverName()).metricsEnabled()) {
+            return;
+        }
         Timer.builder(mcpMethodNames.get(method))
                 .tags(MCP_SERVER, mcpRequest.serverName(), FAILURE, failure(failure))
                 .tags(createTags(method, message, mcpRequest))

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/metrics/MetricsDisabledTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/metrics/MetricsDisabledTest.java
@@ -1,0 +1,58 @@
+package io.quarkiverse.mcp.server.test.metrics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolArg;
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkiverse.mcp.server.test.McpAssured.McpStreamableTestClient;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class MetricsDisabledTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest test = defaultConfig()
+            .withApplicationRoot(root -> root
+                    .addClasses(MyFeatures.class));
+
+    @Inject
+    MeterRegistry registry;
+
+    @BeforeAll
+    static void addSimpleRegistry() {
+        Metrics.globalRegistry.add(new SimpleMeterRegistry());
+    }
+
+    @Test
+    void testMetricsDisabledByDefault() {
+        McpStreamableTestClient client = McpAssured.newConnectedStreamableClient();
+        client.when()
+                .toolsCall("alpha", toolResponse -> {
+                    assertEquals("20", toolResponse.firstContent().asText().text());
+                })
+                .thenAssertResults();
+
+        assertNull(registry.find("mcp.server.connections.active").gauge());
+        assertNull(registry.find("mcp.server.requests.tools.call").timer());
+    }
+
+    public static class MyFeatures {
+
+        @Tool
+        String alpha(@ToolArg(defaultValue = "10") int price) {
+            return "" + price * 2;
+        }
+    }
+
+}


### PR DESCRIPTION
- backport of b0e21217 from main
- fixes #844