### PR TITLE
Renumber MCP error codes per draft spec and add MISSING_REQUIRED_CLIENT_CAPABILITY

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/JsonRpcErrorCodes.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/JsonRpcErrorCodes.java
@@ -8,9 +8,10 @@ public final class JsonRpcErrorCodes {
     public static final int METHOD_NOT_FOUND = -32601;
     public static final int INVALID_REQUEST = -32600;
     public static final int PARSE_ERROR = -32700;
-    public static final int HEADER_MISMATCH = -32001;
+    public static final int HEADER_MISMATCH = -32020;
+    public static final int MISSING_REQUIRED_CLIENT_CAPABILITY = -32021;
+    public static final int UNSUPPORTED_PROTOCOL_VERSION = -32022;
     public static final int SECURITY_ERROR = -32005;
-    public static final int UNSUPPORTED_PROTOCOL_VERSION = -32004;
     public static final int URL_ELICITATION_REQUIRED = -32042;
 
     private JsonRpcErrorCodes() {

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/McpException.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/McpException.java
@@ -14,6 +14,8 @@ public class McpException extends RuntimeException {
 
     private final int jsonRpcErrorCode;
 
+    private final Object data;
+
     /**
      *
      * @param message
@@ -23,6 +25,7 @@ public class McpException extends RuntimeException {
     public McpException(String message, Throwable cause, int jsonRpcErrorCode) {
         super(message, cause);
         this.jsonRpcErrorCode = jsonRpcErrorCode;
+        this.data = null;
     }
 
     /**
@@ -33,6 +36,19 @@ public class McpException extends RuntimeException {
     public McpException(String message, int jsonRpcError) {
         super(message);
         this.jsonRpcErrorCode = jsonRpcError;
+        this.data = null;
+    }
+
+    /**
+     *
+     * @param message
+     * @param jsonRpcErrorCode
+     * @param data the optional structured data to include in the JSON-RPC error response
+     */
+    public McpException(String message, int jsonRpcErrorCode, Object data) {
+        super(message);
+        this.jsonRpcErrorCode = jsonRpcErrorCode;
+        this.data = data;
     }
 
     /**
@@ -42,6 +58,14 @@ public class McpException extends RuntimeException {
      */
     public int getJsonRpcErrorCode() {
         return jsonRpcErrorCode;
+    }
+
+    /**
+     *
+     * @return the optional structured data to include in the JSON-RPC error response, or {@code null}
+     */
+    public Object getData() {
+        return data;
     }
 
 }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ElicitationImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ElicitationImpl.java
@@ -12,7 +12,9 @@ import io.quarkiverse.mcp.server.ElicitationRequest;
 import io.quarkiverse.mcp.server.ElicitationRequest.Builder;
 import io.quarkiverse.mcp.server.ElicitationRequest.PrimitiveSchema;
 import io.quarkiverse.mcp.server.InputResponses;
+import io.quarkiverse.mcp.server.JsonRpcErrorCodes;
 import io.quarkiverse.mcp.server.McpConnection;
+import io.quarkiverse.mcp.server.McpException;
 import io.quarkiverse.mcp.server.UrlElicitationRequest;
 import io.vertx.core.json.JsonObject;
 
@@ -95,6 +97,12 @@ class ElicitationImpl implements Elicitation {
             throw McpMessageHandler.clientNotInitialized(connection);
         }
         if (!isFormModeSupported()) {
+            if (connection.initialRequest().protocolVersion().isStateless()) {
+                throw new McpException(
+                        "Client does not support the required `elicitation` capability",
+                        JsonRpcErrorCodes.MISSING_REQUIRED_CLIENT_CAPABILITY,
+                        Map.of("requiredCapabilities", Map.of("elicitation", Map.of())));
+            }
             throw new IllegalStateException(
                     "Client " + connection.initialRequest().implementation()
                             + " does not support the form mode of the `elicitation` capability");
@@ -108,6 +116,12 @@ class ElicitationImpl implements Elicitation {
             throw McpMessageHandler.clientNotInitialized(connection);
         }
         if (!isUrlModeSupported()) {
+            if (connection.initialRequest().protocolVersion().isStateless()) {
+                throw new McpException(
+                        "Client does not support the required `elicitation` capability",
+                        JsonRpcErrorCodes.MISSING_REQUIRED_CLIENT_CAPABILITY,
+                        Map.of("requiredCapabilities", Map.of("elicitation", Map.of())));
+            }
             throw new IllegalStateException(
                     "Client " + connection.initialRequest().implementation()
                             + " does not support the URL mode of the `elicitation` capability");

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/FeatureManagerBase.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/FeatureManagerBase.java
@@ -47,6 +47,7 @@ import io.quarkiverse.mcp.server.McpConnection;
 import io.quarkiverse.mcp.server.McpException;
 import io.quarkiverse.mcp.server.McpLog;
 import io.quarkiverse.mcp.server.McpMethod;
+import io.quarkiverse.mcp.server.McpProtocolVersion;
 import io.quarkiverse.mcp.server.McpServer;
 import io.quarkiverse.mcp.server.Meta;
 import io.quarkiverse.mcp.server.Progress;
@@ -141,7 +142,7 @@ public abstract class FeatureManagerBase<RESULT, INFO extends FeatureManager.Fea
                 }
             });
         }
-        throw notFound(id);
+        throw notFound(id, executionContext.mcpRequest().protocolVersion());
     }
 
     protected boolean transformsExecutionFailure() {
@@ -331,7 +332,7 @@ public abstract class FeatureManagerBase<RESULT, INFO extends FeatureManager.Fea
 
     protected abstract FeatureInvoker<RESULT> getInvoker(String id, McpRequest mcpRequest, JsonObject message);
 
-    protected abstract McpException notFound(String id);
+    protected abstract McpException notFound(String id, McpProtocolVersion version);
 
     protected Future<RESULT> execute(ExecutionModel executionModel, Callable<Uni<RESULT>> action) {
         Promise<RESULT> ret = Promise.promise();

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/MessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/MessageHandler.java
@@ -56,6 +56,10 @@ public abstract class MessageHandler {
                     Messages.newError(requestId, urlElicitation.getJsonRpcErrorCode(), urlElicitation.getMessage(), data));
         } else if (cause instanceof McpException mcp) {
             mcpRequest.setTracingErrorResponse(false, mcp.getJsonRpcErrorCode(), mcp.getMessage());
+            if (mcp.getData() != null) {
+                return sender.send(
+                        Messages.newError(requestId, mcp.getJsonRpcErrorCode(), mcp.getMessage(), mcp.getData()));
+            }
             return sender.sendError(requestId, mcp.getJsonRpcErrorCode(), mcp.getMessage());
         } else if (cause instanceof Cancellation.OperationCancellationException
                 || cause instanceof org.mcpjava.server.Cancellation.OperationCancelledException) {

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/NotificationManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/NotificationManagerImpl.java
@@ -19,6 +19,7 @@ import io.quarkiverse.mcp.server.JsonRpcErrorCodes;
 import io.quarkiverse.mcp.server.McpException;
 import io.quarkiverse.mcp.server.McpLog;
 import io.quarkiverse.mcp.server.McpMethod;
+import io.quarkiverse.mcp.server.McpProtocolVersion;
 import io.quarkiverse.mcp.server.Notification;
 import io.quarkiverse.mcp.server.Notification.Type;
 import io.quarkiverse.mcp.server.NotificationManager;
@@ -109,7 +110,7 @@ public class NotificationManagerImpl extends FeatureManagerBase<Void, Notificati
     }
 
     @Override
-    protected McpException notFound(String id) {
+    protected McpException notFound(String id, McpProtocolVersion version) {
         return new McpException("Invalid notification name: " + id, JsonRpcErrorCodes.INVALID_PARAMS);
     }
 

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/PromptCompletionManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/PromptCompletionManagerImpl.java
@@ -8,6 +8,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.quarkiverse.mcp.server.CompletionResponse;
 import io.quarkiverse.mcp.server.JsonRpcErrorCodes;
 import io.quarkiverse.mcp.server.McpException;
+import io.quarkiverse.mcp.server.McpProtocolVersion;
 import io.quarkiverse.mcp.server.PromptCompletionManager;
 import io.quarkiverse.mcp.server.PromptManager;
 import io.quarkiverse.mcp.server.runtime.config.McpServersRuntimeConfig;
@@ -43,7 +44,7 @@ public class PromptCompletionManagerImpl extends CompletionManagerBase implement
     }
 
     @Override
-    protected McpException notFound(String id) {
+    protected McpException notFound(String id, McpProtocolVersion version) {
         return new McpException("Prompt completion does not exist: " + id, JsonRpcErrorCodes.INVALID_PARAMS);
     }
 

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/PromptManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/PromptManagerImpl.java
@@ -28,6 +28,7 @@ import io.quarkiverse.mcp.server.JsonRpcErrorCodes;
 import io.quarkiverse.mcp.server.McpException;
 import io.quarkiverse.mcp.server.McpLog;
 import io.quarkiverse.mcp.server.McpMethod;
+import io.quarkiverse.mcp.server.McpProtocolVersion;
 import io.quarkiverse.mcp.server.MetaKey;
 import io.quarkiverse.mcp.server.PromptFilter;
 import io.quarkiverse.mcp.server.PromptManager;
@@ -145,7 +146,7 @@ public class PromptManagerImpl extends FeatureManagerBase<PromptResponse, Prompt
     }
 
     @Override
-    protected McpException notFound(String id) {
+    protected McpException notFound(String id, McpProtocolVersion version) {
         return new McpException("Invalid prompt name: " + id, JsonRpcErrorCodes.INVALID_PARAMS);
     }
 

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceManagerImpl.java
@@ -34,6 +34,7 @@ import io.quarkiverse.mcp.server.JsonRpcErrorCodes;
 import io.quarkiverse.mcp.server.McpException;
 import io.quarkiverse.mcp.server.McpLog;
 import io.quarkiverse.mcp.server.McpMethod;
+import io.quarkiverse.mcp.server.McpProtocolVersion;
 import io.quarkiverse.mcp.server.MetaKey;
 import io.quarkiverse.mcp.server.RequestUri;
 import io.quarkiverse.mcp.server.ResourceContentsEncoder.ResourceContentsData;
@@ -124,7 +125,7 @@ public class ResourceManagerImpl extends FeatureManagerBase<ResourceResponse, Re
     void subscribe(String uri, McpRequest mcpRequest) {
         ResourceInfo info = getResource(uri, mcpRequest.serverName());
         if (info == null) {
-            throw notFound(uri);
+            throw notFound(uri, mcpRequest.protocolVersion());
         }
         List<String> ids = new CopyOnWriteArrayList<>();
         ids.add(mcpRequest.connection().id());
@@ -135,7 +136,7 @@ public class ResourceManagerImpl extends FeatureManagerBase<ResourceResponse, Re
     void unsubscribe(String uri, McpRequest mcpRequest) {
         ResourceInfo info = getResource(uri);
         if (info == null || !matchesServer(info, mcpRequest)) {
-            throw notFound(uri);
+            throw notFound(uri, mcpRequest.protocolVersion());
         }
         unsubscribe(uri, mcpRequest.connection().id());
     }
@@ -255,8 +256,9 @@ public class ResourceManagerImpl extends FeatureManagerBase<ResourceResponse, Re
     }
 
     @Override
-    protected McpException notFound(String id) {
-        return new McpException("Resource not found: " + id, JsonRpcErrorCodes.RESOURCE_NOT_FOUND);
+    protected McpException notFound(String id, McpProtocolVersion version) {
+        return new McpException("Resource not found: " + id,
+                version.isStateless() ? JsonRpcErrorCodes.INVALID_PARAMS : JsonRpcErrorCodes.RESOURCE_NOT_FOUND);
     }
 
     private boolean test(ResourceInfo resource, FilterContext filterContext) {

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceMessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceMessageHandler.java
@@ -116,7 +116,9 @@ class ResourceMessageHandler extends MessageHandler {
                     new FeatureExecutionContext(message, mcpRequest, argProviders));
             return fu.compose(resourceResponse -> {
                 if (resourceResponse == null) {
-                    return mcpRequest.sender().sendError(id, JsonRpcErrorCodes.RESOURCE_NOT_FOUND,
+                    return mcpRequest.sender().sendError(id,
+                            mcpRequest.protocolVersion().isStateless() ? JsonRpcErrorCodes.INVALID_PARAMS
+                                    : JsonRpcErrorCodes.RESOURCE_NOT_FOUND,
                             "Resource not found: " + resourceUri);
                 } else {
                     ResourceResponse resolved = resolveResourceReadCacheControl(resourceResponse, resourceUri,

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceTemplateCompletionManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceTemplateCompletionManagerImpl.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.quarkiverse.mcp.server.CompletionResponse;
 import io.quarkiverse.mcp.server.JsonRpcErrorCodes;
 import io.quarkiverse.mcp.server.McpException;
+import io.quarkiverse.mcp.server.McpProtocolVersion;
 import io.quarkiverse.mcp.server.ResourceTemplateCompletionManager;
 import io.quarkiverse.mcp.server.runtime.ResourceTemplateManagerImpl.ResourceTemplateMetadata;
 import io.quarkiverse.mcp.server.runtime.config.McpServersRuntimeConfig;
@@ -55,7 +56,7 @@ public class ResourceTemplateCompletionManagerImpl extends CompletionManagerBase
     }
 
     @Override
-    protected McpException notFound(String id) {
+    protected McpException notFound(String id, McpProtocolVersion version) {
         return new McpException("Resource template completion does not exist: " + id, JsonRpcErrorCodes.INVALID_PARAMS);
     }
 

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceTemplateManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceTemplateManagerImpl.java
@@ -35,6 +35,7 @@ import io.quarkiverse.mcp.server.JsonRpcErrorCodes;
 import io.quarkiverse.mcp.server.McpException;
 import io.quarkiverse.mcp.server.McpLog;
 import io.quarkiverse.mcp.server.McpMethod;
+import io.quarkiverse.mcp.server.McpProtocolVersion;
 import io.quarkiverse.mcp.server.MetaKey;
 import io.quarkiverse.mcp.server.RequestUri;
 import io.quarkiverse.mcp.server.ResourceContentsEncoder.ResourceContentsData;
@@ -240,8 +241,9 @@ public class ResourceTemplateManagerImpl extends FeatureManagerBase<ResourceResp
     }
 
     @Override
-    protected McpException notFound(String id) {
-        return new McpException("Resource not found: " + id, JsonRpcErrorCodes.RESOURCE_NOT_FOUND);
+    protected McpException notFound(String id, McpProtocolVersion version) {
+        return new McpException("Resource not found: " + id,
+                version.isStateless() ? JsonRpcErrorCodes.INVALID_PARAMS : JsonRpcErrorCodes.RESOURCE_NOT_FOUND);
     }
 
     @Override
@@ -274,7 +276,7 @@ public class ResourceTemplateManagerImpl extends FeatureManagerBase<ResourceResp
     protected Object wrapResult(FeatureInvoker<?> invoker, Object ret, FeatureMetadata<?> metadata,
             ArgumentProviders argProviders) {
         if (ret == null) {
-            throw notFound(argProviders.uri());
+            throw notFound(argProviders.uri(), argProviders.connection().initialRequest().protocolVersion());
         }
         if (invoker instanceof ResourceTemplateMethod m
                 && metadata.resultMapper() instanceof EncoderMapper) {

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/RootsImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/RootsImpl.java
@@ -3,13 +3,16 @@ package io.quarkiverse.mcp.server.runtime;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.jboss.logging.Logger;
 
 import io.quarkiverse.mcp.server.InputResponses;
+import io.quarkiverse.mcp.server.JsonRpcErrorCodes;
 import io.quarkiverse.mcp.server.McpConnection;
+import io.quarkiverse.mcp.server.McpException;
 import io.quarkiverse.mcp.server.McpMethod;
 import io.quarkiverse.mcp.server.Root;
 import io.quarkiverse.mcp.server.Roots;
@@ -83,6 +86,12 @@ class RootsImpl implements Roots {
             throw McpMessageHandler.clientNotInitialized(connection);
         }
         if (!isSupported()) {
+            if (connection.initialRequest().protocolVersion().isStateless()) {
+                throw new McpException(
+                        "Client does not support the required `roots` capability",
+                        JsonRpcErrorCodes.MISSING_REQUIRED_CLIENT_CAPABILITY,
+                        Map.of("requiredCapabilities", Map.of("roots", Map.of())));
+            }
             throw new IllegalStateException(
                     "Client " + connection.initialRequest().implementation() + " does not support the `roots` capability");
         }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/SamplingImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/SamplingImpl.java
@@ -8,7 +8,9 @@ import java.util.Map;
 import java.util.Objects;
 
 import io.quarkiverse.mcp.server.InputResponses;
+import io.quarkiverse.mcp.server.JsonRpcErrorCodes;
 import io.quarkiverse.mcp.server.McpConnection;
+import io.quarkiverse.mcp.server.McpException;
 import io.quarkiverse.mcp.server.ModelPreferences;
 import io.quarkiverse.mcp.server.Sampling;
 import io.quarkiverse.mcp.server.SamplingMessage;
@@ -80,6 +82,12 @@ class SamplingImpl implements Sampling {
             throw McpMessageHandler.clientNotInitialized(connection);
         }
         if (!isSupported()) {
+            if (connection.initialRequest().protocolVersion().isStateless()) {
+                throw new McpException(
+                        "Client does not support the required `sampling` capability",
+                        JsonRpcErrorCodes.MISSING_REQUIRED_CLIENT_CAPABILITY,
+                        Map.of("requiredCapabilities", Map.of("sampling", Map.of())));
+            }
             throw new IllegalStateException(
                     "Client " + connection.initialRequest().implementation() + " does not support the `sampling` capability");
         }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ToolManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ToolManagerImpl.java
@@ -40,6 +40,7 @@ import io.quarkiverse.mcp.server.McpConnection;
 import io.quarkiverse.mcp.server.McpException;
 import io.quarkiverse.mcp.server.McpLog;
 import io.quarkiverse.mcp.server.McpMethod;
+import io.quarkiverse.mcp.server.McpProtocolVersion;
 import io.quarkiverse.mcp.server.Meta;
 import io.quarkiverse.mcp.server.MetaKey;
 import io.quarkiverse.mcp.server.OutputSchemaGenerator;
@@ -221,7 +222,7 @@ public class ToolManagerImpl extends FeatureManagerBase<ToolResponse, ToolInfo> 
     }
 
     @Override
-    protected McpException notFound(String id) {
+    protected McpException notFound(String id, McpProtocolVersion version) {
         return new McpException("Invalid tool name: " + id, JsonRpcErrorCodes.INVALID_PARAMS);
     }
 

--- a/test/src/main/java/io/quarkiverse/mcp/server/test/McpAssured.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/McpAssured.java
@@ -1711,8 +1711,11 @@ public class McpAssured {
     public record HttpResponse(int statusCode, MultiMap headers, String body) {
     }
 
-    public record McpError(int code, String message) {
+    public record McpError(int code, String message, JsonObject data) {
 
+        public McpError(int code, String message) {
+            this(code, message, null);
+        }
     }
 
     public record ConnectFailureResponse(int statusCode, Map<String, List<String>> headers) {

--- a/test/src/main/java/io/quarkiverse/mcp/server/test/McpTestClientBase.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/McpTestClientBase.java
@@ -1283,7 +1283,8 @@ abstract class McpTestClientBase<ASSERT extends McpAssert<ASSERT>, CLIENT extend
         @Override
         public void doAssert(JsonObject response) {
             JsonObject error = assertErrorResponse(response, response);
-            errorMessageAssert.accept(new McpError(error.getInteger("code"), error.getString("message")));
+            errorMessageAssert
+                    .accept(new McpError(error.getInteger("code"), error.getString("message"), error.getJsonObject("data")));
         }
 
     }

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/stateless/StatelessErrorCodesTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/stateless/StatelessErrorCodesTest.java
@@ -1,0 +1,140 @@
+package io.quarkiverse.mcp.server.test.stateless;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.Elicitation;
+import io.quarkiverse.mcp.server.JsonRpcErrorCodes;
+import io.quarkiverse.mcp.server.RequestUri;
+import io.quarkiverse.mcp.server.Resource;
+import io.quarkiverse.mcp.server.ResourceResponse;
+import io.quarkiverse.mcp.server.Roots;
+import io.quarkiverse.mcp.server.Sampling;
+import io.quarkiverse.mcp.server.TextResourceContents;
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkiverse.mcp.server.test.McpAssured.McpStreamableTestClient;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class StatelessErrorCodesTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .withApplicationRoot(root -> root.addClasses(MyTools.class, MyResources.class));
+
+    @Test
+    public void testMissingClientCapabilitySampling() {
+        McpStreamableTestClient client = McpAssured.newStreamableClient()
+                .setStateless()
+                .build()
+                .connect();
+
+        client.when()
+                .toolsCall("useSampling")
+                .withErrorAssert(error -> {
+                    assertEquals(JsonRpcErrorCodes.MISSING_REQUIRED_CLIENT_CAPABILITY, error.code());
+                    assertTrue(error.message().contains("sampling"));
+                    assertNotNull(error.data());
+                    assertNotNull(error.data().getJsonObject("requiredCapabilities").getJsonObject("sampling"));
+                })
+                .send()
+                .thenAssertResults();
+        client.disconnect();
+    }
+
+    @Test
+    public void testMissingClientCapabilityElicitation() {
+        McpStreamableTestClient client = McpAssured.newStreamableClient()
+                .setStateless()
+                .build()
+                .connect();
+
+        client.when()
+                .toolsCall("useElicitation")
+                .withErrorAssert(error -> {
+                    assertEquals(JsonRpcErrorCodes.MISSING_REQUIRED_CLIENT_CAPABILITY, error.code());
+                    assertTrue(error.message().contains("elicitation"));
+                    assertNotNull(error.data());
+                    assertNotNull(error.data().getJsonObject("requiredCapabilities").getJsonObject("elicitation"));
+                })
+                .send()
+                .thenAssertResults();
+        client.disconnect();
+    }
+
+    @Test
+    public void testMissingClientCapabilityRoots() {
+        McpStreamableTestClient client = McpAssured.newStreamableClient()
+                .setStateless()
+                .build()
+                .connect();
+
+        client.when()
+                .toolsCall("useRoots")
+                .withErrorAssert(error -> {
+                    assertEquals(JsonRpcErrorCodes.MISSING_REQUIRED_CLIENT_CAPABILITY, error.code());
+                    assertTrue(error.message().contains("roots"));
+                    assertNotNull(error.data());
+                    assertNotNull(error.data().getJsonObject("requiredCapabilities").getJsonObject("roots"));
+                })
+                .send()
+                .thenAssertResults();
+        client.disconnect();
+    }
+
+    @Test
+    public void testResourceNotFoundUsesInvalidParams() {
+        McpStreamableTestClient client = McpAssured.newStreamableClient()
+                .setStateless()
+                .build()
+                .connect();
+
+        client.when()
+                .resourcesRead("file:///nonexistent")
+                .withErrorAssert(error -> {
+                    assertEquals(JsonRpcErrorCodes.INVALID_PARAMS, error.code());
+                    assertEquals("Resource not found: file:///nonexistent", error.message());
+                    assertNull(error.data());
+                })
+                .send()
+                .thenAssertResults();
+        client.disconnect();
+    }
+
+    public static class MyTools {
+
+        @Tool
+        String useSampling(Sampling sampling) {
+            sampling.requestBuilder();
+            return "unreachable";
+        }
+
+        @Tool
+        String useElicitation(Elicitation elicitation) {
+            elicitation.requestBuilder();
+            return "unreachable";
+        }
+
+        @Tool
+        String useRoots(Roots roots) {
+            roots.list();
+            return "unreachable";
+        }
+    }
+
+    public static class MyResources {
+
+        @Resource(uri = "file:///project/alpha")
+        ResourceResponse alpha(RequestUri uri) {
+            return new ResourceResponse(List.of(new TextResourceContents(uri.value(), "content", null)));
+        }
+    }
+}


### PR DESCRIPTION
- make RESOURCE_NOT_FOUND version-dependent: emit INVALID_PARAMS (-32602) for stateless protocol, keep RESOURCE_NOT_FOUND (-32002) for older versions
- add data field to McpException and McpError