### PR TITLE
Test the default cacheScope for resource templates with CacheControl

### DIFF
--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/cachecontrol/CacheControlResources.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/cachecontrol/CacheControlResources.java
@@ -40,6 +40,11 @@ public class CacheControlResources {
         return new TextResourceContents(uri.value(), "template-" + id, null);
     }
 
+    @ResourceTemplate(uriTemplate = "file:///cc/template_default_scope/{id}", cacheControl = @Resource.CacheControl(ttlMs = 7000))
+    TextResourceContents templateDefaultScope(String id, RequestUri uri) {
+        return new TextResourceContents(uri.value(), "template-default-scope-" + id, null);
+    }
+
     @Tool
     TextContent ccTool(String input) {
         return new TextContent(input);

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/cachecontrol/CacheControlTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/cachecontrol/CacheControlTest.java
@@ -115,6 +115,19 @@ public class CacheControlTest extends McpServerTest {
     }
 
     @Test
+    public void testResourceTemplateReadDefaultScope() {
+        McpStreamableTestClient client = McpAssured.newConnectedStreamableClient();
+        client.when()
+                // templateDefaultScope has @CacheControl(ttlMs = 7000) with no explicit cacheScope - defaults to PUBLIC
+                .resourcesRead("file:///cc/template_default_scope/1", r -> {
+                    assertEquals("template-default-scope-1", r.contents().get(0).asText().text());
+                    assertEquals(7000L, r.cacheControl().ttlMs());
+                    assertEquals(CacheScope.PUBLIC, r.cacheControl().cacheScope());
+                })
+                .thenAssertResults();
+    }
+
+    @Test
     public void testResourceTemplateReadCacheControl() {
         McpStreamableTestClient client = McpAssured.newConnectedStreamableClient();
         client.when()

--- a/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/StreamableHttpMcpMessageHandler.java
+++ b/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/StreamableHttpMcpMessageHandler.java
@@ -402,8 +402,8 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
         try {
             boolean containsRequest = scan(mcpRequest);
             handle(mcpRequest).onComplete(ar -> {
-                completeResponse(ctx, mcpRequest, containsRequest, ar.succeeded());
                 removeAutoInitConnection(connection);
+                completeResponse(ctx, mcpRequest, containsRequest, ar.succeeded());
             });
         } catch (Exception e) {
             removeAutoInitConnection(connection);
@@ -516,7 +516,8 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
     }
 
     private void removeAutoInitConnection(StreamableHttpMcpConnection connection) {
-        if (connection.initialRequest() != null
+        if (!connection.isTransient()
+                && connection.initialRequest() != null
                 && connection.initialRequest().autoInitialized()
                 && connectionManager.remove(connection.id())) {
             LOG.debugf("Auto-initialized session removed [%s]", connection.id());


### PR DESCRIPTION
- also fix race condition in auto-init connection cleanup