### PR TITLE
htttp: support custom headers from tool parameters (x-mcp-header)

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/FeatureMethodBuildItem.java
+++ b/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/FeatureMethodBuildItem.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.mcp.server.deployment;
 
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
@@ -20,7 +21,12 @@ import io.quarkus.arc.processor.BeanInfo;
 import io.quarkus.arc.processor.InvokerInfo;
 import io.quarkus.builder.item.MultiBuildItem;
 
-final class FeatureMethodBuildItem extends MultiBuildItem {
+/**
+ * Represents a CDI bean method annotated with one of the MCP feature annotations, such as
+ * {@link io.quarkiverse.mcp.server.Tool @Tool}, {@link io.quarkiverse.mcp.server.Prompt @Prompt},
+ * {@link io.quarkiverse.mcp.server.Resource @Resource}, etc.
+ */
+public final class FeatureMethodBuildItem extends MultiBuildItem {
 
     static final Comparator<FeatureMethodBuildItem> NAME_COMPARATOR = Comparator.comparing(fm -> fm.getName());
 
@@ -100,123 +106,123 @@ final class FeatureMethodBuildItem extends MultiBuildItem {
         this.iconsProvider = iconsProvider;
     }
 
-    BeanInfo getBean() {
+    public BeanInfo getBean() {
         return bean;
     }
 
-    MethodInfo getMethod() {
+    public MethodInfo getMethod() {
         return method;
     }
 
-    InvokerInfo getInvoker() {
+    public InvokerInfo getInvoker() {
         return invoker;
     }
 
-    String getName() {
+    public String getName() {
         return name;
     }
 
-    String getTitle() {
+    public String getTitle() {
         return title;
     }
 
-    String getDescription() {
+    public String getDescription() {
         return description;
     }
 
-    String getUri() {
+    public String getUri() {
         return uri;
     }
 
-    String getMimeType() {
+    public String getMimeType() {
         return mimeType;
     }
 
-    int getSize() {
+    public int getSize() {
         return size;
     }
 
-    Feature getFeature() {
+    public Feature getFeature() {
         return feature;
     }
 
-    ToolManager.ToolAnnotations getToolAnnotations() {
+    public ToolManager.ToolAnnotations getToolAnnotations() {
         return toolAnnotations;
     }
 
-    Set<String> getServers() {
-        return servers;
+    public Set<String> getServers() {
+        return Collections.unmodifiableSet(servers);
     }
 
-    boolean isStructuredContent() {
+    public boolean isStructuredContent() {
         return structuredContent;
     }
 
-    Type getOutputSchemaFrom() {
+    public Type getOutputSchemaFrom() {
         return outputSchemaFrom;
     }
 
-    Type getOutputSchemaGenerator() {
+    public Type getOutputSchemaGenerator() {
         return outputSchemaGenerator;
     }
 
-    Type getInputSchemaGenerator() {
+    public Type getInputSchemaGenerator() {
         return inputSchemaGenerator;
     }
 
-    Annotations getResourceAnnotations() {
+    public Annotations getResourceAnnotations() {
         return resourceAnnotations;
     }
 
-    CacheControl getCacheControl() {
+    public CacheControl getCacheControl() {
         return cacheControl;
     }
 
-    Map<String, String> getMetadata() {
-        return metadata;
+    public Map<String, String> getMetadata() {
+        return Collections.unmodifiableMap(metadata);
     }
 
-    List<DotName> getInputGuardrails() {
-        return inputGuardrails;
+    public List<DotName> getInputGuardrails() {
+        return Collections.unmodifiableList(inputGuardrails);
     }
 
-    List<DotName> getOutputGuardrails() {
-        return outputGuardrails;
+    public List<DotName> getOutputGuardrails() {
+        return Collections.unmodifiableList(outputGuardrails);
     }
 
-    ExecutionModel getExecutionModel() {
+    public ExecutionModel getExecutionModel() {
         return executionModel;
     }
 
-    DotName getIconsProvider() {
+    public DotName getIconsProvider() {
         return iconsProvider;
     }
 
-    boolean isTool() {
+    public boolean isTool() {
         return feature == Feature.TOOL;
     }
 
-    boolean isPrompt() {
+    public boolean isPrompt() {
         return feature == Feature.PROMPT;
     }
 
-    boolean isPromptComplete() {
+    public boolean isPromptComplete() {
         return feature == Feature.PROMPT_COMPLETE;
     }
 
-    boolean isResource() {
+    public boolean isResource() {
         return feature == Feature.RESOURCE;
     }
 
-    boolean isResourceTemplate() {
+    public boolean isResourceTemplate() {
         return feature == Feature.RESOURCE_TEMPLATE;
     }
 
-    boolean isResourceTemplateComplete() {
+    public boolean isResourceTemplateComplete() {
         return feature == Feature.RESOURCE_TEMPLATE_COMPLETE;
     }
 
-    boolean isNotification() {
+    public boolean isNotification() {
         return feature == Feature.NOTIFICATION;
     }
 

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/DefaultSchemaGenerator.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/DefaultSchemaGenerator.java
@@ -89,7 +89,7 @@ public class DefaultSchemaGenerator implements GlobalInputSchemaGenerator, Globa
         }
     }
 
-    record InputSchemaImpl(JsonObject value) implements InputSchema {
+    public record InputSchemaImpl(JsonObject value) implements InputSchema {
 
         @Override
         public String asJson() {

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ToolManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ToolManagerImpl.java
@@ -19,6 +19,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import jakarta.enterprise.event.Event;
 import jakarta.enterprise.inject.Any;
 import jakarta.enterprise.inject.Instance;
 import jakarta.inject.Singleton;
@@ -90,6 +91,9 @@ public class ToolManagerImpl extends FeatureManagerBase<ToolResponse, ToolInfo> 
     final Instance<ToolOutputGuardrail> outputGuardrails;
     final Instance<IconsProvider> iconsProviders;
 
+    final Event<ToolAdded> toolAddedEvent;
+    final Event<ToolRemoved> toolRemovedEvent;
+
     ToolManagerImpl(McpMetadata metadata,
             Vertx vertx,
             ObjectMapper mapper,
@@ -106,7 +110,9 @@ public class ToolManagerImpl extends FeatureManagerBase<ToolResponse, ToolInfo> 
             Instance<InputSchemaGenerator<?>> inputSchemaGenerator,
             Instance<OutputSchemaGenerator> outputSchemaGenerator,
             McpServersBuildTimeConfig buildTimeConfig,
-            McpServersRuntimeConfig config) {
+            McpServersRuntimeConfig config,
+            Event<ToolAdded> toolAddedEvent,
+            Event<ToolRemoved> toolRemovedEvent) {
         super(vertx, mapper, connectionManager, currentIdentityAssociation, serverRequests, cancellationRequests,
                 config,
                 metadata);
@@ -122,6 +128,8 @@ public class ToolManagerImpl extends FeatureManagerBase<ToolResponse, ToolInfo> 
         this.filters = filters;
         this.buildTimeConfig = buildTimeConfig;
         this.config = config;
+        this.toolAddedEvent = toolAddedEvent;
+        this.toolRemovedEvent = toolRemovedEvent;
         for (FeatureMetadata<ToolResponse> f : metadata.tools()) {
             ToolMethod toolMethod = new ToolMethod(f, iconsProviders);
             for (String server : f.info().serverNames()) {
@@ -177,7 +185,11 @@ public class ToolManagerImpl extends FeatureManagerBase<ToolResponse, ToolInfo> 
             }
             return value;
         });
-        return removed.get();
+        ToolInfo removedTool = removed.get();
+        if (removedTool != null) {
+            toolRemovedEvent.fire(new ToolRemoved(removedTool));
+        }
+        return removedTool;
     }
 
     @Override
@@ -190,10 +202,12 @@ public class ToolManagerImpl extends FeatureManagerBase<ToolResponse, ToolInfo> 
             }
             return false;
         });
-        if (removed.get() != null) {
+        ToolInfo removedTool = removed.get();
+        if (removedTool != null) {
             notifyConnections(McpMethod.NOTIFICATIONS_TOOLS_LIST_CHANGED);
+            toolRemovedEvent.fire(new ToolRemoved(removedTool));
         }
-        return removed.get();
+        return removedTool;
     }
 
     @SuppressWarnings("unchecked")
@@ -678,6 +692,7 @@ public class ToolManagerImpl extends FeatureManagerBase<ToolResponse, ToolInfo> 
                 registrationLock.unlock();
             }
             notifyConnections(McpMethod.NOTIFICATIONS_TOOLS_LIST_CHANGED);
+            toolAddedEvent.fire(new ToolAdded(ret));
             return ret;
         }
 
@@ -842,6 +857,12 @@ public class ToolManagerImpl extends FeatureManagerBase<ToolResponse, ToolInfo> 
     @SuppressWarnings("unchecked")
     private static <T> T cast(Object obj) {
         return (T) obj;
+    }
+
+    public record ToolAdded(ToolInfo tool) {
+    }
+
+    public record ToolRemoved(ToolInfo tool) {
     }
 
 }

--- a/transports/http/deployment/src/main/java/io/quarkiverse/mcp/server/http/deployment/HttpMcpServerProcessor.java
+++ b/transports/http/deployment/src/main/java/io/quarkiverse/mcp/server/http/deployment/HttpMcpServerProcessor.java
@@ -4,6 +4,7 @@ import static io.quarkus.deployment.annotations.ExecutionTime.RUNTIME_INIT;
 import static io.quarkus.deployment.annotations.ExecutionTime.STATIC_INIT;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -11,10 +12,19 @@ import java.util.Set;
 
 import jakarta.inject.Singleton;
 
+import org.jboss.jandex.AnnotationInstance;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.MethodParameterInfo;
+import org.jboss.jandex.PrimitiveType;
 import org.jboss.logging.Logger;
 
+import io.quarkiverse.mcp.server.deployment.FeatureMethodBuildItem;
 import io.quarkiverse.mcp.server.deployment.ServerNameBuildItem;
+import io.quarkiverse.mcp.server.http.McpParamHeader;
+import io.quarkiverse.mcp.server.http.runtime.HttpInputSchemaGenerator;
 import io.quarkiverse.mcp.server.http.runtime.HttpMcpServerRecorder;
+import io.quarkiverse.mcp.server.http.runtime.McpParamHeaderMetadata;
+import io.quarkiverse.mcp.server.http.runtime.McpParamHeaderObserver;
 import io.quarkiverse.mcp.server.http.runtime.McpServerEndpoints;
 import io.quarkiverse.mcp.server.http.runtime.McpServerEndpoints.McpServerEndpoint;
 import io.quarkiverse.mcp.server.http.runtime.McpServerEndpointsLogger;
@@ -22,6 +32,7 @@ import io.quarkiverse.mcp.server.http.runtime.SseMcpMessageHandler;
 import io.quarkiverse.mcp.server.http.runtime.StreamableHttpMcpMessageHandler;
 import io.quarkiverse.mcp.server.http.runtime.config.McpHttpServerBuildTimeConfig;
 import io.quarkiverse.mcp.server.http.runtime.config.McpHttpServersBuildTimeConfig;
+import io.quarkiverse.mcp.server.runtime.FeatureKey;
 import io.quarkus.arc.deployment.AdditionalBeanBuildItem;
 import io.quarkus.arc.deployment.SyntheticBeanBuildItem;
 import io.quarkus.arc.deployment.SyntheticBeansRuntimeInitBuildItem;
@@ -49,7 +60,8 @@ public class HttpMcpServerProcessor {
                 AdditionalBeanBuildItem.builder()
                         .setUnremovable()
                         .addBeanClasses(SseMcpMessageHandler.class, StreamableHttpMcpMessageHandler.class,
-                                McpServerEndpointsLogger.class)
+                                McpServerEndpointsLogger.class, HttpInputSchemaGenerator.class,
+                                McpParamHeaderObserver.class)
                         .build());
     }
 
@@ -98,6 +110,121 @@ public class HttpMcpServerProcessor {
                 .scope(Singleton.class)
                 .createWith(recorder.createMcpServerEndpoints(mcpServerEndpoints.getEndpoints()))
                 .done());
+    }
+
+    private static final DotName MCP_PARAM_HEADER = DotName.createSimple(McpParamHeader.class);
+    private static final DotName TOOL_ARG = DotName.createSimple(io.quarkiverse.mcp.server.ToolArg.class);
+
+    private static final Set<DotName> ALLOWED_HEADER_TYPES = Set.of(
+            DotName.createSimple(String.class),
+            DotName.createSimple(Integer.class),
+            DotName.createSimple(Long.class),
+            DotName.createSimple(Boolean.class));
+
+    @Record(STATIC_INIT)
+    @BuildStep
+    void registerMcpParamHeaderMetadataBean(List<FeatureMethodBuildItem> featureMethods,
+            HttpMcpServerRecorder recorder,
+            BuildProducer<SyntheticBeanBuildItem> syntheticBeans) {
+        Map<FeatureKey, Map<String, String>> toolHeaders = new HashMap<>();
+        for (FeatureMethodBuildItem fm : featureMethods) {
+            if (!fm.isTool()) {
+                continue;
+            }
+            Map<String, String> headers = null;
+            Set<String> headerNamesLower = null;
+            for (MethodParameterInfo param : fm.getMethod().parameters()) {
+                AnnotationInstance mcpParamHeader = param.declaredAnnotation(MCP_PARAM_HEADER);
+                if (mcpParamHeader == null) {
+                    continue;
+                }
+                String headerName = mcpParamHeader.value().asString();
+                // Validate header name is non-empty
+                if (headerName.isEmpty()) {
+                    throw new IllegalStateException(
+                            "@McpParamHeader value must not be empty [method: %s#%s(), parameter: %s]"
+                                    .formatted(fm.getMethod().declaringClass().name(), fm.getMethod().name(), param.name()));
+                }
+                // Validate header name is a valid HTTP token
+                if (!isValidHttpToken(headerName)) {
+                    throw new IllegalStateException(
+                            "@McpParamHeader value '%s' is not a valid HTTP field-name token [method: %s#%s(), parameter: %s]"
+                                    .formatted(headerName, fm.getMethod().declaringClass().name(), fm.getMethod().name(),
+                                            param.name()));
+                }
+                // Validate parameter type is a supported primitive type
+                if (!isAllowedHeaderType(param.type())) {
+                    throw new IllegalStateException(
+                            "@McpParamHeader is only allowed on String, Integer, Long, Boolean, int, long, or boolean parameters"
+                                    + " [method: %s#%s(), parameter: %s]"
+                                            .formatted(fm.getMethod().declaringClass().name(), fm.getMethod().name(),
+                                                    param.name()));
+                }
+                // Validate uniqueness (case-insensitive) within the tool
+                if (headerNamesLower == null) {
+                    headerNamesLower = new HashSet<>();
+                }
+                if (!headerNamesLower.add(headerName.toLowerCase())) {
+                    throw new IllegalStateException(
+                            "Duplicate @McpParamHeader value '%s' (case-insensitive) in tool method %s#%s()"
+                                    .formatted(headerName, fm.getMethod().declaringClass().name(), fm.getMethod().name()));
+                }
+
+                if (headers == null) {
+                    headers = new HashMap<>();
+                }
+                String argName = resolveArgName(param);
+                headers.put(argName, headerName);
+            }
+            if (headers != null) {
+                for (String serverName : fm.getServers()) {
+                    toolHeaders.put(new FeatureKey(fm.getName(), serverName), Map.copyOf(headers));
+                }
+            }
+        }
+        syntheticBeans.produce(SyntheticBeanBuildItem.configure(McpParamHeaderMetadata.class)
+                .scope(Singleton.class)
+                .createWith(recorder.createMcpParamHeaderMetadata(toolHeaders))
+                .done());
+    }
+
+    private static String resolveArgName(MethodParameterInfo param) {
+        AnnotationInstance toolArg = param.declaredAnnotation(TOOL_ARG);
+        if (toolArg != null && toolArg.value("name") != null) {
+            String name = toolArg.value("name").asString();
+            if (!io.quarkiverse.mcp.server.ToolArg.ELEMENT_NAME.equals(name)) {
+                return name;
+            }
+        }
+        return param.name();
+    }
+
+    static boolean isAllowedHeaderType(org.jboss.jandex.Type type) {
+        if (type.kind() == org.jboss.jandex.Type.Kind.PRIMITIVE) {
+            PrimitiveType.Primitive primitive = type.asPrimitiveType().primitive();
+            return primitive == PrimitiveType.Primitive.INT
+                    || primitive == PrimitiveType.Primitive.LONG
+                    || primitive == PrimitiveType.Primitive.BOOLEAN;
+        }
+        return ALLOWED_HEADER_TYPES.contains(type.name());
+    }
+
+    static boolean isValidHttpToken(String value) {
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            if (!isTchar(c)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    // RFC 9110 Section 5.6.2: tchar = "!" / "#" / "$" / "%" / "&" / "'" / "*" / "+" / "-" / "." /
+    // "^" / "_" / "`" / "|" / "~" / DIGIT / ALPHA
+    private static boolean isTchar(char c) {
+        return (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')
+                || c == '!' || c == '#' || c == '$' || c == '%' || c == '&' || c == '\'' || c == '*'
+                || c == '+' || c == '-' || c == '.' || c == '^' || c == '_' || c == '`' || c == '|' || c == '~';
     }
 
     @BuildStep

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/http/deployment/HttpMcpServerProcessorTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/http/deployment/HttpMcpServerProcessorTest.java
@@ -1,0 +1,58 @@
+package io.quarkiverse.mcp.server.http.deployment;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.jboss.jandex.ClassType;
+import org.jboss.jandex.DotName;
+import org.jboss.jandex.PrimitiveType;
+import org.junit.jupiter.api.Test;
+
+public class HttpMcpServerProcessorTest {
+
+    @Test
+    public void testIsValidHttpToken() {
+        assertTrue(HttpMcpServerProcessor.isValidHttpToken("Region"));
+        assertTrue(HttpMcpServerProcessor.isValidHttpToken("Content-Type"));
+        assertTrue(HttpMcpServerProcessor.isValidHttpToken("X-Custom"));
+        assertTrue(HttpMcpServerProcessor.isValidHttpToken("abc123"));
+        assertTrue(HttpMcpServerProcessor.isValidHttpToken("a"));
+        // tchar specials
+        assertTrue(HttpMcpServerProcessor.isValidHttpToken("!#$%&'*+-.^_`|~"));
+        // invalid chars
+        assertFalse(HttpMcpServerProcessor.isValidHttpToken("has space"));
+        assertFalse(HttpMcpServerProcessor.isValidHttpToken("has\ttab"));
+        assertFalse(HttpMcpServerProcessor.isValidHttpToken("with/slash"));
+        assertFalse(HttpMcpServerProcessor.isValidHttpToken("with(paren"));
+        assertFalse(HttpMcpServerProcessor.isValidHttpToken("with@at"));
+        assertFalse(HttpMcpServerProcessor.isValidHttpToken("with=equals"));
+        assertFalse(HttpMcpServerProcessor.isValidHttpToken("with\"quote"));
+        assertFalse(HttpMcpServerProcessor.isValidHttpToken("with[bracket"));
+        assertFalse(HttpMcpServerProcessor.isValidHttpToken("with{brace"));
+    }
+
+    @Test
+    public void testIsAllowedHeaderTypePrimitives() {
+        assertTrue(HttpMcpServerProcessor.isAllowedHeaderType(PrimitiveType.INT));
+        assertTrue(HttpMcpServerProcessor.isAllowedHeaderType(PrimitiveType.LONG));
+        assertTrue(HttpMcpServerProcessor.isAllowedHeaderType(PrimitiveType.BOOLEAN));
+        assertFalse(HttpMcpServerProcessor.isAllowedHeaderType(PrimitiveType.DOUBLE));
+        assertFalse(HttpMcpServerProcessor.isAllowedHeaderType(PrimitiveType.FLOAT));
+        assertFalse(HttpMcpServerProcessor.isAllowedHeaderType(PrimitiveType.BYTE));
+        assertFalse(HttpMcpServerProcessor.isAllowedHeaderType(PrimitiveType.SHORT));
+        assertFalse(HttpMcpServerProcessor.isAllowedHeaderType(PrimitiveType.CHAR));
+    }
+
+    @Test
+    public void testIsAllowedHeaderTypeBoxed() {
+        assertTrue(HttpMcpServerProcessor.isAllowedHeaderType(ClassType.create(DotName.createSimple(String.class))));
+        assertTrue(HttpMcpServerProcessor.isAllowedHeaderType(ClassType.create(DotName.createSimple(Integer.class))));
+        assertTrue(HttpMcpServerProcessor.isAllowedHeaderType(ClassType.create(DotName.createSimple(Long.class))));
+        assertTrue(HttpMcpServerProcessor.isAllowedHeaderType(ClassType.create(DotName.createSimple(Boolean.class))));
+        assertFalse(HttpMcpServerProcessor.isAllowedHeaderType(ClassType.create(DotName.createSimple(Double.class))));
+        assertFalse(
+                HttpMcpServerProcessor.isAllowedHeaderType(ClassType.create(DotName.createSimple(java.util.List.class))));
+        assertFalse(HttpMcpServerProcessor
+                .isAllowedHeaderType(ClassType.create(DotName.createSimple(io.vertx.core.json.JsonObject.class))));
+    }
+}

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/mcpheader/McpParamHeaderTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/mcpheader/McpParamHeaderTest.java
@@ -1,0 +1,399 @@
+package io.quarkiverse.mcp.server.test.mcpheader;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Map;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.JsonRpcErrorCodes;
+import io.quarkiverse.mcp.server.McpProtocolVersion;
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolManager;
+import io.quarkiverse.mcp.server.ToolResponse;
+import io.quarkiverse.mcp.server.http.McpParamHeader;
+import io.quarkiverse.mcp.server.http.runtime.StreamableHttpMcpMessageHandler;
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkiverse.mcp.server.test.McpAssured.McpStreamableTestClient;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+import io.restassured.RestAssured;
+import io.vertx.core.MultiMap;
+import io.vertx.core.json.JsonObject;
+
+public class McpParamHeaderTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .withApplicationRoot(root -> root.addClasses(MyTools.class));
+
+    @Inject
+    ToolManager toolManager;
+
+    @Test
+    public void testInputSchemaContainsXMcpHeader() {
+        McpStreamableTestClient client = McpAssured.newStreamableClient()
+                .setStateless()
+                .build()
+                .connect();
+
+        client.when()
+                .toolsList(tools -> {
+                    McpAssured.ToolInfo queryTool = tools.findByName("query");
+                    assertNotNull(queryTool);
+                    JsonObject inputSchema = queryTool.inputSchema();
+                    JsonObject properties = inputSchema.getJsonObject("properties");
+                    // region param has @McpParamHeader("Region")
+                    JsonObject regionProp = properties.getJsonObject("region");
+                    assertNotNull(regionProp);
+                    assertEquals("Region", regionProp.getString("x-mcp-header"));
+                    // value param does not have @McpParamHeader
+                    JsonObject valueProp = properties.getJsonObject("value");
+                    assertNotNull(valueProp);
+                    assertFalse(valueProp.containsKey("x-mcp-header"));
+
+                    // echo tool has no @McpParamHeader params
+                    McpAssured.ToolInfo echoTool = tools.findByName("echo");
+                    assertNotNull(echoTool);
+                    JsonObject echoProp = echoTool.inputSchema().getJsonObject("properties").getJsonObject("message");
+                    assertNotNull(echoProp);
+                    assertFalse(echoProp.containsKey("x-mcp-header"));
+                })
+                .thenAssertResults();
+        client.disconnect();
+    }
+
+    @Test
+    public void testToolCallWithCorrectHeaders() {
+        McpStreamableTestClient client = McpAssured.newStreamableClient()
+                .setStateless()
+                .setAdditionalHeaders(m -> {
+                    MultiMap headers = MultiMap.caseInsensitiveMultiMap();
+                    headers.add("Mcp-Param-Region", "us-west1");
+                    return headers;
+                })
+                .build()
+                .connect();
+
+        client.when()
+                .toolsCall("query", Map.of("region", "us-west1", "value", "SELECT 1"), r -> {
+                    assertFalse(r.isError());
+                    assertEquals("us-west1:SELECT 1", r.firstContent().asText().text());
+                })
+                .thenAssertResults();
+        client.disconnect();
+    }
+
+    @Test
+    public void testToolCallMissingParamHeader() {
+        McpStreamableTestClient client = McpAssured.newStreamableClient()
+                .setStateless()
+                .build()
+                .connect();
+
+        JsonObject message = newStatelessToolsCallMessage("query",
+                new JsonObject().put("region", "us-west1").put("value", "SELECT 1"));
+
+        JsonObject response = new JsonObject(RestAssured.given()
+                .when()
+                .headers(Map.of(
+                        "Accept", "application/json, text/event-stream",
+                        StreamableHttpMcpMessageHandler.MCP_PROTOCOL_VERSION_HEADER,
+                        McpProtocolVersion.FIRST_STATELESS.version(),
+                        StreamableHttpMcpMessageHandler.MCP_METHOD_HEADER, "tools/call",
+                        StreamableHttpMcpMessageHandler.MCP_NAME_HEADER, "query"))
+                .body(message.encode())
+                .post(client.mcpEndpoint())
+                .then()
+                .statusCode(400)
+                .extract().body().asString());
+
+        JsonObject error = response.getJsonObject("error");
+        assertNotNull(error);
+        assertEquals(JsonRpcErrorCodes.HEADER_MISMATCH, error.getInteger("code"));
+        assertTrue(error.getString("message").contains("Mcp-Param-Region"));
+        client.disconnect();
+    }
+
+    @Test
+    public void testToolCallMismatchedParamHeader() {
+        McpStreamableTestClient client = McpAssured.newStreamableClient()
+                .setStateless()
+                .build()
+                .connect();
+
+        JsonObject message = newStatelessToolsCallMessage("query",
+                new JsonObject().put("region", "us-west1").put("value", "SELECT 1"));
+
+        JsonObject response = new JsonObject(RestAssured.given()
+                .when()
+                .headers(Map.of(
+                        "Accept", "application/json, text/event-stream",
+                        StreamableHttpMcpMessageHandler.MCP_PROTOCOL_VERSION_HEADER,
+                        McpProtocolVersion.FIRST_STATELESS.version(),
+                        StreamableHttpMcpMessageHandler.MCP_METHOD_HEADER, "tools/call",
+                        StreamableHttpMcpMessageHandler.MCP_NAME_HEADER, "query",
+                        StreamableHttpMcpMessageHandler.MCP_PARAM_HEADER_PREFIX + "Region", "eu-west1"))
+                .body(message.encode())
+                .post(client.mcpEndpoint())
+                .then()
+                .statusCode(400)
+                .extract().body().asString());
+
+        JsonObject error = response.getJsonObject("error");
+        assertNotNull(error);
+        assertEquals(JsonRpcErrorCodes.HEADER_MISMATCH, error.getInteger("code"));
+        assertTrue(error.getString("message").contains("mismatch"));
+        client.disconnect();
+    }
+
+    @Test
+    public void testToolCallWithIntegerHeader() {
+        McpStreamableTestClient client = McpAssured.newStreamableClient()
+                .setStateless()
+                .setAdditionalHeaders(m -> {
+                    MultiMap headers = MultiMap.caseInsensitiveMultiMap();
+                    headers.add("Mcp-Param-Limit", "10");
+                    return headers;
+                })
+                .build()
+                .connect();
+
+        client.when()
+                .toolsCall("limitedQuery", Map.of("limit", 10, "value", "SELECT 1"), r -> {
+                    assertFalse(r.isError());
+                    assertEquals("10:SELECT 1", r.firstContent().asText().text());
+                })
+                .thenAssertResults();
+        client.disconnect();
+    }
+
+    @Test
+    public void testToolCallWithBooleanHeader() {
+        McpStreamableTestClient client = McpAssured.newStreamableClient()
+                .setStateless()
+                .setAdditionalHeaders(m -> {
+                    MultiMap headers = MultiMap.caseInsensitiveMultiMap();
+                    headers.add("Mcp-Param-DryRun", "true");
+                    return headers;
+                })
+                .build()
+                .connect();
+
+        client.when()
+                .toolsCall("dryRun", Map.of("dryRun", true, "value", "DROP TABLE"), r -> {
+                    assertFalse(r.isError());
+                    assertEquals("true:DROP TABLE", r.firstContent().asText().text());
+                })
+                .thenAssertResults();
+        client.disconnect();
+    }
+
+    @Test
+    public void testToolCallWithBase64EncodedHeader() {
+        String value = "hello world / special=chars";
+        String encoded = "=?base64?" + Base64.getEncoder().encodeToString(value.getBytes(StandardCharsets.UTF_8)) + "?=";
+        McpStreamableTestClient client = McpAssured.newStreamableClient()
+                .setStateless()
+                .setAdditionalHeaders(m -> {
+                    MultiMap headers = MultiMap.caseInsensitiveMultiMap();
+                    headers.add("Mcp-Param-Region", encoded);
+                    return headers;
+                })
+                .build()
+                .connect();
+
+        client.when()
+                .toolsCall("query", Map.of("region", value, "value", "test"), r -> {
+                    assertFalse(r.isError());
+                    assertEquals(value + ":test", r.firstContent().asText().text());
+                })
+                .thenAssertResults();
+        client.disconnect();
+    }
+
+    @Test
+    public void testToolWithoutHeaderParamIgnoresValidation() {
+        McpStreamableTestClient client = McpAssured.newStreamableClient()
+                .setStateless()
+                .build()
+                .connect();
+
+        client.when()
+                .toolsCall("echo", Map.of("message", "hello"), r -> {
+                    assertFalse(r.isError());
+                    assertEquals("hello", r.firstContent().asText().text());
+                })
+                .thenAssertResults();
+        client.disconnect();
+    }
+
+    @Test
+    public void testProgrammaticToolSchemaContainsXMcpHeader() {
+        toolManager.newTool("programmaticQuery")
+                .setDescription("A programmatic tool with x-mcp-header")
+                .setInputSchema(new JsonObject()
+                        .put("type", "object")
+                        .put("properties", new JsonObject()
+                                .put("region", new JsonObject()
+                                        .put("type", "string")
+                                        .put("x-mcp-header", "Region"))
+                                .put("value", new JsonObject()
+                                        .put("type", "string")))
+                        .put("required", new io.vertx.core.json.JsonArray().add("region").add("value")))
+                .setHandler(args -> ToolResponse.success(args.args().get("region") + ":" + args.args().get("value")))
+                .register();
+        try {
+            McpStreamableTestClient client = McpAssured.newStreamableClient()
+                    .setStateless()
+                    .build()
+                    .connect();
+
+            client.when()
+                    .toolsList(tools -> {
+                        McpAssured.ToolInfo tool = tools.findByName("programmaticQuery");
+                        assertNotNull(tool);
+                        JsonObject properties = tool.inputSchema().getJsonObject("properties");
+                        assertEquals("Region", properties.getJsonObject("region").getString("x-mcp-header"));
+                        assertFalse(properties.getJsonObject("value").containsKey("x-mcp-header"));
+                    })
+                    .thenAssertResults();
+            client.disconnect();
+        } finally {
+            toolManager.removeTool("programmaticQuery");
+        }
+    }
+
+    @Test
+    public void testProgrammaticToolCallWithCorrectHeaders() {
+        toolManager.newTool("programmaticQuery2")
+                .setDescription("A programmatic tool with x-mcp-header")
+                .setInputSchema(new JsonObject()
+                        .put("type", "object")
+                        .put("properties", new JsonObject()
+                                .put("region", new JsonObject()
+                                        .put("type", "string")
+                                        .put("x-mcp-header", "Region"))
+                                .put("value", new JsonObject()
+                                        .put("type", "string"))))
+                .setHandler(args -> ToolResponse.success(args.args().get("region") + ":" + args.args().get("value")))
+                .register();
+        try {
+            McpStreamableTestClient client = McpAssured.newStreamableClient()
+                    .setStateless()
+                    .setAdditionalHeaders(m -> {
+                        MultiMap headers = MultiMap.caseInsensitiveMultiMap();
+                        headers.add("Mcp-Param-Region", "us-east1");
+                        return headers;
+                    })
+                    .build()
+                    .connect();
+
+            client.when()
+                    .toolsCall("programmaticQuery2", Map.of("region", "us-east1", "value", "test"), r -> {
+                        assertFalse(r.isError());
+                        assertEquals("us-east1:test", r.firstContent().asText().text());
+                    })
+                    .thenAssertResults();
+            client.disconnect();
+        } finally {
+            toolManager.removeTool("programmaticQuery2");
+        }
+    }
+
+    @Test
+    public void testProgrammaticToolCallMissingParamHeader() {
+        toolManager.newTool("programmaticQuery3")
+                .setDescription("A programmatic tool with x-mcp-header")
+                .setInputSchema(new JsonObject()
+                        .put("type", "object")
+                        .put("properties", new JsonObject()
+                                .put("region", new JsonObject()
+                                        .put("type", "string")
+                                        .put("x-mcp-header", "Region"))
+                                .put("value", new JsonObject()
+                                        .put("type", "string"))))
+                .setHandler(args -> ToolResponse.success("unreachable"))
+                .register();
+        try {
+            McpStreamableTestClient client = McpAssured.newStreamableClient()
+                    .setStateless()
+                    .build()
+                    .connect();
+
+            JsonObject message = newStatelessToolsCallMessage("programmaticQuery3",
+                    new JsonObject().put("region", "us-east1").put("value", "test"));
+
+            JsonObject response = new JsonObject(RestAssured.given()
+                    .when()
+                    .headers(Map.of(
+                            "Accept", "application/json, text/event-stream",
+                            StreamableHttpMcpMessageHandler.MCP_PROTOCOL_VERSION_HEADER,
+                            McpProtocolVersion.FIRST_STATELESS.version(),
+                            StreamableHttpMcpMessageHandler.MCP_METHOD_HEADER, "tools/call",
+                            StreamableHttpMcpMessageHandler.MCP_NAME_HEADER, "programmaticQuery3"))
+                    .body(message.encode())
+                    .post(client.mcpEndpoint())
+                    .then()
+                    .statusCode(400)
+                    .extract().body().asString());
+
+            JsonObject error = response.getJsonObject("error");
+            assertNotNull(error);
+            assertEquals(JsonRpcErrorCodes.HEADER_MISMATCH, error.getInteger("code"));
+            assertTrue(error.getString("message").contains("Mcp-Param-Region"));
+            client.disconnect();
+        } finally {
+            toolManager.removeTool("programmaticQuery3");
+        }
+    }
+
+    private static JsonObject newStatelessToolsCallMessage(String toolName, JsonObject arguments) {
+        JsonObject meta = new JsonObject()
+                .put("io.modelcontextprotocol/protocolVersion", McpProtocolVersion.FIRST_STATELESS.version())
+                .put("io.modelcontextprotocol/clientInfo", new JsonObject()
+                        .put("name", "test-client")
+                        .put("version", "1.0"))
+                .put("io.modelcontextprotocol/clientCapabilities", new JsonObject());
+        return new JsonObject()
+                .put("jsonrpc", "2.0")
+                .put("id", 1)
+                .put("method", "tools/call")
+                .put("params", new JsonObject()
+                        .put("name", toolName)
+                        .put("arguments", arguments)
+                        .put("_meta", meta));
+    }
+
+    public static class MyTools {
+
+        @Tool
+        String query(@McpParamHeader("Region") String region, String value) {
+            return region + ":" + value;
+        }
+
+        @Tool
+        String limitedQuery(@McpParamHeader("Limit") int limit, String value) {
+            return limit + ":" + value;
+        }
+
+        @Tool
+        String dryRun(@McpParamHeader("DryRun") boolean dryRun, String value) {
+            return dryRun + ":" + value;
+        }
+
+        @Tool
+        String echo(String message) {
+            return message;
+        }
+    }
+
+}

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/mcpheader/McpParamHeaderValidationTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/mcpheader/McpParamHeaderValidationTest.java
@@ -1,0 +1,33 @@
+package io.quarkiverse.mcp.server.test.mcpheader;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.http.McpParamHeader;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class McpParamHeaderValidationTest {
+
+    @RegisterExtension
+    public static final QuarkusUnitTest test = new QuarkusUnitTest()
+            .withApplicationRoot(root -> root.addClasses(InvalidTools.class))
+            .setExpectedException(IllegalStateException.class, true);
+
+    @Test
+    public void test() {
+        fail();
+    }
+
+    public static class InvalidTools {
+
+        @Tool
+        String unsupportedType(@McpParamHeader("Data") List<String> data) {
+            return data.toString();
+        }
+    }
+}

--- a/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/McpParamHeader.java
+++ b/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/McpParamHeader.java
@@ -1,0 +1,41 @@
+package io.quarkiverse.mcp.server.http;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import io.quarkiverse.mcp.server.Tool;
+
+/**
+ * Designates a {@link Tool} method parameter to be mirrored as an HTTP header ({@code Mcp-Param-{value}}) when using the
+ * Streamable HTTP transport.
+ * <p>
+ * This enables network intermediaries (load balancers, gateways, firewalls) to route and inspect requests based on parameter
+ * values without parsing the JSON-RPC request body.
+ * <p>
+ * The annotated parameter must be of type {@code String}, {@code int}/{@code Integer}, {@code long}/{@code Long},
+ * or {@code boolean}/{@code Boolean}.
+ *
+ * <pre>
+ * &#64;Tool
+ * String query(&#64;McpParamHeader("Region") String region, String value) {
+ *     // ...
+ * }
+ * </pre>
+ *
+ * @see Tool
+ */
+@Retention(RUNTIME)
+@Target(ElementType.PARAMETER)
+public @interface McpParamHeader {
+
+    /**
+     * The header name portion used to construct the HTTP header {@code Mcp-Param-{value}}.
+     * <p>
+     * Must be a non-empty, valid HTTP field-name token as defined by RFC 9110 Section 5.1.
+     */
+    String value();
+
+}

--- a/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/HttpInputSchemaGenerator.java
+++ b/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/HttpInputSchemaGenerator.java
@@ -1,0 +1,87 @@
+package io.quarkiverse.mcp.server.http.runtime;
+
+import java.util.List;
+import java.util.Map;
+
+import jakarta.annotation.Priority;
+import jakarta.inject.Singleton;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.quarkiverse.mcp.server.GlobalInputSchemaGenerator;
+import io.quarkiverse.mcp.server.ToolManager.ToolInfo;
+import io.quarkiverse.mcp.server.http.McpParamHeader;
+import io.quarkiverse.mcp.server.runtime.DefaultSchemaGenerator;
+import io.quarkiverse.mcp.server.runtime.FeatureKey;
+import io.quarkiverse.mcp.server.runtime.McpMetadata;
+import io.quarkiverse.mcp.server.runtime.SchemaGeneratorConfigCustomizer;
+import io.quarkus.arc.All;
+import io.quarkus.arc.DefaultBean;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * HTTP-transport-specific input schema generator that extends the default schema generation to add
+ * {@value #X_MCP_HEADER} extension properties for tool parameters annotated with {@link McpParamHeader @McpParamHeader}.
+ * <p>
+ * This bean has {@link Priority} 100 so it takes precedence over the core {@link DefaultSchemaGenerator}, but is itself
+ * a {@link DefaultBean} so that users can still provide a custom implementation.
+ * <p>
+ * The {@value #X_MCP_HEADER} values are resolved from {@link McpParamHeaderMetadata} which is populated at build time by
+ * scanning
+ * tool method parameters for {@link McpParamHeader @McpParamHeader} annotations.
+ */
+@DefaultBean
+@Priority(100)
+@Singleton
+public class HttpInputSchemaGenerator extends DefaultSchemaGenerator {
+
+    static final String X_MCP_HEADER = "x-mcp-header";
+
+    private final McpParamHeaderMetadata headerMetadata;
+
+    public HttpInputSchemaGenerator(@All List<SchemaGeneratorConfigCustomizer> schemaGeneratorConfigCustomizers,
+            ObjectMapper objectMapper,
+            McpMetadata metadata,
+            McpParamHeaderMetadata headerMetadata) {
+        super(schemaGeneratorConfigCustomizers, objectMapper, metadata);
+        this.headerMetadata = headerMetadata;
+    }
+
+    @Override
+    public GlobalInputSchemaGenerator.InputSchema generate(ToolInfo tool) {
+        InputSchema schema = super.generate(tool);
+
+        if (headerMetadata.isEmpty()) {
+            return schema;
+        }
+
+        // The @McpParamHeader mapping is per-method, identical across all servers the tool is bound to
+        Map<String, String> headers = null;
+        for (String serverName : tool.serverNames()) {
+            headers = headerMetadata.getHeaders(new FeatureKey(tool.name(), serverName));
+            if (headers != null) {
+                break;
+            }
+        }
+
+        if (headers == null || headers.isEmpty()) {
+            return schema;
+        }
+
+        JsonObject schemaJson = new JsonObject(schema.asJson());
+        JsonObject properties = schemaJson.getJsonObject("properties");
+        if (properties == null) {
+            return schema;
+        }
+
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            JsonObject property = properties.getJsonObject(entry.getKey());
+            if (property != null) {
+                property.put(X_MCP_HEADER, entry.getValue());
+            }
+        }
+
+        return new InputSchemaImpl(schemaJson);
+    }
+
+}

--- a/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/HttpMcpServerRecorder.java
+++ b/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/HttpMcpServerRecorder.java
@@ -7,6 +7,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 import java.util.function.Consumer;
@@ -19,6 +20,7 @@ import io.quarkiverse.mcp.server.JsonRpcErrorCodes;
 import io.quarkiverse.mcp.server.http.runtime.config.McpHttpServersBuildTimeConfig;
 import io.quarkiverse.mcp.server.http.runtime.config.McpHttpServersRuntimeConfig;
 import io.quarkiverse.mcp.server.runtime.ConnectionManager;
+import io.quarkiverse.mcp.server.runtime.FeatureKey;
 import io.quarkiverse.mcp.server.runtime.TrafficListeners;
 import io.quarkiverse.mcp.server.runtime.config.McpServerRuntimeConfig;
 import io.quarkiverse.mcp.server.runtime.config.McpServersRuntimeConfig;
@@ -282,6 +284,17 @@ public class HttpMcpServerRecorder {
             @Override
             public McpServerEndpoints apply(SyntheticCreationalContext<McpServerEndpoints> t) {
                 return new McpServerEndpoints(endpoints);
+            }
+        };
+    }
+
+    public Function<SyntheticCreationalContext<McpParamHeaderMetadata>, McpParamHeaderMetadata> createMcpParamHeaderMetadata(
+            Map<FeatureKey, Map<String, String>> toolHeaders) {
+        return new Function<SyntheticCreationalContext<McpParamHeaderMetadata>, McpParamHeaderMetadata>() {
+
+            @Override
+            public McpParamHeaderMetadata apply(SyntheticCreationalContext<McpParamHeaderMetadata> t) {
+                return new McpParamHeaderMetadata(toolHeaders);
             }
         };
     }

--- a/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/McpParamHeaderMetadata.java
+++ b/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/McpParamHeaderMetadata.java
@@ -1,0 +1,42 @@
+package io.quarkiverse.mcp.server.http.runtime;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import io.quarkiverse.mcp.server.runtime.FeatureKey;
+
+/**
+ * Holds the mapping from tool parameters annotated with {@link io.quarkiverse.mcp.server.http.McpParamHeader @McpParamHeader}
+ * to their corresponding HTTP header names.
+ * <p>
+ * Build-time entries are populated via the recorder. Runtime entries (for programmatically registered tools) are added/removed
+ * via {@link #register(FeatureKey, Map)} and {@link #remove(FeatureKey)}.
+ */
+public class McpParamHeaderMetadata {
+
+    private final ConcurrentHashMap<FeatureKey, Map<String, String>> toolHeaders;
+
+    McpParamHeaderMetadata(Map<FeatureKey, Map<String, String>> toolHeaders) {
+        this.toolHeaders = new ConcurrentHashMap<>(toolHeaders);
+    }
+
+    /**
+     * @return the header mapping for the given tool, or {@code null} if none
+     */
+    public Map<String, String> getHeaders(FeatureKey key) {
+        return toolHeaders.get(key);
+    }
+
+    public boolean isEmpty() {
+        return toolHeaders.isEmpty();
+    }
+
+    public void register(FeatureKey key, Map<String, String> headers) {
+        toolHeaders.put(key, Map.copyOf(headers));
+    }
+
+    public void remove(FeatureKey key) {
+        toolHeaders.remove(key);
+    }
+
+}

--- a/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/McpParamHeaderObserver.java
+++ b/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/McpParamHeaderObserver.java
@@ -1,0 +1,70 @@
+package io.quarkiverse.mcp.server.http.runtime;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import jakarta.enterprise.event.Observes;
+import jakarta.inject.Singleton;
+
+import io.quarkiverse.mcp.server.ToolManager.ToolInfo;
+import io.quarkiverse.mcp.server.runtime.FeatureKey;
+import io.quarkiverse.mcp.server.runtime.ToolManagerImpl.ToolAdded;
+import io.quarkiverse.mcp.server.runtime.ToolManagerImpl.ToolRemoved;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Observes {@link ToolAdded} and {@link ToolRemoved} CDI events to extract {@code x-mcp-header}
+ * extension properties from the input schema of programmatically registered tools and update
+ * {@link McpParamHeaderMetadata} accordingly.
+ */
+@Singleton
+public class McpParamHeaderObserver {
+
+    private final McpParamHeaderMetadata headerMetadata;
+
+    McpParamHeaderObserver(McpParamHeaderMetadata headerMetadata) {
+        this.headerMetadata = headerMetadata;
+    }
+
+    void onToolAdded(@Observes ToolAdded event) {
+        ToolInfo tool = event.tool();
+        // Method-backed tools are handled at build time by the deployment processor
+        if (tool.isMethod()) {
+            return;
+        }
+        // Serialize and re-parse to avoid ClassCastException when the input schema
+        // contains Jackson ObjectNode values from the schema generator
+        JsonObject toolJson = new JsonObject(tool.asJson().encode());
+        JsonObject inputSchema = toolJson.getJsonObject("inputSchema");
+        if (inputSchema == null) {
+            return;
+        }
+        JsonObject properties = inputSchema.getJsonObject("properties");
+        if (properties == null) {
+            return;
+        }
+        Map<String, String> headers = null;
+        for (String argName : properties.fieldNames()) {
+            JsonObject prop = properties.getJsonObject(argName);
+            if (prop != null && prop.containsKey(HttpInputSchemaGenerator.X_MCP_HEADER)) {
+                if (headers == null) {
+                    headers = new HashMap<>();
+                }
+                headers.put(argName, prop.getString(HttpInputSchemaGenerator.X_MCP_HEADER));
+            }
+        }
+        if (headers != null) {
+            for (String serverName : tool.serverNames()) {
+                headerMetadata.register(new FeatureKey(tool.name(), serverName), headers);
+            }
+        }
+    }
+
+    void onToolRemoved(@Observes ToolRemoved event) {
+        ToolInfo tool = event.tool();
+        for (String serverName : tool.serverNames()) {
+            headerMetadata.remove(new FeatureKey(tool.name(), serverName));
+        }
+    }
+
+}

--- a/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/StreamableHttpMcpMessageHandler.java
+++ b/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/StreamableHttpMcpMessageHandler.java
@@ -8,6 +8,7 @@ import static io.quarkiverse.mcp.server.runtime.FeatureArgument.Provider.SAMPLIN
 import static io.quarkiverse.mcp.server.runtime.Messages.newError;
 
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
@@ -101,6 +102,7 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
     public static final String MCP_PROTOCOL_VERSION_HEADER = "Mcp-Protocol-Version";
     public static final String MCP_METHOD_HEADER = "Mcp-Method";
     public static final String MCP_NAME_HEADER = "Mcp-Name";
+    public static final String MCP_PARAM_HEADER_PREFIX = "Mcp-Param-";
     public static final String AUTO_INIT_IMPL_NAME = "quarkus.mcp.http.streamable.dummy";
     private static final Implementation AUTO_INIT_IMPLEMENTATION = new Implementation(AUTO_INIT_IMPL_NAME, "1", null);
 
@@ -108,6 +110,7 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
     private final CurrentIdentityAssociation currentIdentityAssociation;
     private final McpHttpServersRuntimeConfig httpConfig;
     private final TrafficListeners trafficListeners;
+    private final McpParamHeaderMetadata headerMetadata;
 
     // Precomputed maps for eager SSE init (lazySseInit=false), null when lazy
     private final Map<FeatureKey, Boolean> toolsForceSse;
@@ -137,7 +140,8 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
             Instance<McpMetrics> metrics,
             Instance<McpTracing> tracing,
             Instance<McpRequestValidator> mcpRequestValidator,
-            TrafficListeners trafficListeners) {
+            TrafficListeners trafficListeners,
+            McpParamHeaderMetadata headerMetadata) {
         super(config, connectionManager, promptManager, toolManager, resourceManager, promptCompleteManager,
                 resourceTemplateManager, resourceTemplateCompleteManager, notificationManager, serverRequests,
                 metadata,
@@ -148,6 +152,7 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
         this.currentIdentityAssociation = currentIdentityAssociation.isResolvable() ? currentIdentityAssociation.get() : null;
         this.httpConfig = runtimeConfig;
         this.trafficListeners = trafficListeners;
+        this.headerMetadata = headerMetadata;
         checkCorsConfig(config);
 
         // Precompute forceSse maps only when eager SSE init is configured
@@ -226,7 +231,7 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
             JsonObject message, String mcpProtocolVersion, JsonObject meta) {
 
         // Validate required headers for stateless clients
-        if (!validateStatelessHeaders(ctx, message, mcpProtocolVersion, meta)) {
+        if (!validateStatelessHeaders(ctx, serverName, message, mcpProtocolVersion, meta)) {
             return;
         }
 
@@ -279,8 +284,8 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
         }
     }
 
-    private boolean validateStatelessHeaders(RoutingContext ctx, JsonObject message, String mcpProtocolVersion,
-            JsonObject meta) {
+    private boolean validateStatelessHeaders(RoutingContext ctx, String serverName, JsonObject message,
+            String mcpProtocolVersion, JsonObject meta) {
         // Validate Mcp-Method header
         String mcpMethodHeader = ctx.request().getHeader(MCP_METHOD_HEADER);
         String bodyMethod = message.getString("method");
@@ -302,13 +307,19 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
         }
 
         // Validate Mcp-Name header for methods that require it
-        if ("tools/call".equals(bodyMethod) || "prompts/get".equals(bodyMethod)) {
+        McpMethod mcpMethod = McpMethod.from(bodyMethod);
+        if (McpMethod.TOOLS_CALL == mcpMethod || McpMethod.PROMPTS_GET == mcpMethod) {
             JsonObject params = Messages.getParams(message);
             String bodyName = params != null ? params.getString("name") : null;
             if (!validateMcpNameHeader(ctx, bodyName)) {
                 return false;
             }
-        } else if ("resources/read".equals(bodyMethod)) {
+            if (McpMethod.TOOLS_CALL == mcpMethod && bodyName != null) {
+                if (!validateMcpParamHeaders(ctx, serverName, bodyName, params)) {
+                    return false;
+                }
+            }
+        } else if (McpMethod.RESOURCES_READ == mcpMethod) {
             JsonObject params = Messages.getParams(message);
             String bodyUri = params != null ? params.getString("uri") : null;
             if (!validateMcpNameHeader(ctx, bodyUri)) {
@@ -330,6 +341,56 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
             }
         }
         return true;
+    }
+
+    private boolean validateMcpParamHeaders(RoutingContext ctx, String serverName, String toolName, JsonObject params) {
+        if (headerMetadata.isEmpty()) {
+            return true;
+        }
+        Map<String, String> headers = headerMetadata.getHeaders(new FeatureKey(toolName, serverName));
+        if (headers == null || headers.isEmpty()) {
+            return true;
+        }
+        JsonObject arguments = params.getJsonObject("arguments");
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            String argName = entry.getKey();
+            String headerName = MCP_PARAM_HEADER_PREFIX + entry.getValue();
+            String headerValue = ctx.request().getHeader(headerName);
+            Object bodyValue = arguments != null ? arguments.getValue(argName) : null;
+
+            if (bodyValue != null && headerValue == null) {
+                ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+                ctx.response().setStatusCode(400);
+                ctx.end(newError(null, JsonRpcErrorCodes.HEADER_MISMATCH,
+                        "Missing required header: " + headerName).toBuffer());
+                return false;
+            }
+            if (bodyValue != null && headerValue != null) {
+                String decodedHeaderValue = decodeHeaderValue(headerValue);
+                String bodyValueStr = String.valueOf(bodyValue);
+                if (!decodedHeaderValue.equals(bodyValueStr)) {
+                    ctx.response().putHeader(HttpHeaders.CONTENT_TYPE, "application/json");
+                    ctx.response().setStatusCode(400);
+                    ctx.end(newError(null, JsonRpcErrorCodes.HEADER_MISMATCH,
+                            "Header mismatch: " + headerName + " header value '" + decodedHeaderValue
+                                    + "' does not match body value '" + bodyValueStr + "'")
+                            .toBuffer());
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private static final String BASE64_PREFIX = "=?base64?";
+    private static final String BASE64_SUFFIX = "?=";
+
+    static String decodeHeaderValue(String value) {
+        if (value.startsWith(BASE64_PREFIX) && value.endsWith(BASE64_SUFFIX)) {
+            String encoded = value.substring(BASE64_PREFIX.length(), value.length() - BASE64_SUFFIX.length());
+            return new String(Base64.getDecoder().decode(encoded), java.nio.charset.StandardCharsets.UTF_8);
+        }
+        return value;
     }
 
     private boolean validateMcpNameHeader(RoutingContext ctx, String expectedValue) {


### PR DESCRIPTION
- introduce `@McpParamHeader` annotation that mirrors tool parameters into Mcp-Param-{Name} HTTP headers
- resolves #887