### PR TITLE
Tracing spans include mcp.server.name and respect per-server config [1.13.x]

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/tracing/McpRequestInfo.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/tracing/McpRequestInfo.java
@@ -82,4 +82,8 @@ public class McpRequestInfo {
     void setAmbientContext(Context ambientContext) {
         this.ambientContext = ambientContext;
     }
+
+    public String getServerName() {
+        return mcpRequest.serverName();
+    }
 }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/tracing/McpTracingInstrumenter.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/tracing/McpTracingInstrumenter.java
@@ -29,7 +29,6 @@ import io.opentelemetry.semconv.incubating.GenAiIncubatingAttributes;
 import io.opentelemetry.semconv.incubating.RpcIncubatingAttributes;
 import io.quarkiverse.mcp.server.InitialRequest;
 import io.quarkiverse.mcp.server.McpMethod;
-import io.quarkiverse.mcp.server.McpServer;
 import io.quarkiverse.mcp.server.runtime.McpRequest;
 import io.quarkiverse.mcp.server.runtime.McpTracing;
 import io.quarkiverse.mcp.server.runtime.McpTracingSpan;
@@ -46,14 +45,19 @@ public class McpTracingInstrumenter implements McpTracing {
     private static final AttributeKey<String> MCP_SESSION_ID = AttributeKey.stringKey("mcp.session.id");
     private static final AttributeKey<String> MCP_PROTOCOL_VERSION = AttributeKey.stringKey("mcp.protocol.version");
     private static final AttributeKey<String> MCP_RESOURCE_URI = AttributeKey.stringKey("mcp.resource.uri");
+    private static final AttributeKey<String> MCP_SERVER_NAME = AttributeKey.stringKey("mcp.server.name");
     private static final AttributeKey<String> GEN_AI_PROMPT_NAME = AttributeKey.stringKey("gen_ai.prompt.name");
 
     private final Instrumenter<McpRequestInfo, McpResponseInfo> instrumenter;
     private final OpenTelemetry openTelemetry;
+    private final McpServersRuntimeConfig mcpConfig;
+    private final boolean otelSdkDisabled;
 
     public McpTracingInstrumenter(OpenTelemetry openTelemetry, OTelRuntimeConfig otelConfig,
             McpServersRuntimeConfig mcpConfig) {
         this.openTelemetry = openTelemetry;
+        this.mcpConfig = mcpConfig;
+        this.otelSdkDisabled = otelConfig.sdkDisabled();
 
         InstrumenterBuilder<McpRequestInfo, McpResponseInfo> builder = Instrumenter.builder(
                 openTelemetry,
@@ -63,8 +67,7 @@ public class McpTracingInstrumenter implements McpTracing {
         builder.addAttributesExtractor(new McpAttributesExtractor())
                 .setSpanStatusExtractor(new McpSpanStatusExtractor())
                 .addSpanLinksExtractor(new McpAmbientContextLinksExtractor())
-                .setEnabled(!otelConfig.sdkDisabled()
-                        && mcpConfig.servers().get(McpServer.DEFAULT).tracingEnabled());
+                .setEnabled(!otelSdkDisabled);
 
         // Use buildInstrumenter with SERVER kind instead of buildServerInstrumenter
         // to avoid nested server span suppression (Quarkus HTTP already creates a server span)
@@ -79,6 +82,10 @@ public class McpTracingInstrumenter implements McpTracing {
     @Override
     public McpTracingSpan startSpan(McpMethod method, JsonObject message, McpRequest mcpRequest,
             InitialRequest.Transport transport) {
+        if (otelSdkDisabled
+                || !mcpConfig.servers().get(mcpRequest.serverName()).tracingEnabled()) {
+            return McpTracingSpan.NOOP;
+        }
         McpRequestInfo requestInfo = new McpRequestInfo(method, message, mcpRequest, transport);
 
         // Capture the ambient transport context (e.g., HTTP server span) before switching to root
@@ -179,6 +186,7 @@ public class McpTracingInstrumenter implements McpTracing {
         @Override
         public void onStart(AttributesBuilder attributes, Context parentContext, McpRequestInfo request) {
             // Required
+            attributes.put(MCP_SERVER_NAME, request.getServerName());
             attributes.put(MCP_METHOD_NAME, request.method().jsonRpcName());
 
             // Conditionally required - only for requests, not notifications

--- a/docs/modules/ROOT/pages/reference-observability.adoc
+++ b/docs/modules/ROOT/pages/reference-observability.adoc
@@ -38,6 +38,18 @@ Tracing is controlled by the following configuration property:
 quarkus.mcp.server.tracing.enabled=true
 ----
 
+For multiple servers, you must enable tracing for each server individually:
+
+[source,properties]
+----
+# Enable for default server
+quarkus.mcp.server.tracing.enabled=true
+
+# Enable for specific named servers
+quarkus.mcp.server."main-server".tracing.enabled=true
+quarkus.mcp.server."admin-server".tracing.enabled=true
+----
+
 === Span Naming
 
 Each MCP operation produces a `SERVER` span. The span name is the JSON-RPC method name, optionally followed by a resource identifier for specific operations:
@@ -74,6 +86,9 @@ All MCP spans include the following attributes:
 [cols="1,3"]
 |===
 | Attribute | Description
+
+| `mcp.server.name`
+| The name of the MCP server configuration (e.g., `<default>` for the default server, or a custom server name)
 
 | `mcp.method.name`
 | The JSON-RPC method name (e.g., `tools/call`, `prompts/get`)
@@ -403,6 +418,10 @@ public class MetricsMonitor {
 | `quarkus.mcp.server.tracing.enabled`
 | Enable tracing when OpenTelemetry is present
 | `false`
+
+| `quarkus.mcp.server."server-name".tracing.enabled`
+| Enable tracing for a specific server instance
+| Inherits from global setting
 
 | `quarkus.mcp.server.metrics.enabled`
 | Enable metrics collection when Micrometer is present

--- a/transports/http/tracing-integration-tests/src/test/java/io/quarkiverse/mcp/server/tracing/it/TracingClientWithoutOtelTest.java
+++ b/transports/http/tracing-integration-tests/src/test/java/io/quarkiverse/mcp/server/tracing/it/TracingClientWithoutOtelTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import io.quarkiverse.mcp.server.ClientCapability;
 import io.quarkiverse.mcp.server.ElicitationResponse;
 import io.quarkiverse.mcp.server.JsonRpcErrorCodes;
+import io.quarkiverse.mcp.server.McpServer;
 import io.quarkiverse.mcp.server.test.McpAssured;
 import io.quarkiverse.mcp.server.test.McpAssured.McpStreamableTestClient;
 import io.quarkiverse.mcp.server.test.McpAssured.PromptInfo;
@@ -133,6 +134,7 @@ class TracingClientWithoutOtelTest {
         assertNotNull(initialize.getJsonObject("attributes").getString("mcp.session.id"));
         final String mcpSessionId = initialize.getJsonObject("attributes").getString("mcp.session.id");
         assertEquals(client.mcpSessionId(), mcpSessionId);
+        assertEquals(McpServer.DEFAULT, initialize.getJsonObject("attributes").getString("mcp.server.name"));
         assertEquals("http", initialize.getJsonObject("attributes").getString("network.protocol.name"));
         assertEquals("tcp", initialize.getJsonObject("attributes").getString("network.transport"));
         assertEquals("2", initialize.getJsonObject("attributes").getString("network.protocol.version"));
@@ -144,6 +146,7 @@ class TracingClientWithoutOtelTest {
         assertNotNull(notifInitialized);
         assertEquals("0000000000000000", notifInitialized.getString("parent_spanId"));
         assertEquals(mcpSessionId, notifInitialized.getJsonObject("attributes").getString("mcp.session.id"));
+        assertEquals(McpServer.DEFAULT, notifInitialized.getJsonObject("attributes").getString("mcp.server.name"));
         assertEquals("http", notifInitialized.getJsonObject("attributes").getString("network.protocol.name"));
         assertEquals("tcp", notifInitialized.getJsonObject("attributes").getString("network.transport"));
         assertEquals("2", notifInitialized.getJsonObject("attributes").getString("network.protocol.version"));
@@ -154,6 +157,7 @@ class TracingClientWithoutOtelTest {
         assertEquals("0000000000000000", listSpan.getString("parent_spanId"));
         assertEquals("SERVER", listSpan.getString("kind"));
         assertEquals(mcpSessionId, listSpan.getJsonObject("attributes").getString("mcp.session.id"));
+        assertEquals(McpServer.DEFAULT, listSpan.getJsonObject("attributes").getString("mcp.server.name"));
         assertEquals("tools/list", listSpan.getJsonObject("attributes").getString("mcp.method.name"));
         assertNotNull(listSpan.getJsonObject("attributes").getString("rpc.jsonrpc.request_id"));
         assertNotNull(listSpan.getJsonObject("attributes").getString("mcp.protocol.version"));
@@ -167,6 +171,7 @@ class TracingClientWithoutOtelTest {
         assertEquals("0000000000000000", callSpan.getString("parent_spanId"));
         assertEquals("SERVER", callSpan.getString("kind"));
         assertEquals(mcpSessionId, callSpan.getJsonObject("attributes").getString("mcp.session.id"));
+        assertEquals(McpServer.DEFAULT, callSpan.getJsonObject("attributes").getString("mcp.server.name"));
         assertEquals("tools/call", callSpan.getJsonObject("attributes").getString("mcp.method.name"));
         assertEquals("toLowerCase", callSpan.getJsonObject("attributes").getString("gen_ai.tool.name"));
         assertEquals("execute_tool", callSpan.getJsonObject("attributes").getString("gen_ai.operation.name"));
@@ -183,6 +188,7 @@ class TracingClientWithoutOtelTest {
         assertEquals("0000000000000000", answerSpan.getString("parent_spanId"));
         assertEquals("SERVER", answerSpan.getString("kind"));
         assertEquals(mcpSessionId, answerSpan.getJsonObject("attributes").getString("mcp.session.id"));
+        assertEquals(McpServer.DEFAULT, answerSpan.getJsonObject("attributes").getString("mcp.server.name"));
         assertEquals("tools/call", answerSpan.getJsonObject("attributes").getString("mcp.method.name"));
         assertEquals("answer", answerSpan.getJsonObject("attributes").getString("gen_ai.tool.name"));
         assertEquals("execute_tool", answerSpan.getJsonObject("attributes").getString("gen_ai.operation.name"));

--- a/transports/http/tracing-integration-tests/src/test/java/io/quarkiverse/mcp/server/tracing/it/TracingMcpServerDisabledTest.java
+++ b/transports/http/tracing-integration-tests/src/test/java/io/quarkiverse/mcp/server/tracing/it/TracingMcpServerDisabledTest.java
@@ -1,0 +1,49 @@
+package io.quarkiverse.mcp.server.tracing.it;
+
+import static io.restassured.RestAssured.given;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkiverse.mcp.server.test.McpAssured.McpStreamableTestClient;
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestProfile;
+import io.quarkus.test.junit.TestProfile;
+import io.vertx.core.json.JsonArray;
+
+@QuarkusTest
+@TestProfile(TracingMcpServerDisabledTest.McpTracingDisabledProfile.class)
+class TracingMcpServerDisabledTest {
+
+    @Test
+    void testNoSpanWhenMcpTracingDisabled() {
+        McpStreamableTestClient client = McpAssured.newConnectedStreamableClient();
+        client.when()
+                .toolsCall("toLowerCase", Map.of("value", "HELLO"), r -> {
+                    assertEquals("hello", r.content().get(0).asText().text());
+                })
+                .thenAssertResults();
+
+        assertNoSpans();
+    }
+
+    private void assertNoSpans() {
+        JsonArray spans = new JsonArray(given().get("/spans").then().statusCode(200)
+                .extract().asString());
+        assertTrue(spans.isEmpty(),
+                "Expected no spans when MCP server tracing is disabled, but found: " + spans);
+    }
+
+    public static class McpTracingDisabledProfile implements QuarkusTestProfile {
+        @Override
+        public Map<String, String> getConfigOverrides() {
+            return Map.of(
+                    "quarkus.otel.sdk.disabled", "false",
+                    "quarkus.otel.bsp.schedule.delay", "100ms");
+        }
+    }
+}


### PR DESCRIPTION
- all MCP tracing spans now include the mcp.server.name attribute
- per-server tracingEnabled check is performed at span start time instead of only checking the default server at construction time
- resolves #845