### PR TITLE
fix: always end the response in the auth failure handler

### DIFF
--- a/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/HttpMcpServerRecorder.java
+++ b/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/HttpMcpServerRecorder.java
@@ -121,16 +121,21 @@ public class HttpMcpServerRecorder {
                         ctx.request().resume();
                     }
                     ctx.request().body().onComplete(ar -> {
-                        if (ar.succeeded() && ar.result() != null) {
-                            Integer id = new JsonObject(ar.result()).getInteger("id");
-                            JsonObject error = new JsonObject()
-                                    .put("jsonrpc", "2.0")
-                                    .put("id", id)
-                                    .put("error", new JsonObject()
-                                            .put("code", JsonRpcErrorCodes.SECURITY_ERROR)
-                                            .put("message", failure.toString()));
-                            ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, "application/json").end(error.toBuffer());
+                        Object id = null;
+                        if (ar.succeeded() && ar.result() != null && ar.result().length() > 0) {
+                            try {
+                                id = new JsonObject(ar.result()).getValue("id");
+                            } catch (Exception e) {
+                                LOG.debugf(e, "Unable to parse request body");
+                            }
                         }
+                        JsonObject error = new JsonObject()
+                                .put("jsonrpc", "2.0")
+                                .put("id", id)
+                                .put("error", new JsonObject()
+                                        .put("code", JsonRpcErrorCodes.SECURITY_ERROR)
+                                        .put("message", failure.toString()));
+                        ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, "application/json").end(error.toBuffer());
                     });
                 } else {
                     ctx.next();


### PR DESCRIPTION
## Problem

`createAuthFailureHandler` (added in #788) intercepts auth rejections at
the MCP endpoint and tries to extract a JSON-RPC `id` from the request
body so it can send a well-formed JSON-RPC error response.

The handler only calls `ctx.response().end()` inside the success branch:

```java
ctx.request().body().onComplete(ar -> {
    if (ar.succeeded() && ar.result() != null) {
        Integer id = new JsonObject(ar.result()).getInteger("id"); // throws on empty body
        ...
        ctx.response().putHeader(...).end(error.toBuffer());
    }
    // ← nothing here: response is never ended if body is empty
});
```

For **GET requests** — which Streamable HTTP clients use to open an SSE
stream — the body is empty. `new JsonObject(emptyBuffer)` throws a
`DecodeException` before `end()` is reached. The response status is set
to 401 but the connection is never closed; the client hangs instead of
receiving the rejection.

The same defect fires when the body future itself fails (e.g. body
already consumed by the time the failure route runs).

## Fix

Move the JSON-RPC error assembly and `end()` call outside the condition
so they always execute. Extract the `id` with a try/catch; on failure
(empty or non-JSON body) `id` stays `null`, which is valid per the
JSON-RPC spec for requests whose `id` cannot be determined.

```java
ctx.request().body().onComplete(ar -> {
    Integer id = null;
    if (ar.succeeded() && ar.result() != null && !ar.result().isEmpty()) {
        try {
            id = new JsonObject(ar.result()).getInteger("id");
        } catch (Exception ignored) {
        }
    }
    JsonObject error = new JsonObject()
            .put("jsonrpc", "2.0")
            .put("id", id)
            .put("error", ...);
    ctx.response().putHeader(...).end(error.toBuffer()); // always reached
});
```

## Impact

Before this fix, any MCP client that sends a GET `/mcp` request with an
invalid or expired token (to reconnect an SSE stream) receives a
hanging connection rather than a clean 401. Observed against
`quarkus-mcp-server` 1.13.0.