### PR TITLE
Add separate RAG artifact for documentation search

### DIFF
--- a/core/deployment/src/main/resources/META-INF/quarkus-rag-artifact.properties
+++ b/core/deployment/src/main/resources/META-INF/quarkus-rag-artifact.properties
@@ -1,0 +1,2 @@
+groupId=io.quarkiverse.mcp
+artifactId=quarkus-mcp-server-core-rag

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -15,5 +15,6 @@
     <modules>
         <module>deployment</module>
         <module>runtime</module>
+        <module>rag</module>
     </modules>
 </project>

--- a/core/rag/pom.xml
+++ b/core/rag/pom.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>io.quarkiverse.mcp</groupId>
+        <artifactId>quarkus-mcp-server-core-parent</artifactId>
+        <version>999-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>quarkus-mcp-server-core-rag</artifactId>
+    <name>Quarkus MCP Server Core - RAG</name>
+    <description>RAG vector embeddings for Quarkus MCP Server documentation</description>
+
+    <properties>
+        <skipRagGeneration>true</skipRagGeneration>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-extension-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate-extension-descriptor</id>
+                        <phase>none</phase>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>io.quarkus</groupId>
+                <artifactId>quarkus-documentation-rag-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate-rag</id>
+                        <goals>
+                            <goal>generate-rag</goal>
+                        </goals>
+                        <configuration>
+                            <guidesDirectory>${project.basedir}/../../docs/modules/ROOT/pages</guidesDirectory>
+                            <skip>${skipRagGeneration}</skip>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <profiles>
+        <profile>
+            <id>rag</id>
+            <properties>
+                <skipRagGeneration>false</skipRagGeneration>
+            </properties>
+        </profile>
+        <profile>
+            <id>release</id>
+            <properties>
+                <skipRagGeneration>false</skipRagGeneration>
+            </properties>
+        </profile>
+    </profiles>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,7 @@
                                         <excludes>
                                             <exclude>io.quarkiverse.mcp:*-integration-tests</exclude>
                                             <exclude>io.quarkiverse.mcp:quarkus-mcp-server-docs</exclude>
+                                            <exclude>io.quarkiverse.mcp:quarkus-mcp-server-core-rag</exclude>
                                         </excludes>
                                     </modules>
                                 </bom>


### PR DESCRIPTION
Ships RAG vector embeddings in a dedicated `core/rag` module instead of bundling them inside the deployment JAR. This keeps the deployment JAR at 56K while the RAG data (1.2M, 560 chunks from all 34 doc pages) lives in a separate artifact that consumers download on demand.

**What changed:**
- New `core/rag` module that runs the RAG plugin against all documentation pages (activated by `-Prag` or `-Prelease`)
- Pointer file `META-INF/quarkus-rag-artifact.properties` in the deployment JAR tells the loader where to find the RAG artifact
- BOM exclusion for the RAG artifact (not a user-facing dependency)

**Deployment JAR impact:** unchanged at 56K (only gains a 61-byte pointer file)

Depends on quarkusio/quarkus-agent-mcp#215 and chappie-bot/chappie-server#43 for the loader-side pointer file support.

Resolves #858