### PR TITLE
Cache control support for MCP results

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/FeatureMethodBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/FeatureMethodBuildItem.java
@@ -10,6 +10,7 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.Type;
 
+import io.quarkiverse.mcp.server.CacheControl;
 import io.quarkiverse.mcp.server.Content;
 import io.quarkiverse.mcp.server.Content.Annotations;
 import io.quarkiverse.mcp.server.ExecutionModel;
@@ -43,6 +44,7 @@ final class FeatureMethodBuildItem extends MultiBuildItem {
     private final String mimeType;
     private final int size;
     private final Content.Annotations resourceAnnotations;
+    private final CacheControl cacheControl;
 
     // Tool-only
     private final ToolManager.ToolAnnotations toolAnnotations;
@@ -67,6 +69,7 @@ final class FeatureMethodBuildItem extends MultiBuildItem {
             Set<String> servers, boolean structuredContent, Type outputSchemaFrom, Type outputSchemaGenerator,
             Type inputSchemaGenerator,
             Content.Annotations resourceAnnotations,
+            CacheControl cacheControl,
             Map<String, String> metadata,
             List<DotName> inputGuardrails,
             List<DotName> outputGuardrails,
@@ -89,6 +92,7 @@ final class FeatureMethodBuildItem extends MultiBuildItem {
         this.outputSchemaGenerator = outputSchemaGenerator;
         this.inputSchemaGenerator = inputSchemaGenerator;
         this.resourceAnnotations = resourceAnnotations;
+        this.cacheControl = cacheControl;
         this.metadata = Objects.requireNonNull(metadata);
         this.inputGuardrails = inputGuardrails;
         this.outputGuardrails = outputGuardrails;
@@ -162,6 +166,10 @@ final class FeatureMethodBuildItem extends MultiBuildItem {
 
     Annotations getResourceAnnotations() {
         return resourceAnnotations;
+    }
+
+    CacheControl getCacheControl() {
+        return cacheControl;
     }
 
     Map<String, String> getMetadata() {

--- a/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/McpServerProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/McpServerProcessor.java
@@ -49,6 +49,8 @@ import org.mcpjava.server.spi.McpServerSPI;
 
 import io.quarkiverse.mcp.server.AudioContent;
 import io.quarkiverse.mcp.server.BlobResourceContents;
+import io.quarkiverse.mcp.server.CacheControl;
+import io.quarkiverse.mcp.server.CacheScope;
 import io.quarkiverse.mcp.server.CompleteArg;
 import io.quarkiverse.mcp.server.Content;
 import io.quarkiverse.mcp.server.DefaultValueConverter;
@@ -352,6 +354,7 @@ class McpServerProcessor {
                     org.jboss.jandex.Type inputSchemaGenerator = null;
                     ToolManager.ToolAnnotations toolAnnotations = null;
                     Content.Annotations resourceAnnotations = null;
+                    CacheControl cacheControl = null;
                     Map<String, String> metadata = new HashMap<>();
 
                     if (feature == RESOURCE) {
@@ -365,6 +368,7 @@ class McpServerProcessor {
                         if (sizeValue != null)
                             size = sizeValue.asInt();
                         resourceAnnotations = parseResourceAnnotations(featureAnnotation);
+                        cacheControl = parseCacheControl(featureAnnotation);
                     } else if (feature == RESOURCE_TEMPLATE) {
                         AnnotationValue uriValue = featureAnnotation.value("uriTemplate");
                         if (uriValue != null)
@@ -373,6 +377,7 @@ class McpServerProcessor {
                         if (mimeTypeValue != null)
                             mimeType = mimeTypeValue.asString();
                         resourceAnnotations = parseResourceAnnotations(featureAnnotation);
+                        cacheControl = parseCacheControl(featureAnnotation);
                     } else if (feature == TOOL) {
                         // Tool annotations
                         AnnotationValue annotations = featureAnnotation.value("annotations");
@@ -525,6 +530,7 @@ class McpServerProcessor {
                             title, description, uri, mimeType, size, feature, toolAnnotations,
                             servers, structuredContent,
                             outputSchemaFrom, outputSchemaGenerator, inputSchemaGenerator, resourceAnnotations,
+                            cacheControl,
                             metadata,
                             inputGuardrails, outputGuardrails,
                             FeatureMethods.executionModel(method, transformedAnnotations),
@@ -781,6 +787,22 @@ class McpServerProcessor {
             AnnotationValue priorityValue = annotationsAnnotation.value("priority");
             return new Content.Annotations(audience, lastModifiedValue != null ? lastModifiedValue.asString() : null,
                     priorityValue != null ? priorityValue.asDouble() : null);
+        }
+        return null;
+    }
+
+    private CacheControl parseCacheControl(AnnotationInstance featureAnnotation) {
+        AnnotationValue cacheControlValue = featureAnnotation.value("cacheControl");
+        if (cacheControlValue != null) {
+            AnnotationInstance cc = cacheControlValue.asNested();
+            AnnotationValue ttlMsValue = cc.value("ttlMs");
+            long ttlMs = ttlMsValue != null ? ttlMsValue.asLong() : -1;
+            if (ttlMs < 0) {
+                return null;
+            }
+            AnnotationValue cacheScopeValue = cc.value("cacheScope");
+            CacheScope scope = cacheScopeValue != null ? CacheScope.valueOf(cacheScopeValue.asEnum()) : CacheScope.PUBLIC;
+            return new CacheControl(ttlMs, scope);
         }
         return null;
     }
@@ -1398,6 +1420,18 @@ class McpServerProcessor {
                     resourceAnnotations = bc.localVar("resourceAnnotations", Const.ofNull(Content.Annotations.class));
                 }
 
+                LocalVar cacheControl;
+                if ((featureMethod.isResource() || featureMethod.isResourceTemplate())
+                        && featureMethod.getCacheControl() != null) {
+                    CacheControl cacheControlVal = featureMethod.getCacheControl();
+                    cacheControl = bc.localVar("cacheControl", bc.new_(
+                            ConstructorDesc.of(CacheControl.class, long.class, CacheScope.class),
+                            Const.of(cacheControlVal.ttlMs()),
+                            Const.of(cacheControlVal.cacheScope())));
+                } else {
+                    cacheControl = bc.localVar("cacheControl", Const.ofNull(CacheControl.class));
+                }
+
                 LocalVar meta;
                 Map<String, String> metaEntries = featureMethod.getMetadata();
                 if (metaEntries.isEmpty()) {
@@ -1458,6 +1492,7 @@ class McpServerProcessor {
                         Const.of(featureMethod.getMethod().name()),
                         toolAnnotations,
                         resourceAnnotations,
+                        cacheControl,
                         serverNames,
                         featureMethod.getOutputSchemaFrom() == null ? Const.ofNull(Class.class)
                                 : Const.of(Jandex2Gizmo.classDescOf(featureMethod.getOutputSchemaFrom().name())),

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/CacheControl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/CacheControl.java
@@ -1,0 +1,23 @@
+package io.quarkiverse.mcp.server;
+
+/**
+ * Caching hints for MCP results.
+ * <p>
+ * {@code ttlMs} is a freshness hint (in milliseconds) indicating how long clients may consider the result fresh before
+ * re-fetching. If {@code 0}, the response should be considered immediately stale. If negative, the value is treated as unset.
+ * <p>
+ * {@code cacheScope} controls whether shared intermediaries may cache the response.
+ *
+ * @param ttlMs time-to-live in milliseconds
+ * @param cacheScope the cache scope
+ * @see CacheScope
+ */
+public record CacheControl(long ttlMs, CacheScope cacheScope) {
+
+    public CacheControl {
+        if (cacheScope == null) {
+            throw new IllegalArgumentException("cacheScope must not be null");
+        }
+    }
+
+}

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/CacheScope.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/CacheScope.java
@@ -1,0 +1,24 @@
+package io.quarkiverse.mcp.server;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Controls who may cache a response, analogous to HTTP {@code Cache-Control: public} vs {@code Cache-Control: private}.
+ * <p>
+ * {@link #PUBLIC} indicates that the response does not contain user-specific data and any client, shared gateway, or caching
+ * proxy may store and serve the cached response to any user.
+ * <p>
+ * {@link #PRIVATE} indicates that the response contains private data. Cached responses may be reused for the same authorization
+ * context but must not be shared across authorization contexts.
+ */
+public enum CacheScope {
+
+    PUBLIC,
+    PRIVATE;
+
+    @JsonValue
+    public String getName() {
+        return toString().toLowerCase();
+    }
+
+}

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/Resource.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/Resource.java
@@ -89,6 +89,14 @@ public @interface Resource {
      */
     Annotations annotations() default @Annotations(audience = Role.USER, lastModified = "", priority = 0.5);
 
+    /**
+     * Optional caching hints for the {@code resources/read} result.
+     * <p>
+     * Note that the default value of this annotation member is ignored. In other words, the cache control has to be declared
+     * explicitly in order to be included in the {@code resources/read} response.
+     */
+    CacheControl cacheControl() default @CacheControl(ttlMs = -1, cacheScope = CacheScope.PUBLIC);
+
     @Retention(RUNTIME)
     @Target(ElementType.ANNOTATION_TYPE)
     public @interface Annotations {
@@ -98,6 +106,22 @@ public @interface Resource {
         String lastModified() default "";
 
         double priority();
+
+    }
+
+    @Retention(RUNTIME)
+    @Target(ElementType.ANNOTATION_TYPE)
+    public @interface CacheControl {
+
+        /**
+         * Time-to-live in milliseconds. A value of {@code 0} means immediately stale. A negative value means unset.
+         */
+        long ttlMs();
+
+        /**
+         * The cache scope.
+         */
+        CacheScope cacheScope() default CacheScope.PUBLIC;
 
     }
 

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/ResourceManager.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/ResourceManager.java
@@ -78,6 +78,8 @@ public interface ResourceManager extends FeatureManager<ResourceInfo> {
 
         Optional<Content.Annotations> annotations();
 
+        Optional<CacheControl> cacheControl();
+
         Map<MetaKey, Object> metadata();
 
         /**
@@ -136,6 +138,12 @@ public interface ResourceManager extends FeatureManager<ResourceInfo> {
          * @return self
          */
         ResourceDefinition setMetadata(Map<MetaKey, Object> metadata);
+
+        /**
+         * @param cacheControl
+         * @return self
+         */
+        ResourceDefinition setCacheControl(CacheControl cacheControl);
 
         /**
          * @return the resource info

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/ResourceResponse.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/ResourceResponse.java
@@ -9,15 +9,21 @@ import java.util.NoSuchElementException;
  *
  * @param contents text and/or binary data (must not be {@code null})
  * @param _meta the optional metadata
+ * @param cacheControl the optional cache control hints; if {@code null} no caching fields are included in the response
  */
-public record ResourceResponse(List<ResourceContents> contents, Map<MetaKey, Object> _meta) {
+public record ResourceResponse(List<ResourceContents> contents, Map<MetaKey, Object> _meta,
+        CacheControl cacheControl) {
 
     public ResourceResponse(ResourceContents contents) {
-        this(List.of(contents), null);
+        this(List.of(contents), null, null);
     }
 
     public ResourceResponse(List<ResourceContents> contents) {
-        this(contents, null);
+        this(contents, null, null);
+    }
+
+    public ResourceResponse(List<ResourceContents> contents, Map<MetaKey, Object> _meta) {
+        this(contents, _meta, null);
     }
 
     public ResourceResponse {

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/ResourceTemplate.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/ResourceTemplate.java
@@ -8,6 +8,7 @@ import java.lang.annotation.Target;
 import java.util.List;
 
 import io.quarkiverse.mcp.server.Resource.Annotations;
+import io.quarkiverse.mcp.server.Resource.CacheControl;
 import io.smallrye.mutiny.Uni;
 
 /**
@@ -88,5 +89,13 @@ public @interface ResourceTemplate {
      * explicitly in order to be included in Resource metadata.
      */
     Annotations annotations() default @Annotations(audience = Role.USER, lastModified = "", priority = 0.5);
+
+    /**
+     * Optional caching hints for the {@code resources/read} result.
+     * <p>
+     * Note that the default value of this annotation member is ignored. In other words, the cache control has to be declared
+     * explicitly in order to be included in the {@code resources/read} response.
+     */
+    CacheControl cacheControl() default @CacheControl(ttlMs = -1, cacheScope = CacheScope.PUBLIC);
 
 }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/ResourceTemplateManager.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/ResourceTemplateManager.java
@@ -78,6 +78,8 @@ public interface ResourceTemplateManager extends FeatureManager<ResourceTemplate
 
         Optional<Content.Annotations> annotations();
 
+        Optional<CacheControl> cacheControl();
+
     }
 
     /**
@@ -122,6 +124,12 @@ public interface ResourceTemplateManager extends FeatureManager<ResourceTemplate
          * @return self
          */
         ResourceTemplateDefinition setMetadata(Map<MetaKey, Object> metadata);
+
+        /**
+         * @param cacheControl
+         * @return self
+         */
+        ResourceTemplateDefinition setCacheControl(CacheControl cacheControl);
 
         /**
          * @return the resource template info

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/FeatureMethodInfo.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/FeatureMethodInfo.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import io.quarkiverse.mcp.server.CacheControl;
 import io.quarkiverse.mcp.server.Content;
 import io.quarkiverse.mcp.server.IconsProvider;
 import io.quarkiverse.mcp.server.InputSchemaGenerator;
@@ -21,6 +22,7 @@ public record FeatureMethodInfo(String name,
         String methodName,
         ToolManager.ToolAnnotations toolAnnotations,
         Content.Annotations resourceAnnotations,
+        CacheControl cacheControl,
         Set<String> serverNames,
         Class<?> outputSchemaFrom,
         Class<? extends OutputSchemaGenerator> outputSchemaGenerator,

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpMessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpMessageHandler.java
@@ -792,6 +792,13 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
         if (instructions.isPresent()) {
             ret.put("instructions", instructions.get());
         }
+        McpServerRuntimeConfig.Discover discover = serverConfig(mcpRequest).discover();
+        if (discover.ttlMs() >= 0) {
+            ret.put("ttlMs", discover.ttlMs());
+        }
+        if (discover.cacheScope().isPresent()) {
+            ret.put("cacheScope", discover.cacheScope().get().getName());
+        }
         return mcpRequest.sender().sendResult(id, ret);
     }
 

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpObjectMapperCustomizer.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpObjectMapperCustomizer.java
@@ -4,10 +4,12 @@ import jakarta.enterprise.context.Dependent;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.quarkiverse.mcp.server.AudioContent;
 import io.quarkiverse.mcp.server.BlobResourceContents;
+import io.quarkiverse.mcp.server.CacheControl;
 import io.quarkiverse.mcp.server.CompletionResponse;
 import io.quarkiverse.mcp.server.Content;
 import io.quarkiverse.mcp.server.EmbeddedResource;
@@ -29,7 +31,8 @@ public class McpObjectMapperCustomizer implements ObjectMapperCustomizer {
     public void customize(ObjectMapper objectMapper) {
         objectMapper.addMixIn(ToolResponse.class, ResponseMixin.class);
         objectMapper.addMixIn(PromptResponse.class, ResponseMixin.class);
-        objectMapper.addMixIn(ResourceResponse.class, ResponseMixin.class);
+        objectMapper.addMixIn(ResourceResponse.class, ResourceResponseMixin.class);
+        objectMapper.addMixIn(CacheControl.class, ResponseMixin.class);
         objectMapper.addMixIn(CompletionResponse.class, ResponseMixin.class);
 
         objectMapper.addMixIn(TextResourceContents.class, ResponseMixin.class);
@@ -49,6 +52,12 @@ public class McpObjectMapperCustomizer implements ObjectMapperCustomizer {
     @JsonInclude(Include.NON_NULL)
     static abstract class ResponseMixin {
 
+    }
+
+    @JsonInclude(Include.NON_NULL)
+    static abstract class ResourceResponseMixin {
+        @JsonUnwrapped
+        CacheControl cacheControl;
     }
 
 }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/MessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/MessageHandler.java
@@ -1,9 +1,11 @@
 package io.quarkiverse.mcp.server.runtime;
 
 import java.util.Map;
+import java.util.Optional;
 
 import org.jboss.logging.Logger;
 
+import io.quarkiverse.mcp.server.CacheScope;
 import io.quarkiverse.mcp.server.Cancellation;
 import io.quarkiverse.mcp.server.InputRequiredException;
 import io.quarkiverse.mcp.server.InputRequiredException.ElicitationInputRequest;
@@ -83,5 +85,14 @@ public abstract class MessageHandler {
                     .put("params", new JsonObject());
         }
         throw new IllegalArgumentException("Unknown input request entry type: " + entry.getClass());
+    }
+
+    static void putCacheControl(JsonObject result, long ttlMs, Optional<CacheScope> cacheScope) {
+        if (ttlMs >= 0) {
+            result.put("ttlMs", ttlMs);
+        }
+        if (cacheScope.isPresent()) {
+            result.put("cacheScope", cacheScope.get().getName());
+        }
     }
 }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/PromptMessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/PromptMessageHandler.java
@@ -53,6 +53,7 @@ class PromptMessageHandler extends MessageHandler {
             PromptManager.PromptInfo last = page.lastInfo();
             result.put("nextCursor", Cursor.encode(last.createdAt(), cursor.snapshotTimestamp()));
         }
+        putCacheControl(result, serverConfig.prompts().ttlMs(), serverConfig.prompts().cacheScope());
         return mcpRequest.sender().sendResult(id, result);
     }
 

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceManagerImpl.java
@@ -24,6 +24,7 @@ import org.jboss.logging.Logger;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import io.quarkiverse.mcp.server.CacheControl;
 import io.quarkiverse.mcp.server.Content;
 import io.quarkiverse.mcp.server.Content.Annotations;
 import io.quarkiverse.mcp.server.FilterContext;
@@ -321,6 +322,11 @@ public class ResourceManagerImpl extends FeatureManagerBase<ResourceResponse, Re
         }
 
         @Override
+        public Optional<CacheControl> cacheControl() {
+            return Optional.ofNullable(metadata.info().cacheControl());
+        }
+
+        @Override
         public Map<MetaKey, Object> metadata() {
             return metadata.info().metadata().entrySet()
                     .stream()
@@ -361,13 +367,15 @@ public class ResourceManagerImpl extends FeatureManagerBase<ResourceResponse, Re
         private final String mimeType;
         private final int size;
         private final Content.Annotations annotations;
+        private final CacheControl cacheControl;
         private final Map<MetaKey, Object> metadata;
         private final Map<TransportHint, Object> transportHints;
 
         private ResourceDefinitionInfo(String name, String title, String description, Set<String> serverNames,
                 Function<ResourceArguments, ResourceResponse> fun,
                 Function<ResourceArguments, Uni<ResourceResponse>> asyncFun, boolean runOnVirtualThread, String uri,
-                String mimeType, int size, Content.Annotations annotations, Map<MetaKey, Object> metadata, List<Icon> icons,
+                String mimeType, int size, Content.Annotations annotations, CacheControl cacheControl,
+                Map<MetaKey, Object> metadata, List<Icon> icons,
                 Map<TransportHint, Object> transportHints) {
             super(name, description, serverNames, fun, asyncFun, runOnVirtualThread, icons);
             this.title = title;
@@ -375,6 +383,7 @@ public class ResourceManagerImpl extends FeatureManagerBase<ResourceResponse, Re
             this.mimeType = mimeType;
             this.size = size;
             this.annotations = annotations;
+            this.cacheControl = cacheControl;
             this.metadata = Map.copyOf(metadata);
             this.transportHints = Map.copyOf(transportHints);
         }
@@ -402,6 +411,11 @@ public class ResourceManagerImpl extends FeatureManagerBase<ResourceResponse, Re
         @Override
         public Optional<Annotations> annotations() {
             return Optional.ofNullable(annotations);
+        }
+
+        @Override
+        public Optional<CacheControl> cacheControl() {
+            return Optional.ofNullable(cacheControl);
         }
 
         @Override
@@ -490,6 +504,7 @@ public class ResourceManagerImpl extends FeatureManagerBase<ResourceResponse, Re
         private String mimeType;
         private int size = -1;
         private Content.Annotations annotations;
+        private CacheControl cacheControl;
         private Map<MetaKey, Object> metadata = Map.of();
 
         ResourceDefinitionImpl(String name) {
@@ -533,13 +548,19 @@ public class ResourceManagerImpl extends FeatureManagerBase<ResourceResponse, Re
         }
 
         @Override
+        public ResourceDefinition setCacheControl(CacheControl cacheControl) {
+            this.cacheControl = cacheControl;
+            return this;
+        }
+
+        @Override
         public ResourceInfo register() {
             validate();
             if (uri == null) {
                 throw new IllegalStateException("uri must be set");
             }
             ResourceDefinitionInfo ret = new ResourceDefinitionInfo(name, title, description, serverNames, fun, asyncFun,
-                    runOnVirtualThread, uri, mimeType, size, annotations, metadata, icons, transportHints);
+                    runOnVirtualThread, uri, mimeType, size, annotations, cacheControl, metadata, icons, transportHints);
             List<FeatureKey> nameKeys = FeatureKey.list(name, serverNames);
             List<FeatureKey> uriKeys = FeatureKey.list(uri, serverNames);
             registrationLock.lock();

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceMessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceMessageHandler.java
@@ -2,13 +2,16 @@ package io.quarkiverse.mcp.server.runtime;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 
 import org.jboss.logging.Logger;
 
+import io.quarkiverse.mcp.server.CacheControl;
 import io.quarkiverse.mcp.server.JsonRpcErrorCodes;
 import io.quarkiverse.mcp.server.McpException;
 import io.quarkiverse.mcp.server.ResourceManager.ResourceInfo;
 import io.quarkiverse.mcp.server.ResourceResponse;
+import io.quarkiverse.mcp.server.ResourceTemplateManager.ResourceTemplateInfo;
 import io.quarkiverse.mcp.server.runtime.FeatureManagerBase.FeatureExecutionContext;
 import io.quarkiverse.mcp.server.runtime.config.McpServerRuntimeConfig;
 import io.quarkiverse.mcp.server.runtime.config.McpServersRuntimeConfig;
@@ -88,6 +91,7 @@ class ResourceMessageHandler extends MessageHandler {
             ResourceInfo last = page.lastInfo();
             result.put("nextCursor", Cursor.encode(last.createdAt(), cursor.snapshotTimestamp()));
         }
+        putCacheControl(result, serverConfig.resources().ttlMs(), serverConfig.resources().cacheScope());
         return mcpRequest.sender().sendResult(id, result);
     }
 
@@ -115,7 +119,9 @@ class ResourceMessageHandler extends MessageHandler {
                     return mcpRequest.sender().sendError(id, JsonRpcErrorCodes.RESOURCE_NOT_FOUND,
                             "Resource not found: " + resourceUri);
                 } else {
-                    return mcpRequest.sender().sendResult(id, resourceResponse);
+                    ResourceResponse resolved = resolveResourceReadCacheControl(resourceResponse, resourceUri,
+                            mcpRequest.serverName());
+                    return mcpRequest.sender().sendResult(id, resolved);
                 }
             },
                     cause -> handleFailure(id, mcpRequest.sender(), mcpRequest, cause, LOG,
@@ -123,6 +129,28 @@ class ResourceMessageHandler extends MessageHandler {
         } catch (McpException e) {
             return mcpRequest.sender().sendError(id, e.getJsonRpcErrorCode(), e.getMessage());
         }
+    }
+
+    // Precedence: ResourceResponse cache control > resource/template cache control
+    private ResourceResponse resolveResourceReadCacheControl(ResourceResponse response, String resourceUri,
+            String serverName) {
+        if (response.cacheControl() != null) {
+            return response;
+        }
+        Optional<CacheControl> cc = Optional.empty();
+        ResourceInfo info = manager.getResource(resourceUri, serverName);
+        if (info != null) {
+            cc = info.cacheControl();
+        } else {
+            ResourceTemplateInfo templateInfo = manager.resourceTemplateManager.findMatching(resourceUri, serverName);
+            if (templateInfo != null) {
+                cc = templateInfo.cacheControl();
+            }
+        }
+        if (cc.isPresent()) {
+            return new ResourceResponse(response.contents(), response._meta(), cc.get());
+        }
+        return response;
     }
 
 }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceTemplateManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceTemplateManagerImpl.java
@@ -25,6 +25,7 @@ import org.jboss.logging.Logger;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
+import io.quarkiverse.mcp.server.CacheControl;
 import io.quarkiverse.mcp.server.Content;
 import io.quarkiverse.mcp.server.Content.Annotations;
 import io.quarkiverse.mcp.server.FilterContext;
@@ -360,6 +361,11 @@ public class ResourceTemplateManagerImpl extends FeatureManagerBase<ResourceResp
         }
 
         @Override
+        public Optional<CacheControl> cacheControl() {
+            return Optional.ofNullable(metadata.info().cacheControl());
+        }
+
+        @Override
         public Map<MetaKey, Object> metadata() {
             return metadata.info().metadata().entrySet()
                     .stream()
@@ -395,19 +401,22 @@ public class ResourceTemplateManagerImpl extends FeatureManagerBase<ResourceResp
         private final String uriTemplate;
         private final String mimeType;
         private final Content.Annotations annotations;
+        private final CacheControl cacheControl;
         private final Map<MetaKey, Object> metadata;
         private final Map<TransportHint, Object> transportHints;
 
         private ResourceTemplateDefinitionInfo(String name, String title, String description, Set<String> serverNames,
                 Function<ResourceTemplateArguments, ResourceResponse> fun,
                 Function<ResourceTemplateArguments, Uni<ResourceResponse>> asyncFun, boolean runOnVirtualThread, String uri,
-                String mimeType, Content.Annotations annotations, Map<MetaKey, Object> metadata, List<Icon> icons,
+                String mimeType, Content.Annotations annotations, CacheControl cacheControl, Map<MetaKey, Object> metadata,
+                List<Icon> icons,
                 Map<TransportHint, Object> transportHints) {
             super(name, description, serverNames, fun, asyncFun, runOnVirtualThread, icons);
             this.title = title;
             this.uriTemplate = uri;
             this.mimeType = mimeType;
             this.annotations = annotations;
+            this.cacheControl = cacheControl;
             this.metadata = Map.copyOf(metadata);
             this.transportHints = Map.copyOf(transportHints);
         }
@@ -430,6 +439,11 @@ public class ResourceTemplateManagerImpl extends FeatureManagerBase<ResourceResp
         @Override
         public Optional<Annotations> annotations() {
             return Optional.ofNullable(annotations);
+        }
+
+        @Override
+        public Optional<CacheControl> cacheControl() {
+            return Optional.ofNullable(cacheControl);
         }
 
         @Override
@@ -521,6 +535,7 @@ public class ResourceTemplateManagerImpl extends FeatureManagerBase<ResourceResp
         private String uriTemplate;
         private String mimeType;
         private Annotations annotations;
+        private CacheControl cacheControl;
         private Map<MetaKey, Object> metadata = Map.of();
 
         ResourceTemplateDefinitionImpl(String name) {
@@ -558,13 +573,20 @@ public class ResourceTemplateManagerImpl extends FeatureManagerBase<ResourceResp
         }
 
         @Override
+        public ResourceTemplateDefinition setCacheControl(CacheControl cacheControl) {
+            this.cacheControl = cacheControl;
+            return this;
+        }
+
+        @Override
         public ResourceTemplateInfo register() {
             validate();
             if (uriTemplate == null) {
                 throw new IllegalStateException("uriTemplate must be set");
             }
             ResourceTemplateDefinitionInfo ret = new ResourceTemplateDefinitionInfo(name, title, description, serverNames,
-                    fun, asyncFun, runOnVirtualThread, uriTemplate, mimeType, annotations, metadata, icons, transportHints);
+                    fun, asyncFun, runOnVirtualThread, uriTemplate, mimeType, annotations, cacheControl, metadata, icons,
+                    transportHints);
             VariableMatcher variableMatcher = createMatcherFromUriTemplate(uriTemplate);
             ResourceTemplateMetadata templateMetadata = new ResourceTemplateMetadata(variableMatcher, ret);
             List<FeatureKey> keys = FeatureKey.list(name, serverNames);

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceTemplateMessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceTemplateMessageHandler.java
@@ -47,6 +47,7 @@ class ResourceTemplateMessageHandler extends MessageHandler {
             ResourceTemplateManager.ResourceTemplateInfo last = page.lastInfo();
             result.put("nextCursor", Cursor.encode(last.createdAt(), cursor.snapshotTimestamp()));
         }
+        putCacheControl(result, serverConfig.resourceTemplates().ttlMs(), serverConfig.resourceTemplates().cacheScope());
         return mcpRequest.sender().sendResult(id, result);
     }
 

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ToolMessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ToolMessageHandler.java
@@ -62,6 +62,7 @@ class ToolMessageHandler extends MessageHandler {
             ToolManager.ToolInfo last = page.lastInfo();
             result.put("nextCursor", Cursor.encode(last.createdAt(), cursor.snapshotTimestamp()));
         }
+        putCacheControl(result, serverConfig.tools().ttlMs(), serverConfig.tools().cacheScope());
         return mcpRequest.sender().sendResult(id, result);
     }
 

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/config/McpServerRuntimeConfig.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/config/McpServerRuntimeConfig.java
@@ -5,6 +5,7 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 
+import io.quarkiverse.mcp.server.CacheScope;
 import io.quarkiverse.mcp.server.McpLog.LogLevel;
 import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithName;
@@ -54,6 +55,11 @@ public interface McpServerRuntimeConfig {
      * Prompts config.
      */
     Prompts prompts();
+
+    /**
+     * Discover config.
+     */
+    Discover discover();
 
     /**
      * Sampling config.
@@ -229,6 +235,20 @@ public interface McpServerRuntimeConfig {
         @WithDefault("50")
         int pageSize();
 
+        /**
+         * The time-to-live in milliseconds for the {@code resources/list} result. Clients may consider the result fresh for
+         * this duration. A value of {@code 0} means immediately stale. A negative value (default) means the field is not
+         * included in
+         * the response.
+         */
+        @WithDefault("-1")
+        long ttlMs();
+
+        /**
+         * The cache scope for the {@code resources/list} result. If not set, the field is not included in the response.
+         */
+        Optional<CacheScope> cacheScope();
+
     }
 
     public interface ResourceTemplates {
@@ -241,6 +261,20 @@ public interface McpServerRuntimeConfig {
         @WithDefault("50")
         int pageSize();
 
+        /**
+         * The time-to-live in milliseconds for the {@code resources/templates/list} result. Clients may consider the result
+         * fresh for this duration. A value of {@code 0} means immediately stale. A negative value (default) means the field is
+         * not included in the response.
+         */
+        @WithDefault("-1")
+        long ttlMs();
+
+        /**
+         * The cache scope for the {@code resources/templates/list} result. If not set, the field is not included in the
+         * response.
+         */
+        Optional<CacheScope> cacheScope();
+
     }
 
     public interface Prompts {
@@ -252,6 +286,19 @@ public interface McpServerRuntimeConfig {
         @WithDefault("50")
         int pageSize();
 
+        /**
+         * The time-to-live in milliseconds for the {@code prompts/list} result. Clients may consider the result fresh for this
+         * duration. A value of {@code 0} means immediately stale. A negative value (default) means the field is not included in
+         * the response.
+         */
+        @WithDefault("-1")
+        long ttlMs();
+
+        /**
+         * The cache scope for the {@code prompts/list} result. If not set, the field is not included in the response.
+         */
+        Optional<CacheScope> cacheScope();
+
     }
 
     public interface Tools {
@@ -262,6 +309,19 @@ public interface McpServerRuntimeConfig {
          */
         @WithDefault("50")
         int pageSize();
+
+        /**
+         * The time-to-live in milliseconds for the {@code tools/list} result. Clients may consider the result fresh for this
+         * duration. A value of {@code 0} means immediately stale. A negative value (default) means the field is not included in
+         * the response.
+         */
+        @WithDefault("-1")
+        long ttlMs();
+
+        /**
+         * The cache scope for the {@code tools/list} result. If not set, the field is not included in the response.
+         */
+        Optional<CacheScope> cacheScope();
 
         /**
          * Structured content config.
@@ -305,6 +365,23 @@ public interface McpServerRuntimeConfig {
          */
         @WithDefault("false")
         boolean compatibilityMode();
+
+    }
+
+    public interface Discover {
+
+        /**
+         * The time-to-live in milliseconds for the {@code server/discover} result. Clients may consider the result fresh for
+         * this duration. A value of {@code 0} means immediately stale. A negative value (default) means the field is not
+         * included in the response.
+         */
+        @WithDefault("-1")
+        long ttlMs();
+
+        /**
+         * The cache scope for the {@code server/discover} result. If not set, the field is not included in the response.
+         */
+        Optional<CacheScope> cacheScope();
 
     }
 

--- a/core/runtime/src/test/java/io/quarkiverse/mcp/server/runtime/CacheControlTest.java
+++ b/core/runtime/src/test/java/io/quarkiverse/mcp/server/runtime/CacheControlTest.java
@@ -1,0 +1,25 @@
+package io.quarkiverse.mcp.server.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkiverse.mcp.server.CacheControl;
+import io.quarkiverse.mcp.server.CacheScope;
+
+public class CacheControlTest {
+
+    @Test
+    public void testCacheScopeNotNull() {
+        assertThrows(IllegalArgumentException.class, () -> new CacheControl(1000, null));
+    }
+
+    @Test
+    public void testValidCacheControl() {
+        CacheControl cc = new CacheControl(5000, CacheScope.PUBLIC);
+        assertEquals(5000, cc.ttlMs());
+        assertEquals(CacheScope.PUBLIC, cc.cacheScope());
+    }
+
+}

--- a/docs/modules/ROOT/pages/concepts-mcp-protocol.adoc
+++ b/docs/modules/ROOT/pages/concepts-mcp-protocol.adoc
@@ -214,6 +214,14 @@ The server responds with its supported versions, capabilities, and server info:
 No `initialized` notification is sent. Each subsequent request is self-contained.
 See xref:concepts-transports.adoc#_stateless_mode[Stateless Mode] for details on required headers and `_meta` fields.
 
+The `server/discover` result can include optional caching hints, configured via application properties:
+
+[source,properties]
+----
+quarkus.mcp.server.discover.ttl-ms=45000
+quarkus.mcp.server.discover.cache-scope=public
+----
+
 === Capability Checking
 
 After initialization, both parties know what features are available:

--- a/docs/modules/ROOT/pages/guides-implementing-prompts.adoc
+++ b/docs/modules/ROOT/pages/guides-implementing-prompts.adoc
@@ -241,6 +241,20 @@ public class SearchPrompts {
 
 The `CompleteContext.arguments()` method returns a `Map<String, String>` containing all previously completed argument values.
 
+== Cache Control
+
+MCP supports optional caching hints (`ttlMs` and `cacheScope`) in the `prompts/list` result, allowing clients to reuse the prompt list without re-fetching.
+These hints are configured via application properties:
+
+[source,properties]
+----
+quarkus.mcp.server.prompts.ttl-ms=30000
+quarkus.mcp.server.prompts.cache-scope=private
+----
+
+`ttl-ms` is a freshness hint in milliseconds — clients may consider the result fresh for this duration.
+`cache-scope` controls whether shared intermediaries may cache the response: `public` (any cache) or `private` (same authorization context only).
+
 == Programmatic API
 
 It's also possible to register a prompt programmatically with the `io.quarkiverse.mcp.server.PromptManager` API.

--- a/docs/modules/ROOT/pages/guides-implementing-resources.adoc
+++ b/docs/modules/ROOT/pages/guides-implementing-resources.adoc
@@ -222,6 +222,74 @@ BlobResourceContents largeFile(McpLog log, Progress progress) throws Exception {
 }
 ----
 
+== Cache Control
+
+MCP supports optional caching hints (`ttlMs` and `cacheScope`) in results, allowing clients to reuse responses without re-fetching.
+Cache control can be applied to `resources/list`, `resources/templates/list`, and `resources/read` results.
+
+=== List Results
+
+Caching hints for `resources/list` and `resources/templates/list` are configured via application properties:
+
+[source,properties]
+----
+quarkus.mcp.server.resources.ttl-ms=10000
+quarkus.mcp.server.resources.cache-scope=public
+quarkus.mcp.server.resource-templates.ttl-ms=20000
+quarkus.mcp.server.resource-templates.cache-scope=private
+----
+
+=== Resource Read
+
+Caching hints for `resources/read` results can be set via annotation or programmatically.
+When both are present, the programmatic `ResourceResponse` cache control takes precedence over the `@Resource.CacheControl` annotation.
+
+==== Annotation
+
+Use `@Resource.CacheControl` on `@Resource` or `@ResourceTemplate` methods:
+
+[source,java]
+----
+import io.quarkiverse.mcp.server.CacheScope;
+import io.quarkiverse.mcp.server.Resource;
+
+public class MyResources {
+
+    @Resource(uri = "file:///data.json",
+              cacheControl = @Resource.CacheControl(ttlMs = 5000, cacheScope = CacheScope.PRIVATE))
+    String data() {
+        return "{\"key\": \"value\"}";
+    }
+}
+----
+
+`ttlMs` is a freshness hint in milliseconds.
+`cacheScope` controls whether shared intermediaries may cache the response — `PUBLIC` (any cache) or `PRIVATE` (same authorization context only).
+
+==== Programmatic
+
+Return a `ResourceResponse` with explicit `CacheControl` to override any annotation or config value:
+
+[source,java]
+----
+import io.quarkiverse.mcp.server.CacheControl;
+import io.quarkiverse.mcp.server.CacheScope;
+import io.quarkiverse.mcp.server.Resource;
+import io.quarkiverse.mcp.server.ResourceResponse;
+import io.quarkiverse.mcp.server.TextResourceContents;
+
+public class MyResources {
+
+    @Resource(uri = "file:///dynamic.txt")
+    ResourceResponse dynamic() {
+        return new ResourceResponse(
+                List.of(TextResourceContents.create("file:///dynamic.txt", "dynamic content")),
+                Map.of(),
+                new CacheControl(9999, CacheScope.PRIVATE));
+    }
+}
+----
+
 == Subscriptions
 
 MCP clients can subscribe to a specific resource and receive update notifications.

--- a/docs/modules/ROOT/pages/guides-implementing-tools.adoc
+++ b/docs/modules/ROOT/pages/guides-implementing-tools.adoc
@@ -106,6 +106,20 @@ The programmatic API also allows you to remove existing tools at runtime (using 
 
 TIP: When using the Streamable HTTP transport, features added programmatically always force SSE initialization because it's not possible to determine whether SSE-dependent functionality (such as `Progress`, `McpLog`, `Sampling`, `Roots`, or `Elicitation`) will be used. If your handler does not use any of these, you can add the `TransportHint.STREAMABLE_HTTP_SKIP_SSE_INIT` hint via `addHint(TransportHint.STREAMABLE_HTTP_SKIP_SSE_INIT)` to skip the SSE initialization and improve performance.
 
+== Cache Control
+
+MCP supports optional caching hints (`ttlMs` and `cacheScope`) in the `tools/list` result, allowing clients to reuse the tool list without re-fetching.
+These hints are configured via application properties:
+
+[source,properties]
+----
+quarkus.mcp.server.tools.ttl-ms=60000
+quarkus.mcp.server.tools.cache-scope=public
+----
+
+`ttl-ms` is a freshness hint in milliseconds — clients may consider the result fresh for this duration.
+`cache-scope` controls whether shared intermediaries may cache the response: `public` (any cache) or `private` (same authorization context only).
+
 == LangChain4j Support
 
 The `@dev.langchain4j.agent.tool.Tool` and `@dev.langchain4j.agent.tool.P` annotations from LangChain4j can be used instead of `@Tool`/`@ToolArg`.

--- a/docs/modules/ROOT/pages/includes/quarkus-mcp-server-core.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-mcp-server-core.adoc
@@ -933,6 +933,58 @@ endif::add-copy-button-to-env-var[]
 |int
 |`+++50+++`
 
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-resources-ttl-ms]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-resources-ttl-ms[`+++quarkus.mcp.server.resources.ttl-ms+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.resources.ttl-ms+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`+++quarkus.mcp.server."server-name".resources.ttl-ms+++`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server."server-name".resources.ttl-ms+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The time-to-live in milliseconds for the `resources/list` result. Clients may consider the result fresh for this duration. A value of `0` means immediately stale. A negative value (default) means the field is not included in the response.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_RESOURCES_TTL_MS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_RESOURCES_TTL_MS+++`
+endif::add-copy-button-to-env-var[]
+--
+|long
+|`+++-1+++`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-resources-cache-scope]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-resources-cache-scope[`+++quarkus.mcp.server.resources.cache-scope+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.resources.cache-scope+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`+++quarkus.mcp.server."server-name".resources.cache-scope+++`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server."server-name".resources.cache-scope+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The cache scope for the `resources/list` result. If not set, the field is not included in the response.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_RESOURCES_CACHE_SCOPE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_RESOURCES_CACHE_SCOPE+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`public`, `private`
+|
+
 a| [[quarkus-mcp-server-core_quarkus-mcp-server-resource-templates-page-size]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-resource-templates-page-size[`+++quarkus.mcp.server.resource-templates.page-size+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.mcp.server.resource-templates.page-size+++[]
@@ -959,6 +1011,58 @@ endif::add-copy-button-to-env-var[]
 |int
 |`+++50+++`
 
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-resource-templates-ttl-ms]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-resource-templates-ttl-ms[`+++quarkus.mcp.server.resource-templates.ttl-ms+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.resource-templates.ttl-ms+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`+++quarkus.mcp.server."server-name".resource-templates.ttl-ms+++`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server."server-name".resource-templates.ttl-ms+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The time-to-live in milliseconds for the `resources/templates/list` result. Clients may consider the result fresh for this duration. A value of `0` means immediately stale. A negative value (default) means the field is not included in the response.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_RESOURCE_TEMPLATES_TTL_MS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_RESOURCE_TEMPLATES_TTL_MS+++`
+endif::add-copy-button-to-env-var[]
+--
+|long
+|`+++-1+++`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-resource-templates-cache-scope]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-resource-templates-cache-scope[`+++quarkus.mcp.server.resource-templates.cache-scope+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.resource-templates.cache-scope+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`+++quarkus.mcp.server."server-name".resource-templates.cache-scope+++`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server."server-name".resource-templates.cache-scope+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The cache scope for the `resources/templates/list` result. If not set, the field is not included in the response.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_RESOURCE_TEMPLATES_CACHE_SCOPE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_RESOURCE_TEMPLATES_CACHE_SCOPE+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`public`, `private`
+|
+
 a| [[quarkus-mcp-server-core_quarkus-mcp-server-tools-page-size]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-tools-page-size[`+++quarkus.mcp.server.tools.page-size+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.mcp.server.tools.page-size+++[]
@@ -984,6 +1088,58 @@ endif::add-copy-button-to-env-var[]
 --
 |int
 |`+++50+++`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-tools-ttl-ms]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-tools-ttl-ms[`+++quarkus.mcp.server.tools.ttl-ms+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.tools.ttl-ms+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`+++quarkus.mcp.server."server-name".tools.ttl-ms+++`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server."server-name".tools.ttl-ms+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The time-to-live in milliseconds for the `tools/list` result. Clients may consider the result fresh for this duration. A value of `0` means immediately stale. A negative value (default) means the field is not included in the response.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_TOOLS_TTL_MS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_TOOLS_TTL_MS+++`
+endif::add-copy-button-to-env-var[]
+--
+|long
+|`+++-1+++`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-tools-cache-scope]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-tools-cache-scope[`+++quarkus.mcp.server.tools.cache-scope+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.tools.cache-scope+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`+++quarkus.mcp.server."server-name".tools.cache-scope+++`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server."server-name".tools.cache-scope+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The cache scope for the `tools/list` result. If not set, the field is not included in the response.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_TOOLS_CACHE_SCOPE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_TOOLS_CACHE_SCOPE+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`public`, `private`
+|
 
 a| [[quarkus-mcp-server-core_quarkus-mcp-server-tools-structured-content-compatibility-mode]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-tools-structured-content-compatibility-mode[`+++quarkus.mcp.server.tools.structured-content.compatibility-mode+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -1063,6 +1219,110 @@ endif::add-copy-button-to-env-var[]
 --
 |int
 |`+++50+++`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-prompts-ttl-ms]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-prompts-ttl-ms[`+++quarkus.mcp.server.prompts.ttl-ms+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.prompts.ttl-ms+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`+++quarkus.mcp.server."server-name".prompts.ttl-ms+++`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server."server-name".prompts.ttl-ms+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The time-to-live in milliseconds for the `prompts/list` result. Clients may consider the result fresh for this duration. A value of `0` means immediately stale. A negative value (default) means the field is not included in the response.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_PROMPTS_TTL_MS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_PROMPTS_TTL_MS+++`
+endif::add-copy-button-to-env-var[]
+--
+|long
+|`+++-1+++`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-prompts-cache-scope]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-prompts-cache-scope[`+++quarkus.mcp.server.prompts.cache-scope+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.prompts.cache-scope+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`+++quarkus.mcp.server."server-name".prompts.cache-scope+++`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server."server-name".prompts.cache-scope+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The cache scope for the `prompts/list` result. If not set, the field is not included in the response.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_PROMPTS_CACHE_SCOPE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_PROMPTS_CACHE_SCOPE+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`public`, `private`
+|
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-discover-ttl-ms]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-discover-ttl-ms[`+++quarkus.mcp.server.discover.ttl-ms+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.discover.ttl-ms+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`+++quarkus.mcp.server."server-name".discover.ttl-ms+++`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server."server-name".discover.ttl-ms+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The time-to-live in milliseconds for the `server/discover` result. Clients may consider the result fresh for this duration. A value of `0` means immediately stale. A negative value (default) means the field is not included in the response.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_DISCOVER_TTL_MS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_DISCOVER_TTL_MS+++`
+endif::add-copy-button-to-env-var[]
+--
+|long
+|`+++-1+++`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-discover-cache-scope]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-discover-cache-scope[`+++quarkus.mcp.server.discover.cache-scope+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.discover.cache-scope+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`+++quarkus.mcp.server."server-name".discover.cache-scope+++`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server."server-name".discover.cache-scope+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The cache scope for the `server/discover` result. If not set, the field is not included in the response.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_DISCOVER_CACHE_SCOPE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_DISCOVER_CACHE_SCOPE+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`public`, `private`
+|
 
 a| [[quarkus-mcp-server-core_quarkus-mcp-server-sampling-default-timeout]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-sampling-default-timeout[`+++quarkus.mcp.server.sampling.default-timeout+++`]##
 ifdef::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-mcp-server-core_quarkus.mcp.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-mcp-server-core_quarkus.mcp.adoc
@@ -933,6 +933,58 @@ endif::add-copy-button-to-env-var[]
 |int
 |`+++50+++`
 
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-resources-ttl-ms]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-resources-ttl-ms[`+++quarkus.mcp.server.resources.ttl-ms+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.resources.ttl-ms+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`+++quarkus.mcp.server."server-name".resources.ttl-ms+++`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server."server-name".resources.ttl-ms+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The time-to-live in milliseconds for the `resources/list` result. Clients may consider the result fresh for this duration. A value of `0` means immediately stale. A negative value (default) means the field is not included in the response.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_RESOURCES_TTL_MS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_RESOURCES_TTL_MS+++`
+endif::add-copy-button-to-env-var[]
+--
+|long
+|`+++-1+++`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-resources-cache-scope]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-resources-cache-scope[`+++quarkus.mcp.server.resources.cache-scope+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.resources.cache-scope+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`+++quarkus.mcp.server."server-name".resources.cache-scope+++`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server."server-name".resources.cache-scope+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The cache scope for the `resources/list` result. If not set, the field is not included in the response.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_RESOURCES_CACHE_SCOPE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_RESOURCES_CACHE_SCOPE+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`public`, `private`
+|
+
 a| [[quarkus-mcp-server-core_quarkus-mcp-server-resource-templates-page-size]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-resource-templates-page-size[`+++quarkus.mcp.server.resource-templates.page-size+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.mcp.server.resource-templates.page-size+++[]
@@ -959,6 +1011,58 @@ endif::add-copy-button-to-env-var[]
 |int
 |`+++50+++`
 
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-resource-templates-ttl-ms]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-resource-templates-ttl-ms[`+++quarkus.mcp.server.resource-templates.ttl-ms+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.resource-templates.ttl-ms+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`+++quarkus.mcp.server."server-name".resource-templates.ttl-ms+++`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server."server-name".resource-templates.ttl-ms+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The time-to-live in milliseconds for the `resources/templates/list` result. Clients may consider the result fresh for this duration. A value of `0` means immediately stale. A negative value (default) means the field is not included in the response.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_RESOURCE_TEMPLATES_TTL_MS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_RESOURCE_TEMPLATES_TTL_MS+++`
+endif::add-copy-button-to-env-var[]
+--
+|long
+|`+++-1+++`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-resource-templates-cache-scope]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-resource-templates-cache-scope[`+++quarkus.mcp.server.resource-templates.cache-scope+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.resource-templates.cache-scope+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`+++quarkus.mcp.server."server-name".resource-templates.cache-scope+++`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server."server-name".resource-templates.cache-scope+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The cache scope for the `resources/templates/list` result. If not set, the field is not included in the response.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_RESOURCE_TEMPLATES_CACHE_SCOPE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_RESOURCE_TEMPLATES_CACHE_SCOPE+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`public`, `private`
+|
+
 a| [[quarkus-mcp-server-core_quarkus-mcp-server-tools-page-size]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-tools-page-size[`+++quarkus.mcp.server.tools.page-size+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.mcp.server.tools.page-size+++[]
@@ -984,6 +1088,58 @@ endif::add-copy-button-to-env-var[]
 --
 |int
 |`+++50+++`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-tools-ttl-ms]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-tools-ttl-ms[`+++quarkus.mcp.server.tools.ttl-ms+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.tools.ttl-ms+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`+++quarkus.mcp.server."server-name".tools.ttl-ms+++`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server."server-name".tools.ttl-ms+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The time-to-live in milliseconds for the `tools/list` result. Clients may consider the result fresh for this duration. A value of `0` means immediately stale. A negative value (default) means the field is not included in the response.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_TOOLS_TTL_MS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_TOOLS_TTL_MS+++`
+endif::add-copy-button-to-env-var[]
+--
+|long
+|`+++-1+++`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-tools-cache-scope]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-tools-cache-scope[`+++quarkus.mcp.server.tools.cache-scope+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.tools.cache-scope+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`+++quarkus.mcp.server."server-name".tools.cache-scope+++`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server."server-name".tools.cache-scope+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The cache scope for the `tools/list` result. If not set, the field is not included in the response.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_TOOLS_CACHE_SCOPE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_TOOLS_CACHE_SCOPE+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`public`, `private`
+|
 
 a| [[quarkus-mcp-server-core_quarkus-mcp-server-tools-structured-content-compatibility-mode]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-tools-structured-content-compatibility-mode[`+++quarkus.mcp.server.tools.structured-content.compatibility-mode+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -1063,6 +1219,110 @@ endif::add-copy-button-to-env-var[]
 --
 |int
 |`+++50+++`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-prompts-ttl-ms]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-prompts-ttl-ms[`+++quarkus.mcp.server.prompts.ttl-ms+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.prompts.ttl-ms+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`+++quarkus.mcp.server."server-name".prompts.ttl-ms+++`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server."server-name".prompts.ttl-ms+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The time-to-live in milliseconds for the `prompts/list` result. Clients may consider the result fresh for this duration. A value of `0` means immediately stale. A negative value (default) means the field is not included in the response.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_PROMPTS_TTL_MS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_PROMPTS_TTL_MS+++`
+endif::add-copy-button-to-env-var[]
+--
+|long
+|`+++-1+++`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-prompts-cache-scope]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-prompts-cache-scope[`+++quarkus.mcp.server.prompts.cache-scope+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.prompts.cache-scope+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`+++quarkus.mcp.server."server-name".prompts.cache-scope+++`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server."server-name".prompts.cache-scope+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The cache scope for the `prompts/list` result. If not set, the field is not included in the response.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_PROMPTS_CACHE_SCOPE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_PROMPTS_CACHE_SCOPE+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`public`, `private`
+|
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-discover-ttl-ms]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-discover-ttl-ms[`+++quarkus.mcp.server.discover.ttl-ms+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.discover.ttl-ms+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`+++quarkus.mcp.server."server-name".discover.ttl-ms+++`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server."server-name".discover.ttl-ms+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The time-to-live in milliseconds for the `server/discover` result. Clients may consider the result fresh for this duration. A value of `0` means immediately stale. A negative value (default) means the field is not included in the response.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_DISCOVER_TTL_MS+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_DISCOVER_TTL_MS+++`
+endif::add-copy-button-to-env-var[]
+--
+|long
+|`+++-1+++`
+
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-discover-cache-scope]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-discover-cache-scope[`+++quarkus.mcp.server.discover.cache-scope+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.discover.cache-scope+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`+++quarkus.mcp.server."server-name".discover.cache-scope+++`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server."server-name".discover.cache-scope+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+The cache scope for the `server/discover` result. If not set, the field is not included in the response.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_DISCOVER_CACHE_SCOPE+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_DISCOVER_CACHE_SCOPE+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`public`, `private`
+|
 
 a| [[quarkus-mcp-server-core_quarkus-mcp-server-sampling-default-timeout]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-sampling-default-timeout[`+++quarkus.mcp.server.sampling.default-timeout+++`]##
 ifdef::add-copy-button-to-config-props[]

--- a/test/src/main/java/io/quarkiverse/mcp/server/test/McpAssured.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/McpAssured.java
@@ -8,6 +8,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Function;
 
+import io.quarkiverse.mcp.server.CacheControl;
 import io.quarkiverse.mcp.server.ClientCapability;
 import io.quarkiverse.mcp.server.CompletionResponse;
 import io.quarkiverse.mcp.server.Content;
@@ -1618,7 +1619,8 @@ public class McpAssured {
     public record InitResult(String protocolVersion,
             // Keep serverName, serverTitle and serverVersion for backwards compatibility
             String serverName, String serverTitle, String serverVersion,
-            List<ServerCapability> capabilities, String instructions, Implementation implementation, JsonObject meta) {
+            List<ServerCapability> capabilities, String instructions, Implementation implementation, JsonObject meta,
+            CacheControl cacheControl) {
 
     }
 
@@ -1626,7 +1628,7 @@ public class McpAssured {
 
     }
 
-    public record ToolsPage(List<ToolInfo> tools, String nextCursor) {
+    public record ToolsPage(List<ToolInfo> tools, String nextCursor, CacheControl cacheControl) {
 
         public int size() {
             return tools().size();
@@ -1638,7 +1640,7 @@ public class McpAssured {
 
     }
 
-    public record PromptsPage(List<PromptInfo> prompts, String nextCursor) {
+    public record PromptsPage(List<PromptInfo> prompts, String nextCursor, CacheControl cacheControl) {
 
         public int size() {
             return prompts().size();
@@ -1650,7 +1652,7 @@ public class McpAssured {
 
     }
 
-    public record ResourcesPage(List<ResourceInfo> resources, String nextCursor) {
+    public record ResourcesPage(List<ResourceInfo> resources, String nextCursor, CacheControl cacheControl) {
 
         public int size() {
             return resources().size();
@@ -1661,7 +1663,8 @@ public class McpAssured {
         }
     }
 
-    public record ResourcesTemplatesPage(List<ResourceTemplateInfo> templates, String nextCursor) {
+    public record ResourcesTemplatesPage(List<ResourceTemplateInfo> templates, String nextCursor,
+            CacheControl cacheControl) {
 
         public int size() {
             return templates().size();

--- a/test/src/main/java/io/quarkiverse/mcp/server/test/McpSseTestClientImpl.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/McpSseTestClientImpl.java
@@ -141,7 +141,8 @@ class McpSseTestClientImpl extends McpTestClientBase<McpSseAssert, McpSseTestCli
                 capabilities,
                 initResult.getString("instructions"),
                 implementation,
-                initResult.getJsonObject("_meta"));
+                initResult.getJsonObject("_meta"),
+                null);
         if (assertFunction != null) {
             assertFunction.accept(r);
         }

--- a/test/src/main/java/io/quarkiverse/mcp/server/test/McpStdioTestClientImpl.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/McpStdioTestClientImpl.java
@@ -170,7 +170,8 @@ class McpStdioTestClientImpl extends McpTestClientBase<McpStdioAssert, McpStdioT
                 capabilities,
                 discoverResult.getString("instructions"),
                 implementation,
-                discoverResult.getJsonObject("_meta"));
+                discoverResult.getJsonObject("_meta"),
+                parseCacheControl(discoverResult));
         if (assertFunction != null) {
             assertFunction.accept(r);
         }
@@ -214,7 +215,8 @@ class McpStdioTestClientImpl extends McpTestClientBase<McpStdioAssert, McpStdioT
                 capabilities,
                 initResult.getString("instructions"),
                 implementation,
-                initResult.getJsonObject("_meta"));
+                initResult.getJsonObject("_meta"),
+                null);
         if (assertFunction != null) {
             assertFunction.accept(r);
         }

--- a/test/src/main/java/io/quarkiverse/mcp/server/test/McpStreamableTestClientImpl.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/McpStreamableTestClientImpl.java
@@ -100,7 +100,8 @@ class McpStreamableTestClientImpl extends McpTestClientBase<McpStreamableAssert,
                 capabilities,
                 discoverResult.getString("instructions"),
                 implementation,
-                discoverResult.getJsonObject("_meta"));
+                discoverResult.getJsonObject("_meta"),
+                parseCacheControl(discoverResult));
         if (assertFunction != null) {
             assertFunction.accept(r);
         }
@@ -153,7 +154,8 @@ class McpStreamableTestClientImpl extends McpTestClientBase<McpStreamableAssert,
                 capabilities,
                 initResult.getString("instructions"),
                 implementation,
-                initResult.getJsonObject("_meta"));
+                initResult.getJsonObject("_meta"),
+                null);
         if (assertFunction != null) {
             assertFunction.accept(r);
         }

--- a/test/src/main/java/io/quarkiverse/mcp/server/test/McpTestClientBase.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/McpTestClientBase.java
@@ -22,6 +22,8 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
+import io.quarkiverse.mcp.server.CacheControl;
+import io.quarkiverse.mcp.server.CacheScope;
 import io.quarkiverse.mcp.server.ClientCapability;
 import io.quarkiverse.mcp.server.CompletionResponse;
 import io.quarkiverse.mcp.server.Content;
@@ -161,6 +163,16 @@ abstract class McpTestClientBase<ASSERT extends McpAssert<ASSERT>, CLIENT extend
         JsonObject result = response.getJsonObject("result");
         assertNotNull(result, "Expected result response but received: " + response);
         return result;
+    }
+
+    protected static CacheControl parseCacheControl(JsonObject result) {
+        Long ttlMs = result.getLong("ttlMs");
+        String cacheScopeStr = result.getString("cacheScope");
+        if (ttlMs == null && cacheScopeStr == null) {
+            return null;
+        }
+        return new CacheControl(ttlMs != null ? ttlMs : -1,
+                cacheScopeStr != null ? CacheScope.valueOf(cacheScopeStr.toUpperCase()) : null);
     }
 
     protected static JsonObject assertErrorResponse(JsonObject request, JsonObject response) {
@@ -1300,7 +1312,8 @@ abstract class McpTestClientBase<ASSERT extends McpAssert<ASSERT>, CLIENT extend
                 JsonObject info = resources.getJsonObject(i);
                 infos.add(parseResource(info));
             }
-            assertFunction.accept(new ResourcesPage(infos, result.getString("nextCursor")));
+            assertFunction.accept(new ResourcesPage(infos, result.getString("nextCursor"),
+                    parseCacheControl(result)));
         }
 
         private ResourceInfo parseResource(JsonObject resource) {
@@ -1324,7 +1337,8 @@ abstract class McpTestClientBase<ASSERT extends McpAssert<ASSERT>, CLIENT extend
                 JsonObject info = templates.getJsonObject(i);
                 infos.add(parseResourceTemplate(info));
             }
-            assertFunction.accept(new ResourcesTemplatesPage(infos, result.getString("nextCursor")));
+            assertFunction.accept(new ResourcesTemplatesPage(infos, result.getString("nextCursor"),
+                    parseCacheControl(result)));
         }
 
         private ResourceTemplateInfo parseResourceTemplate(JsonObject resource) {
@@ -1351,7 +1365,8 @@ abstract class McpTestClientBase<ASSERT extends McpAssert<ASSERT>, CLIENT extend
                 JsonObject prompt = prompts.getJsonObject(i);
                 infos.add(parsePrompt(prompt));
             }
-            assertFunction.accept(new PromptsPage(infos, result.getString("nextCursor")));
+            assertFunction.accept(new PromptsPage(infos, result.getString("nextCursor"),
+                    parseCacheControl(result)));
         }
 
         private PromptInfo parsePrompt(JsonObject prompt) {
@@ -1430,7 +1445,8 @@ abstract class McpTestClientBase<ASSERT extends McpAssert<ASSERT>, CLIENT extend
                 JsonObject tool = tools.getJsonObject(i);
                 infos.add(parseTool(tool));
             }
-            assertFunction.accept(new ToolsPage(infos, result.getString("nextCursor")));
+            assertFunction.accept(new ToolsPage(infos, result.getString("nextCursor"),
+                    parseCacheControl(result)));
         }
 
         private ToolInfo parseTool(JsonObject tool) {
@@ -1470,7 +1486,8 @@ abstract class McpTestClientBase<ASSERT extends McpAssert<ASSERT>, CLIENT extend
                     resourceContents.add(Contents.parseResourceContents(contents.getJsonObject(i)));
                 }
             }
-            assertFunction.accept(new ResourceResponse(resourceContents, Contents.parseMeta(result)));
+            assertFunction.accept(new ResourceResponse(resourceContents, Contents.parseMeta(result),
+                    parseCacheControl(result)));
         }
 
     }

--- a/test/src/main/java/io/quarkiverse/mcp/server/test/McpWebSocketTestClientImpl.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/McpWebSocketTestClientImpl.java
@@ -93,7 +93,8 @@ class McpWebSocketTestClientImpl extends McpTestClientBase<McpWebSocketAssert, M
                 capabilities,
                 discoverResult.getString("instructions"),
                 implementation,
-                discoverResult.getJsonObject("_meta"));
+                discoverResult.getJsonObject("_meta"),
+                parseCacheControl(discoverResult));
         if (assertFunction != null) {
             assertFunction.accept(r);
         }
@@ -136,7 +137,8 @@ class McpWebSocketTestClientImpl extends McpTestClientBase<McpWebSocketAssert, M
                 capabilities,
                 initResult.getString("instructions"),
                 implementation,
-                initResult.getJsonObject("_meta"));
+                initResult.getJsonObject("_meta"),
+                null);
         if (assertFunction != null) {
             assertFunction.accept(r);
         }

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/cachecontrol/CacheControlResources.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/cachecontrol/CacheControlResources.java
@@ -1,0 +1,52 @@
+package io.quarkiverse.mcp.server.test.cachecontrol;
+
+import java.util.List;
+
+import io.quarkiverse.mcp.server.CacheControl;
+import io.quarkiverse.mcp.server.CacheScope;
+import io.quarkiverse.mcp.server.Prompt;
+import io.quarkiverse.mcp.server.PromptMessage;
+import io.quarkiverse.mcp.server.PromptResponse;
+import io.quarkiverse.mcp.server.RequestUri;
+import io.quarkiverse.mcp.server.Resource;
+import io.quarkiverse.mcp.server.ResourceResponse;
+import io.quarkiverse.mcp.server.ResourceTemplate;
+import io.quarkiverse.mcp.server.Role;
+import io.quarkiverse.mcp.server.TextContent;
+import io.quarkiverse.mcp.server.TextResourceContents;
+import io.quarkiverse.mcp.server.Tool;
+
+public class CacheControlResources {
+
+    @Resource(uri = "file:///cc/alpha", cacheControl = @Resource.CacheControl(ttlMs = 5000, cacheScope = CacheScope.PRIVATE))
+    ResourceResponse alpha(RequestUri uri) {
+        return new ResourceResponse(List.of(new TextResourceContents(uri.value(), "alpha", null)));
+    }
+
+    @Resource(uri = "file:///cc/bravo")
+    ResourceResponse bravo(RequestUri uri) {
+        return new ResourceResponse(List.of(new TextResourceContents(uri.value(), "bravo", null)));
+    }
+
+    @Resource(uri = "file:///cc/programmatic_override", cacheControl = @Resource.CacheControl(ttlMs = 1000, cacheScope = CacheScope.PUBLIC))
+    ResourceResponse programmaticOverride(RequestUri uri) {
+        // ResourceResponse cache control takes precedence over annotation
+        return new ResourceResponse(List.of(new TextResourceContents(uri.value(), "override", null)),
+                null, new CacheControl(9999, CacheScope.PRIVATE));
+    }
+
+    @ResourceTemplate(uriTemplate = "file:///cc/template/{id}", cacheControl = @Resource.CacheControl(ttlMs = 3000, cacheScope = CacheScope.PUBLIC))
+    TextResourceContents template(String id, RequestUri uri) {
+        return new TextResourceContents(uri.value(), "template-" + id, null);
+    }
+
+    @Tool
+    TextContent ccTool(String input) {
+        return new TextContent(input);
+    }
+
+    @Prompt
+    PromptResponse ccPrompt() {
+        return new PromptResponse("test", List.of(new PromptMessage(Role.USER, new TextContent("hello"))));
+    }
+}

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/cachecontrol/CacheControlTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/cachecontrol/CacheControlTest.java
@@ -1,0 +1,129 @@
+package io.quarkiverse.mcp.server.test.cachecontrol;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.CacheScope;
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkiverse.mcp.server.test.McpAssured.McpStreamableTestClient;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class CacheControlTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .withApplicationRoot(
+                    root -> root.addClasses(CacheControlResources.class))
+            .overrideConfigKey("quarkus.mcp.server.tools.ttl-ms", "60000")
+            .overrideConfigKey("quarkus.mcp.server.tools.cache-scope", "public")
+            .overrideConfigKey("quarkus.mcp.server.prompts.ttl-ms", "30000")
+            .overrideConfigKey("quarkus.mcp.server.prompts.cache-scope", "private")
+            .overrideConfigKey("quarkus.mcp.server.resources.ttl-ms", "10000")
+            .overrideConfigKey("quarkus.mcp.server.resources.cache-scope", "public")
+            .overrideConfigKey("quarkus.mcp.server.resource-templates.ttl-ms", "20000")
+            .overrideConfigKey("quarkus.mcp.server.resource-templates.cache-scope", "private");
+
+    @Test
+    public void testToolsListCacheControl() {
+        McpStreamableTestClient client = McpAssured.newConnectedStreamableClient();
+        client.when()
+                .toolsList(p -> {
+                    assertNotNull(p.cacheControl());
+                    assertEquals(60000, p.cacheControl().ttlMs());
+                    assertEquals(CacheScope.PUBLIC, p.cacheControl().cacheScope());
+                })
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testPromptsListCacheControl() {
+        McpStreamableTestClient client = McpAssured.newConnectedStreamableClient();
+        client.when()
+                .promptsList(p -> {
+                    assertNotNull(p.cacheControl());
+                    assertEquals(30000, p.cacheControl().ttlMs());
+                    assertEquals(CacheScope.PRIVATE, p.cacheControl().cacheScope());
+                })
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testResourcesListCacheControl() {
+        McpStreamableTestClient client = McpAssured.newConnectedStreamableClient();
+        client.when()
+                .resourcesList(p -> {
+                    assertNotNull(p.cacheControl());
+                    assertEquals(10000, p.cacheControl().ttlMs());
+                    assertEquals(CacheScope.PUBLIC, p.cacheControl().cacheScope());
+                })
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testResourceTemplatesListCacheControl() {
+        McpStreamableTestClient client = McpAssured.newConnectedStreamableClient();
+        client.when()
+                .resourcesTemplatesList(p -> {
+                    assertNotNull(p.cacheControl());
+                    assertEquals(20000, p.cacheControl().ttlMs());
+                    assertEquals(CacheScope.PRIVATE, p.cacheControl().cacheScope());
+                })
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testResourceReadAnnotationCacheControl() {
+        McpStreamableTestClient client = McpAssured.newConnectedStreamableClient();
+        client.when()
+                // alpha has @CacheControl(ttlMs = 5000, cacheScope = PRIVATE) - takes precedence over config
+                .resourcesRead("file:///cc/alpha", r -> {
+                    assertEquals("alpha", r.contents().get(0).asText().text());
+                    assertEquals(5000L, r.cacheControl().ttlMs());
+                    assertEquals(CacheScope.PRIVATE, r.cacheControl().cacheScope());
+                })
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testResourceReadNoAnnotationNoCacheControl() {
+        McpStreamableTestClient client = McpAssured.newConnectedStreamableClient();
+        client.when()
+                // bravo has no @CacheControl and no programmatic override - no cache control in response
+                .resourcesRead("file:///cc/bravo", r -> {
+                    assertEquals("bravo", r.contents().get(0).asText().text());
+                    assertNull(r.cacheControl());
+                })
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testResourceReadProgrammaticOverride() {
+        McpStreamableTestClient client = McpAssured.newConnectedStreamableClient();
+        client.when()
+                // programmaticOverride has @CacheControl(ttlMs=1000) but ResourceResponse sets ttlMs=9999
+                .resourcesRead("file:///cc/programmatic_override", r -> {
+                    assertEquals("override", r.contents().get(0).asText().text());
+                    assertEquals(9999L, r.cacheControl().ttlMs());
+                    assertEquals(CacheScope.PRIVATE, r.cacheControl().cacheScope());
+                })
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testResourceTemplateReadCacheControl() {
+        McpStreamableTestClient client = McpAssured.newConnectedStreamableClient();
+        client.when()
+                // template has @CacheControl(ttlMs = 3000, cacheScope = PUBLIC)
+                .resourcesRead("file:///cc/template/42", r -> {
+                    assertEquals("template-42", r.contents().get(0).asText().text());
+                    assertEquals(3000L, r.cacheControl().ttlMs());
+                    assertEquals(CacheScope.PUBLIC, r.cacheControl().cacheScope());
+                })
+                .thenAssertResults();
+    }
+}

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/cachecontrol/NoCacheControlResources.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/cachecontrol/NoCacheControlResources.java
@@ -1,0 +1,38 @@
+package io.quarkiverse.mcp.server.test.cachecontrol;
+
+import java.util.List;
+
+import io.quarkiverse.mcp.server.Prompt;
+import io.quarkiverse.mcp.server.PromptMessage;
+import io.quarkiverse.mcp.server.PromptResponse;
+import io.quarkiverse.mcp.server.RequestUri;
+import io.quarkiverse.mcp.server.Resource;
+import io.quarkiverse.mcp.server.ResourceResponse;
+import io.quarkiverse.mcp.server.ResourceTemplate;
+import io.quarkiverse.mcp.server.Role;
+import io.quarkiverse.mcp.server.TextContent;
+import io.quarkiverse.mcp.server.TextResourceContents;
+import io.quarkiverse.mcp.server.Tool;
+
+public class NoCacheControlResources {
+
+    @Resource(uri = "file:///nocc/alpha")
+    ResourceResponse alpha(RequestUri uri) {
+        return new ResourceResponse(List.of(new TextResourceContents(uri.value(), "alpha", null)));
+    }
+
+    @ResourceTemplate(uriTemplate = "file:///nocc/template/{id}")
+    TextResourceContents template(String id, RequestUri uri) {
+        return new TextResourceContents(uri.value(), "template-" + id, null);
+    }
+
+    @Tool
+    TextContent noccTool(String input) {
+        return new TextContent(input);
+    }
+
+    @Prompt
+    PromptResponse noccPrompt() {
+        return new PromptResponse("test", List.of(new PromptMessage(Role.USER, new TextContent("hello"))));
+    }
+}

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/cachecontrol/NoCacheControlTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/cachecontrol/NoCacheControlTest.java
@@ -1,0 +1,40 @@
+package io.quarkiverse.mcp.server.test.cachecontrol;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkiverse.mcp.server.test.McpAssured.McpStreamableTestClient;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class NoCacheControlTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .withApplicationRoot(
+                    root -> root.addClasses(NoCacheControlResources.class));
+
+    @Test
+    public void testNoCacheControlOnList() {
+        McpStreamableTestClient client = McpAssured.newConnectedStreamableClient();
+        client.when()
+                .toolsList(p -> assertNull(p.cacheControl()))
+                .promptsList(p -> assertNull(p.cacheControl()))
+                .resourcesList(p -> assertNull(p.cacheControl()))
+                .resourcesTemplatesList(p -> assertNull(p.cacheControl()))
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testNoCacheControlOnResourceRead() {
+        McpStreamableTestClient client = McpAssured.newConnectedStreamableClient();
+        client.when()
+                .resourcesRead("file:///nocc/alpha", r -> {
+                    assertNull(r.cacheControl());
+                })
+                .thenAssertResults();
+    }
+}

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/stateless/StatelessTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/stateless/StatelessTest.java
@@ -13,6 +13,7 @@ import jakarta.inject.Inject;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkiverse.mcp.server.CacheScope;
 import io.quarkiverse.mcp.server.JsonRpcErrorCodes;
 import io.quarkiverse.mcp.server.McpConnection;
 import io.quarkiverse.mcp.server.McpLog.LogLevel;
@@ -30,7 +31,9 @@ public class StatelessTest extends McpServerTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = defaultConfig()
-            .withApplicationRoot(root -> root.addClass(MyTools.class));
+            .withApplicationRoot(root -> root.addClass(MyTools.class))
+            .overrideConfigKey("quarkus.mcp.server.discover.ttl-ms", "45000")
+            .overrideConfigKey("quarkus.mcp.server.discover.cache-scope", "public");
 
     @Inject
     ConnectionManager connectionManager;
@@ -44,6 +47,9 @@ public class StatelessTest extends McpServerTest {
                     assertNotNull(initResult);
                     assertNotNull(initResult.capabilities());
                     assertNotNull(initResult.implementation());
+                    assertNotNull(initResult.cacheControl());
+                    assertEquals(45000, initResult.cacheControl().ttlMs());
+                    assertEquals(CacheScope.PUBLIC, initResult.cacheControl().cacheScope());
                 });
         assertTrue(client.isConnected());
         assertNull(client.mcpSessionId());


### PR DESCRIPTION
- add ttlMs/cacheScope caching hints (MCP spec draft SEP-2549) to tools/list, prompts/list, resources/list, resources/templates/list, resources/read, and server/discover results
- cache control for list endpoints and server/discover is config-driven
- for resources/read it can be set via annotation or programmatically