### PR TITLE
Handle notifications/initialized on auto-init path

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/McpServerProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/McpServerProcessor.java
@@ -114,6 +114,7 @@ import io.quarkiverse.mcp.server.runtime.ToolEncoderResultMapper;
 import io.quarkiverse.mcp.server.runtime.ToolManagerImpl;
 import io.quarkiverse.mcp.server.runtime.ToolStructuredContentResultMapper;
 import io.quarkiverse.mcp.server.runtime.TrafficListeners;
+import io.quarkiverse.mcp.server.runtime.TrafficLogger;
 import io.quarkiverse.mcp.server.runtime.WrapBusinessErrorInterceptor;
 import io.quarkiverse.mcp.server.runtime.config.McpServerBuildTimeConfig;
 import io.quarkiverse.mcp.server.runtime.config.McpServersBuildTimeConfig;
@@ -213,6 +214,7 @@ class McpServerProcessor {
         AdditionalBeanBuildItem.Builder unremovable = AdditionalBeanBuildItem.builder().setUnremovable();
         unremovable.addBeanClass("io.quarkiverse.mcp.server.runtime.ConnectionManager");
         unremovable.addBeanClass(TrafficListeners.class);
+        unremovable.addBeanClass(TrafficLogger.class);
         unremovable.addBeanClass(ServerRequests.class);
         unremovable.addBeanClass(RequestIdGenerator.class);
         unremovable.addBeanClass(CancellationRequests.class);

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpMessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpMessageHandler.java
@@ -425,6 +425,7 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
                 case COMPLETION_COMPLETE -> complete(message, mcpRequest);
                 case NOTIFICATIONS_ROOTS_LIST_CHANGED -> rootsListChanged(message, mcpRequest);
                 case NOTIFICATIONS_CANCELLED -> cancelRequest(message, mcpRequest);
+                case NOTIFICATIONS_INITIALIZED -> alreadyInitialized(mcpRequest);
                 default -> unsupportedMethod(message, mcpRequest);
             };
             future.onComplete(r -> {
@@ -584,6 +585,12 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
         Object id = Messages.getId(message);
         LOG.debugf("Ping [id: %s]", id);
         return mcpRequest.sender().sendResult(id, new JsonObject());
+    }
+
+    private Future<Void> alreadyInitialized(MCP_REQUEST mcpRequest) {
+        LOG.debugf("Ignoring notifications/initialized on already initialized connection [%s]",
+                mcpRequest.connection().id());
+        return Future.succeededFuture();
     }
 
     private Future<Void> progress(JsonObject message, MCP_REQUEST mcpRequest) {

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/dummyinit/AutoInitTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/dummyinit/AutoInitTest.java
@@ -81,6 +81,34 @@ public class AutoInitTest extends McpServerTest {
         }
     }
 
+    @Test
+    public void testNotificationsInitialized() {
+        McpStreamableTestClient client = McpAssured.newConnectedStreamableClient();
+        URI endpoint = client.mcpEndpoint();
+        String sessionId = client.mcpSessionId();
+        client.terminateSession();
+        client.disconnect();
+
+        // notifications/initialized with an unknown session id should not result in 404
+        RestAssured.given()
+                .when()
+                .headers(StreamableHttpMcpMessageHandler.MCP_SESSION_ID_HEADER, sessionId,
+                        HttpHeaders.ACCEPT + "", "application/json, text/event-stream")
+                .body(notificationsInitialized().encode())
+                .post(endpoint)
+                .then()
+                .statusCode(202);
+
+        // Auto-initialized connection should have been removed
+        assertFalse(connectionManager.iterator().hasNext());
+    }
+
+    private JsonObject notificationsInitialized() {
+        return new JsonObject()
+                .put("jsonrpc", "2.0")
+                .put("method", "notifications/initialized");
+    }
+
     private JsonObject toolsCall(String name, int id) {
         return new JsonObject()
                 .put("jsonrpc", "2.0")


### PR DESCRIPTION
- when notifications/initialized arrives with an unknown session id and
 auto-init is enabled, the notification now returns 202 instead of an
 unsupported method error