### PR TITLE
Convert McpProtocolVersion from enum to final class

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/McpProtocolVersion.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/McpProtocolVersion.java
@@ -1,43 +1,27 @@
 package io.quarkiverse.mcp.server;
 
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
- * Represents the supported MCP protocol versions.
+ * Represents an MCP protocol version.
  * <p>
  * Protocol versions are ISO 8601 dates (YYYY-MM-DD). Versions {@link #FIRST_STATELESS} and later use the stateless
  * (per-request metadata) model. Earlier versions use the stateful (session-based) model.
+ * <p>
+ * Instances for known/supported versions are available as constants. The {@link #from(String)} factory method
+ * returns these constants when possible, otherwise creates a new instance representing an unknown version.
  */
-public enum McpProtocolVersion {
+public final class McpProtocolVersion {
 
-    V_2024_11_05("2024-11-05"),
-    V_2025_03_26("2025-03-26"),
-    V_2025_06_18("2025-06-18"),
-    V_2025_11_25("2025-11-25"),
-    V_2026_07_28("2026-07-28"),
-    ;
-
-    private final String version;
-
-    private McpProtocolVersion(String version) {
-        this.version = version;
-    }
-
-    /**
-     * @return the version string in ISO 8601 date format (YYYY-MM-DD)
-     */
-    public String version() {
-        return version;
-    }
-
-    /**
-     * @return {@code true} if this version uses the stateless (per-request metadata) model
-     */
-    public boolean isStateless() {
-        return version.compareTo(FIRST_STATELESS.version) >= 0;
-    }
+    public static final McpProtocolVersion V_2024_11_05 = new McpProtocolVersion("2024-11-05");
+    public static final McpProtocolVersion V_2025_03_26 = new McpProtocolVersion("2025-03-26");
+    public static final McpProtocolVersion V_2025_06_18 = new McpProtocolVersion("2025-06-18");
+    public static final McpProtocolVersion V_2025_11_25 = new McpProtocolVersion("2025-11-25");
+    public static final McpProtocolVersion V_2026_07_28 = new McpProtocolVersion("2026-07-28");
 
     /**
      * The first protocol version that uses the stateless model.
@@ -67,17 +51,44 @@ public enum McpProtocolVersion {
             V_2025_03_26.version,
             V_2024_11_05.version);
 
-    private static final Map<String, McpProtocolVersion> BY_VERSION;
+    private static final Map<String, McpProtocolVersion> BY_VERSION = Stream.of(
+            V_2024_11_05, V_2025_03_26, V_2025_06_18, V_2025_11_25, V_2026_07_28)
+            .collect(Collectors.toUnmodifiableMap(McpProtocolVersion::version, v -> v));
 
-    static {
-        Map<String, McpProtocolVersion> map = new HashMap<>();
-        for (McpProtocolVersion v : values()) {
-            map.put(v.version, v);
-        }
-        BY_VERSION = Map.copyOf(map);
+    private final String version;
+
+    private McpProtocolVersion(String version) {
+        this.version = Objects.requireNonNull(version, "version must not be null");
     }
 
     /**
+     * @return the version string in ISO 8601 date format (YYYY-MM-DD)
+     */
+    public String version() {
+        return version;
+    }
+
+    /**
+     * Uses lexicographic comparison of the version strings, so this method may return {@code true} even for
+     * {@linkplain #isKnown() unknown} versions whose date is equal to or later than {@link #FIRST_STATELESS}.
+     *
+     * @return {@code true} if this version uses the stateless (per-request metadata) model
+     */
+    public boolean isStateless() {
+        return version.compareTo(FIRST_STATELESS.version) >= 0;
+    }
+
+    /**
+     * @return {@code true} if this instance represents a known/supported protocol version
+     */
+    public boolean isKnown() {
+        return BY_VERSION.containsKey(version);
+    }
+
+    /**
+     * Uses lexicographic comparison of the version strings, so this method may return {@code true} even for
+     * unknown versions whose date is equal to or later than {@link #FIRST_STATELESS}.
+     *
      * @return {@code true} if the given version string uses the stateless model
      */
     public static boolean isStateless(String version) {
@@ -88,14 +99,41 @@ public enum McpProtocolVersion {
     }
 
     /**
+     * Returns the {@code McpProtocolVersion} for the given version string.
+     * <p>
+     * If the string matches a known version, the corresponding constant is returned.
+     * If the string is non-null but unrecognized, a new instance is created.
+     *
      * @param version the version string
-     * @return the matching enum constant, or {@code null} if no match
+     * @return the matching instance, or {@code null} if the input is {@code null}
      */
     public static McpProtocolVersion from(String version) {
         if (version == null) {
             return null;
         }
-        return BY_VERSION.get(version);
+        McpProtocolVersion known = BY_VERSION.get(version);
+        return known != null ? known : new McpProtocolVersion(version);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof McpProtocolVersion other)) {
+            return false;
+        }
+        return version.equals(other.version);
+    }
+
+    @Override
+    public int hashCode() {
+        return version.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return version;
     }
 
 }

--- a/core/runtime/src/test/java/io/quarkiverse/mcp/server/McpProtocolVersionTest.java
+++ b/core/runtime/src/test/java/io/quarkiverse/mcp/server/McpProtocolVersionTest.java
@@ -1,0 +1,75 @@
+package io.quarkiverse.mcp.server;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+public class McpProtocolVersionTest {
+
+    @Test
+    public void testFromKnownVersion() {
+        assertSame(McpProtocolVersion.V_2024_11_05, McpProtocolVersion.from("2024-11-05"));
+        assertSame(McpProtocolVersion.V_2025_03_26, McpProtocolVersion.from("2025-03-26"));
+        assertSame(McpProtocolVersion.V_2025_06_18, McpProtocolVersion.from("2025-06-18"));
+        assertSame(McpProtocolVersion.V_2025_11_25, McpProtocolVersion.from("2025-11-25"));
+        assertSame(McpProtocolVersion.V_2026_07_28, McpProtocolVersion.from("2026-07-28"));
+    }
+
+    @Test
+    public void testFromNull() {
+        assertNull(McpProtocolVersion.from(null));
+    }
+
+    @Test
+    public void testFromUnknownVersion() {
+        McpProtocolVersion unknown = McpProtocolVersion.from("9999-01-01");
+        assertEquals("9999-01-01", unknown.version());
+        assertFalse(unknown.isKnown());
+        assertTrue(unknown.isStateless());
+    }
+
+    @Test
+    public void testFromUnknownOldVersion() {
+        McpProtocolVersion unknown = McpProtocolVersion.from("2020-01-01");
+        assertEquals("2020-01-01", unknown.version());
+        assertFalse(unknown.isKnown());
+        assertFalse(unknown.isStateless());
+    }
+
+    @Test
+    public void testIsKnown() {
+        assertTrue(McpProtocolVersion.V_2024_11_05.isKnown());
+        assertTrue(McpProtocolVersion.V_2026_07_28.isKnown());
+        assertFalse(McpProtocolVersion.from("2099-01-01").isKnown());
+    }
+
+    @Test
+    public void testIsStateless() {
+        assertFalse(McpProtocolVersion.V_2024_11_05.isStateless());
+        assertFalse(McpProtocolVersion.V_2025_03_26.isStateless());
+        assertFalse(McpProtocolVersion.V_2025_11_25.isStateless());
+        assertTrue(McpProtocolVersion.V_2026_07_28.isStateless());
+        assertSame(McpProtocolVersion.FIRST_STATELESS, McpProtocolVersion.V_2026_07_28);
+    }
+
+    @Test
+    public void testEqualsAndHashCode() {
+        McpProtocolVersion a = McpProtocolVersion.from("2099-01-01");
+        McpProtocolVersion b = McpProtocolVersion.from("2099-01-01");
+        assertEquals(a, b);
+        assertEquals(a.hashCode(), b.hashCode());
+
+        assertEquals(McpProtocolVersion.V_2024_11_05, McpProtocolVersion.from("2024-11-05"));
+    }
+
+    @Test
+    public void testToString() {
+        assertEquals("2024-11-05", McpProtocolVersion.V_2024_11_05.toString());
+        assertEquals("9999-01-01", McpProtocolVersion.from("9999-01-01").toString());
+    }
+
+}

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -2,4 +2,4 @@
 
 :examples-dir: ./../examples/
 :spec-version: 2025-11-25
-:quarkus-version: 3.33.2
+:quarkus-version: 3.33.2.1

--- a/test/src/main/java/io/quarkiverse/mcp/server/test/McpTestClientBuilder.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/McpTestClientBuilder.java
@@ -50,7 +50,7 @@ abstract class McpTestClientBuilder<BUILDER extends Builder<BUILDER>> implements
             throw mustNotBeNull("protocolVersion");
         }
         McpProtocolVersion v = McpProtocolVersion.from(protocolVersion);
-        if (v == null) {
+        if (!v.isKnown()) {
             throw new IllegalArgumentException("Unknown protocol version: " + protocolVersion);
         }
         this.protocolVersion = v;

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/initrequest/InitialRequestTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/initrequest/InitialRequestTest.java
@@ -59,7 +59,7 @@ public class InitialRequestTest extends McpServerTest {
         String testInitRequest(McpConnection connection) {
             InitialRequest initRequest = connection.initialRequest();
             if (initRequest != null) {
-                if (initRequest.protocolVersion() != McpProtocolVersion.LATEST_STATEFUL) {
+                if (!McpProtocolVersion.LATEST_STATEFUL.equals(initRequest.protocolVersion())) {
                     throw new IllegalStateException();
                 }
                 if (!initRequest.implementation().name().equals("test-client")) {

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/initrequest/UnknownProtocolVersionTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/initrequest/UnknownProtocolVersionTest.java
@@ -1,0 +1,61 @@
+package io.quarkiverse.mcp.server.test.initrequest;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.InitialRequest;
+import io.quarkiverse.mcp.server.McpConnection;
+import io.quarkiverse.mcp.server.McpProtocolVersion;
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkiverse.mcp.server.test.McpAssured.McpSseTestClient;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class UnknownProtocolVersionTest extends McpServerTest {
+
+    static final String UNKNOWN_VERSION = "2025-09-01";
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .withApplicationRoot(root -> root.addClass(MyTools.class));
+
+    @Test
+    public void testUnknownProtocolVersion() {
+        McpSseTestClient client = McpAssured.newSseClient()
+                .setProtocolVersion(McpProtocolVersion.from(UNKNOWN_VERSION))
+                .build()
+                .connect();
+
+        client.when()
+                .toolsCall("verifyProtocolVersion", r -> {
+                    assertFalse(r.isError());
+                    assertEquals("ok", r.firstContent().asText().text());
+                })
+                .thenAssertResults();
+    }
+
+    public static class MyTools {
+
+        @Tool
+        String verifyProtocolVersion(McpConnection connection) {
+            InitialRequest initRequest = connection.initialRequest();
+            McpProtocolVersion protocolVersion = initRequest.protocolVersion();
+            if (!UNKNOWN_VERSION.equals(protocolVersion.version())) {
+                throw new IllegalStateException(
+                        "Expected version " + UNKNOWN_VERSION + " but got " + protocolVersion.version());
+            }
+            if (protocolVersion.isKnown()) {
+                throw new IllegalStateException("Expected unknown protocol version");
+            }
+            if (protocolVersion.isStateless()) {
+                throw new IllegalStateException("Expected stateful protocol version");
+            }
+            return "ok";
+        }
+    }
+
+}


### PR DESCRIPTION
- unknown/unsupported protocol versions are now representable as McpProtocolVersion instances instead of being silently replaced with a fallback
- from(String) factory method returns known constants for recognized versions and creates new instances for unrecognized ones
- isKnown() method distinguishes the two variants