### PR TITLE
fix: always end the response in the auth failure handler [1.13.x]

### DIFF
--- a/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/HttpMcpServerRecorder.java
+++ b/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/HttpMcpServerRecorder.java
@@ -121,16 +121,21 @@ public class HttpMcpServerRecorder {
                         ctx.request().resume();
                     }
                     ctx.request().body().onComplete(ar -> {
-                        if (ar.succeeded() && ar.result() != null) {
-                            Integer id = new JsonObject(ar.result()).getInteger("id");
-                            JsonObject error = new JsonObject()
-                                    .put("jsonrpc", "2.0")
-                                    .put("id", id)
-                                    .put("error", new JsonObject()
-                                            .put("code", JsonRpcErrorCodes.SECURITY_ERROR)
-                                            .put("message", failure.toString()));
-                            ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, "application/json").end(error.toBuffer());
+                        Object id = null;
+                        if (ar.succeeded() && ar.result() != null && ar.result().length() > 0) {
+                            try {
+                                id = new JsonObject(ar.result()).getValue("id");
+                            } catch (Exception e) {
+                                LOG.debugf(e, "Unable to parse request body");
+                            }
                         }
+                        JsonObject error = new JsonObject()
+                                .put("jsonrpc", "2.0")
+                                .put("id", id)
+                                .put("error", new JsonObject()
+                                        .put("code", JsonRpcErrorCodes.SECURITY_ERROR)
+                                        .put("message", failure.toString()));
+                        ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, "application/json").end(error.toBuffer());
                     });
                 } else {
                     ctx.next();


### PR DESCRIPTION
The handler called ctx.response().end() only inside the `if (ar.succeeded() && ar.result() != null)` block. For GET requests — used by Streamable HTTP clients to open an SSE stream — the body is empty: `new JsonObject(emptyBuffer)` throws a DecodeException before `end()` is reached, leaving the response status set to 401 but the connection never closed.

Move the JSON-RPC error assembly and the `end()` call outside the condition so they always execute.  Extract the `id` with a try/catch; on failure (empty body, non-JSON body) `id` stays null, which is a valid JSON-RPC error response.