### PR TITLE
Fix output schema generation for generic return types

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/McpServerProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/McpServerProcessor.java
@@ -42,6 +42,7 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.MethodParameterInfo;
+import org.jboss.jandex.Type;
 import org.jboss.jandex.Type.Kind;
 import org.jboss.jandex.gizmo2.Jandex2Gizmo;
 import org.jboss.logging.Logger;
@@ -758,11 +759,11 @@ class McpServerProcessor {
         metadata.put(key.toString(), jsonValue);
     }
 
-    private ClassType outputSchemaFromReturnType(org.jboss.jandex.Type returnType) {
+    private Type outputSchemaFromReturnType(Type returnType) {
         if (DotNames.isAsyncType(returnType.name())) {
-            return ClassType.create(returnType.asParameterizedType().arguments().get(0).name());
+            return returnType.asParameterizedType().arguments().get(0);
         }
-        return ClassType.create(returnType.name());
+        return returnType;
     }
 
     private Content.Annotations parseResourceAnnotations(AnnotationInstance featureAnnotation) {
@@ -904,7 +905,7 @@ class McpServerProcessor {
                                                 prompt.getMethod().hasDeclaredAnnotation(DotNames.MCPJAVA_PROMPT)
                                                         ? DotNames.MCPJAVA_PROMPT_ARG
                                                         : DotNames.PROMPT_ARG,
-                                                PromptArg.ELEMENT_NAME),
+                                                PromptArg.ELEMENT_NAME, beanArchiveIndex.getIndex()),
                                         cc.this_()));
                     }
                     bc.return_(ret);
@@ -928,7 +929,7 @@ class McpServerProcessor {
                                                         .hasDeclaredAnnotation(DotNames.MCPJAVA_COMPLETE_PROMPT)
                                                                 ? DotNames.MCPJAVA_COMPLETE_ARG
                                                                 : DotNames.COMPLETE_ARG,
-                                                CompleteArg.ELEMENT_NAME),
+                                                CompleteArg.ELEMENT_NAME, beanArchiveIndex.getIndex()),
                                         cc.this_()));
                     }
                     bc.return_(ret);
@@ -952,7 +953,7 @@ class McpServerProcessor {
                                                 : tool.getMethod().hasDeclaredAnnotation(DotNames.MCPJAVA_TOOL)
                                                         ? DotNames.MCPJAVA_TOOL_ARG
                                                         : DotNames.TOOL_ARG,
-                                        ToolArg.ELEMENT_NAME),
+                                        ToolArg.ELEMENT_NAME, beanArchiveIndex.getIndex()),
                                         cc.this_()));
                     }
                     bc.return_(ret);
@@ -970,7 +971,8 @@ class McpServerProcessor {
                             .toList()) {
                         // ret.add(meta$123());
                         bc.invokeInterface(MD_Collection.add, ret,
-                                bc.invokeVirtual(processFeatureMethod(counter, cc, resource, null, null),
+                                bc.invokeVirtual(
+                                        processFeatureMethod(counter, cc, resource, null, null, beanArchiveIndex.getIndex()),
                                         cc.this_()));
                     }
                     bc.return_(ret);
@@ -994,7 +996,7 @@ class McpServerProcessor {
                                                         .hasDeclaredAnnotation(DotNames.MCPJAVA_RESOURCE_TEMPLATE)
                                                                 ? DotNames.MCPJAVA_RESOURCE_TEMPLATE_ARG
                                                                 : DotNames.RESOURCE_TEMPLATE_ARG,
-                                                ResourceTemplateArg.ELEMENT_NAME),
+                                                ResourceTemplateArg.ELEMENT_NAME, beanArchiveIndex.getIndex()),
                                         cc.this_()));
                     }
                     bc.return_(ret);
@@ -1019,7 +1021,7 @@ class McpServerProcessor {
                                                                 DotNames.MCPJAVA_COMPLETE_RESOURCE_TEMPLATE)
                                                                         ? DotNames.MCPJAVA_COMPLETE_ARG
                                                                         : DotNames.COMPLETE_ARG,
-                                                CompleteArg.ELEMENT_NAME),
+                                                CompleteArg.ELEMENT_NAME, beanArchiveIndex.getIndex()),
                                         cc.this_()));
                     }
                     bc.return_(ret);
@@ -1038,7 +1040,8 @@ class McpServerProcessor {
                         // ret.add(meta$123());
                         bc.invokeInterface(MD_Collection.add, ret,
                                 bc.invokeVirtual(
-                                        processFeatureMethod(counter, cc, notification, null, null),
+                                        processFeatureMethod(counter, cc, notification, null, null,
+                                                beanArchiveIndex.getIndex()),
                                         cc.this_()));
                     }
                     bc.return_(ret);
@@ -1054,7 +1057,9 @@ class McpServerProcessor {
                             .sorted(Comparator.comparing(DefaultValueConverterBuildItem::getClassName))
                             .toList();
                     for (DefaultValueConverterBuildItem converter : sortedConverters) {
-                        LocalVar converterType = RuntimeTypeCreator.of(bc).create(converter.getArgumentType());
+                        LocalVar converterType = RuntimeTypeCreator.of(bc)
+                                .withIndex(beanArchiveIndex.getIndex())
+                                .create(converter.getArgumentType());
                         bc.withMap(ret).put(converterType, bc.new_(ClassDesc.of(converter.getClassName())));
                     }
                     bc.return_(ret);
@@ -1303,7 +1308,7 @@ class McpServerProcessor {
     }
 
     private MethodDesc processFeatureMethod(AtomicInteger counter, ClassCreator cc,
-            FeatureMethodBuildItem featureMethod, DotName argAnnotationName, String argNameSentinel) {
+            FeatureMethodBuildItem featureMethod, DotName argAnnotationName, String argNameSentinel, IndexView index) {
         return cc.method("meta$" + counter.incrementAndGet(), mc -> {
             mc.returning(FeatureMetadata.class);
 
@@ -1368,7 +1373,7 @@ class McpServerProcessor {
                                                 explicitAnnotation));
                     }
 
-                    LocalVar type = RuntimeTypeCreator.of(bc).create(param.type());
+                    LocalVar type = RuntimeTypeCreator.of(bc).withIndex(index).create(param.type());
                     // new FeatureArgument(String name, String title, String description, boolean
                     // required, Type type, String defaultValue, Provider provider)
                     LocalVar arg = bc.localVar("arg", bc.new_(FeatureArgument.class,
@@ -1488,8 +1493,9 @@ class McpServerProcessor {
                         resourceAnnotations,
                         cacheControl,
                         serverNames,
-                        featureMethod.getOutputSchemaFrom() == null ? Const.ofNull(Class.class)
-                                : Const.of(Jandex2Gizmo.classDescOf(featureMethod.getOutputSchemaFrom().name())),
+                        featureMethod.getOutputSchemaFrom() == null
+                                ? Const.ofNull(java.lang.reflect.Type.class)
+                                : RuntimeTypeCreator.of(bc).withIndex(index).create(featureMethod.getOutputSchemaFrom()),
                         featureMethod.getOutputSchemaGenerator() == null ? Const.ofNull(Class.class)
                                 : Const.of(Jandex2Gizmo.classDescOf(featureMethod.getOutputSchemaGenerator().name())),
                         featureMethod.getInputSchemaGenerator() == null ? Const.ofNull(Class.class)

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/OutputSchemaGenerator.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/OutputSchemaGenerator.java
@@ -1,20 +1,43 @@
 package io.quarkiverse.mcp.server;
 
+import java.lang.reflect.Type;
+
 /**
  * Generates the output schema for a return type of a {@link Tool} method.
  * <p>
  * Implementation classes must be CDI beans. Qualifiers are ignored.
+ * <p>
+ * Implementations should override the {@link #generate(Type)} method. The {@link #generate(Class)} method is deprecated.
  *
  * @see Tool.OutputSchema#generator()
  */
 public interface OutputSchemaGenerator {
 
     /**
+     * @param from
+     * @return the object representing the schema
+     * @deprecated Implement {@link #generate(Type)} instead; {@link #generate(Type)} is always used internally
+     *             and its default implementation delegates to this method for {@link Class} arguments
+     */
+    @Deprecated(forRemoval = true)
+    default Object generate(Class<?> from) {
+        return null;
+    }
+
+    /**
      * The return value is serialized with the {@code jackson-databind} library.
+     * <p>
+     * This method is always used internally. The default implementation delegates to {@link #generate(Class)} if the argument
+     * is a {@link Class}, and throws {@link UnsupportedOperationException} otherwise.
      *
      * @param from
      * @return the object representing the schema
      */
-    Object generate(Class<?> from);
+    default Object generate(Type from) {
+        if (from instanceof Class<?> clazz) {
+            return generate(clazz);
+        }
+        throw new UnsupportedOperationException("Generic type schema generation is not supported by " + getClass().getName());
+    }
 
 }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/ToolManager.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/ToolManager.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.mcp.server;
 
+import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -125,10 +126,20 @@ public interface ToolManager extends FeatureManager<ToolInfo> {
         /**
          * Generate the output schema for structured content from the given class.
          *
-         * @param outputSchema
+         * @param from
          * @return self
          */
-        ToolDefinition generateOutputSchema(Class<?> from);
+        default ToolDefinition generateOutputSchema(Class<?> from) {
+            return generateOutputSchema((Type) from);
+        }
+
+        /**
+         * Generate the output schema for structured content from the given type.
+         *
+         * @param from
+         * @return self
+         */
+        ToolDefinition generateOutputSchema(Type from);
 
         /**
          * @param schema

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/DefaultSchemaGenerator.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/DefaultSchemaGenerator.java
@@ -99,7 +99,7 @@ public class DefaultSchemaGenerator implements GlobalInputSchemaGenerator, Globa
     }
 
     @Override
-    public Object generate(Class<?> from) {
+    public Object generate(Type from) {
         return schemaGenerator.generateSchema(from);
     }
 

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/FeatureMethodInfo.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/FeatureMethodInfo.java
@@ -1,5 +1,6 @@
 package io.quarkiverse.mcp.server.runtime;
 
+import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -24,7 +25,7 @@ public record FeatureMethodInfo(String name,
         Content.Annotations resourceAnnotations,
         CacheControl cacheControl,
         Set<String> serverNames,
-        Class<?> outputSchemaFrom,
+        Type outputSchemaFrom,
         Class<? extends OutputSchemaGenerator> outputSchemaGenerator,
         Class<? extends InputSchemaGenerator<?>> inputSchemaGenerator,
         // meta key (prefix + name) -> json

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ToolManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ToolManagerImpl.java
@@ -369,7 +369,7 @@ public class ToolManagerImpl extends FeatureManagerBase<ToolResponse, ToolInfo> 
             Class<? extends OutputSchemaGenerator> outputSchemaGeneratorClass = metadata.info().outputSchemaGenerator();
             if (outputSchemaGeneratorClass != null) {
                 Object outputSchema;
-                Class<?> outputSchemaFrom = metadata.info().outputSchemaFrom();
+                Type outputSchemaFrom = metadata.info().outputSchemaFrom();
                 if (GlobalOutputSchemaGenerator.class.equals(outputSchemaGeneratorClass)) {
                     outputSchema = globalOutputSchemaGenerator.generate(outputSchemaFrom);
                 } else {
@@ -602,7 +602,7 @@ public class ToolManagerImpl extends FeatureManagerBase<ToolResponse, ToolInfo> 
         }
 
         @Override
-        public ToolDefinition generateOutputSchema(Class<?> from) {
+        public ToolDefinition generateOutputSchema(Type from) {
             this.outputSchema = globalOutputSchemaGenerator.generate(from);
             return this;
         }

--- a/docs/modules/ROOT/pages/guides-using-structured-content.adoc
+++ b/docs/modules/ROOT/pages/guides-using-structured-content.adoc
@@ -171,13 +171,14 @@ import io.quarkiverse.mcp.server.Tool;
 import io.quarkiverse.mcp.server.Tool.OutputSchema;
 import jakarta.inject.Singleton;
 import io.vertx.core.json.JsonObject;
+import java.lang.reflect.Type;
 import java.util.List;
 
 @Singleton // <1>
 public class CustomSchemaGenerator implements OutputSchemaGenerator {
 
     @Override
-    public Object generate(Class<?> from) {
+    public Object generate(Type from) {
         return new JsonObject()
             .put("type", "object")
             .put("properties", new JsonObject()
@@ -218,12 +219,13 @@ To customize schema generation for all tools, implement `GlobalOutputSchemaGener
 import io.quarkiverse.mcp.server.GlobalOutputSchemaGenerator;
 import jakarta.inject.Singleton;
 import io.vertx.core.json.JsonObject;
+import java.lang.reflect.Type;
 
 @Singleton
 public class MyGlobalSchemaGenerator implements GlobalOutputSchemaGenerator {
 
     @Override
-    public Object generate(Class<?> from) {
+    public Object generate(Type from) {
         // Custom schema generation logic for all tools
         return new JsonObject()
             .put("type", "object")
@@ -231,8 +233,8 @@ public class MyGlobalSchemaGenerator implements GlobalOutputSchemaGenerator {
             .put("additionalProperties", false);
     }
 
-    private JsonObject generateProperties(Class<?> from) {
-        // Introspect the class and generate properties...
+    private JsonObject generateProperties(Type from) {
+        // Introspect the type and generate properties...
         return new JsonObject();
     }
 }
@@ -242,7 +244,8 @@ The global generator is used for all tools unless a specific generator is provid
 
 === Programmatic API
 
-When registering tools programmatically, use `generateOutputSchema(Class<?> from)` to set the output schema:
+When registering tools programmatically, use `generateOutputSchema()` to set the output schema.
+The method accepts a `java.lang.reflect.Type`, so you can pass a simple `Class` or a parameterized type:
 
 [source,java]
 ----
@@ -271,7 +274,7 @@ public class MyTools {
     }
 }
 ----
-<1> Generate the output schema from the `User` class.
+<1> Generate the output schema from the `User` class. A `Class` can be passed directly since it implements `java.lang.reflect.Type`.
 
 Alternatively, provide a schema object directly:
 

--- a/docs/modules/ROOT/pages/release-notes.adoc
+++ b/docs/modules/ROOT/pages/release-notes.adoc
@@ -16,6 +16,8 @@ include::./includes/attributes.adoc[]
 [[version-2-0-breaking]]
 === Breaking Changes
 
+* [2.0.0] `OutputSchemaGenerator.generate(Type)` is now the primary method for output schema generation. The `generate(Class<?>)` method is deprecated. Existing implementations that override `generate(Class<?>)` continue to work — the default `generate(Type)` delegates to `generate(Class<?>)` for `Class` arguments. New implementations should override `generate(Type)` instead. `ToolDefinition.generateOutputSchema()` now also accepts `java.lang.reflect.Type`.
+
 * [2.0.0] The Maven artifact relocations and configuration property fallbacks for the old `quarkus-mcp-server-sse` artifact (renamed to `quarkus-mcp-server-http` in <<version-1-8,1.8.0>>) have been removed. Users still referencing `quarkus-mcp-server-sse` must switch to `quarkus-mcp-server-http`, and any configuration properties using the `sse.` prefix (e.g. `quarkus.mcp.server.sse.root-path`) must be updated to use the `http.` prefix (e.g. `quarkus.mcp.server.http.root-path`). (https://github.com/quarkiverse/quarkus-mcp-server/issues/826[#826])
 * [2.0.0] JSON-RPC batching support has been removed. Batching was added in MCP 2025-03-26 and removed in 2025-06-18. The server now rejects batch (JSON array) messages with a parse error. The `whenBatch()` method has been removed from the `McpAssured` test API. (https://github.com/quarkiverse/quarkus-mcp-server/issues/723[#723])
 * [2.0.0] `McpRequest.protocolVersion()` now returns `McpProtocolVersion` instead of `String`.
@@ -39,6 +41,8 @@ include::./includes/attributes.adoc[]
 * [2.0.0] HTTP GET (SSE stream) and DELETE (session termination) requests from stateless clients now return `405 Method Not Allowed`.
 * [2.0.0] `subscriptions/listen` support for stateless clients. Replaces `resources/subscribe`/`resources/unsubscribe` for protocol version `2026-07-28`+. Clients specify a notification filter (tools, prompts, resources list changes, and resource URI subscriptions) and receive matching notifications on the subscription stream. Supported on all transports (HTTP, WebSocket, stdio). See xref:concepts-mcp-protocol.adoc#_subscription_notifications_stateless[Subscription Notifications]. (https://github.com/quarkiverse/quarkus-mcp-server/issues/824[#824])
 * [2.0.0] Initial support for https://github.com/mcp-java/java-mcp-annotations[Java MCP Annotations]. Both the Quarkus-specific and the standard Java MCP annotations are supported during the transitional period. (https://github.com/quarkiverse/quarkus-mcp-server/issues/823[#823])
+
+* [2.0.0] Output schema generation now preserves generic type information for tool return types (e.g. `List<MyPojo>`). Previously, parameterized return types with `structuredContent = true` produced incorrect schemas because generic type arguments were lost. See xref:guides-using-structured-content.adoc[Using Structured Content].
 
 [[version-2-0-fixes]]
 === Important Bug Fixes

--- a/test/src/main/java/io/quarkiverse/mcp/server/test/McpTestClientBase.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/McpTestClientBase.java
@@ -1512,7 +1512,7 @@ abstract class McpTestClientBase<ASSERT extends McpAssert<ASSERT>, CLIENT extend
                 content = List.of();
             }
             assertFunction.accept(
-                    new ToolResponse(isError, content, result.getJsonObject("structuredContent"), Contents.parseMeta(result)));
+                    new ToolResponse(isError, content, result.getValue("structuredContent"), Contents.parseMeta(result)));
         }
     }
 

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/structcontent/ToolStructuredContentTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/structcontent/ToolStructuredContentTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.util.List;
 import java.util.Objects;
 
 import jakarta.inject.Inject;
@@ -20,9 +21,11 @@ import io.quarkiverse.mcp.server.ToolResponse;
 import io.quarkiverse.mcp.server.test.McpAssured;
 import io.quarkiverse.mcp.server.test.McpAssured.McpStreamableTestClient;
 import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.arc.impl.ParameterizedTypeImpl;
 import io.quarkus.runtime.Startup;
 import io.quarkus.test.QuarkusUnitTest;
 import io.smallrye.mutiny.Uni;
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 public class ToolStructuredContentTest extends McpServerTest {
@@ -38,7 +41,7 @@ public class ToolStructuredContentTest extends McpServerTest {
 
         client.when()
                 .toolsList(page -> {
-                    assertEquals(5, page.tools().size());
+                    assertEquals(7, page.tools().size());
                     JsonObject alphaSchema = page.findByName("alpha").outputSchema();
                     assertNotNull(alphaSchema);
                     assertEquals("integer", alphaSchema.getJsonObject("properties").getJsonObject("val").getString("type"));
@@ -55,6 +58,18 @@ public class ToolStructuredContentTest extends McpServerTest {
                     JsonObject echoSchema = page.findByName("echo").outputSchema();
                     assertNotNull(echoSchema);
                     assertEquals("integer", echoSchema.getJsonObject("properties").getJsonObject("val").getString("type"));
+                    JsonObject foxtrotSchema = page.findByName("foxtrot").outputSchema();
+                    assertNotNull(foxtrotSchema);
+                    assertEquals("array", foxtrotSchema.getString("type"));
+                    assertEquals("integer",
+                            foxtrotSchema.getJsonObject("items").getJsonObject("properties").getJsonObject("val")
+                                    .getString("type"));
+                    JsonObject golfSchema = page.findByName("golf").outputSchema();
+                    assertNotNull(golfSchema);
+                    assertEquals("array", golfSchema.getString("type"));
+                    assertEquals("integer",
+                            golfSchema.getJsonObject("items").getJsonObject("properties").getJsonObject("val")
+                                    .getString("type"));
                 })
                 .toolsCall("alpha", toolResponse -> {
                     assertEquals(0, toolResponse.content().size());
@@ -99,6 +114,28 @@ public class ToolStructuredContentTest extends McpServerTest {
                         assertEquals(7, json.getInteger("val"));
                     } else {
                         fail("Not a JsonObject");
+                    }
+                })
+                .toolsCall("foxtrot", toolResponse -> {
+                    assertEquals(0, toolResponse.content().size());
+                    assertNotNull(toolResponse.structuredContent());
+                    if (toolResponse.structuredContent() instanceof JsonArray jsonArray) {
+                        assertEquals(2, jsonArray.size());
+                        assertEquals(1, jsonArray.getJsonObject(0).getInteger("val"));
+                        assertEquals(2, jsonArray.getJsonObject(1).getInteger("val"));
+                    } else {
+                        fail("Not a JsonArray");
+                    }
+                })
+                .toolsCall("golf", toolResponse -> {
+                    assertEquals(0, toolResponse.content().size());
+                    assertNotNull(toolResponse.structuredContent());
+                    if (toolResponse.structuredContent() instanceof JsonArray jsonArray) {
+                        assertEquals(2, jsonArray.size());
+                        assertEquals(3, jsonArray.getJsonObject(0).getInteger("val"));
+                        assertEquals(4, jsonArray.getJsonObject(1).getInteger("val"));
+                    } else {
+                        fail("Not a JsonArray");
                     }
                 })
                 .thenAssertResults();
@@ -155,6 +192,17 @@ public class ToolStructuredContentTest extends McpServerTest {
                         return ToolResponse.structuredSuccess(pojo);
                     })
                     .register();
+            toolManager.newTool("golf")
+                    .setDescription("Use golf for a list")
+                    .generateOutputSchema(new ParameterizedTypeImpl(List.class, MyPojo.class))
+                    .setHandler(toolArgs -> {
+                        MyPojo pojo1 = new MyPojo();
+                        pojo1.setVal(3);
+                        MyPojo pojo2 = new MyPojo();
+                        pojo2.setVal(4);
+                        return ToolResponse.structuredSuccess(List.of(pojo1, pojo2));
+                    })
+                    .register();
         }
 
         @Tool(description = "Use echo!", structuredContent = true)
@@ -162,6 +210,15 @@ public class ToolStructuredContentTest extends McpServerTest {
             MyPojo pojo = new MyPojo();
             pojo.setVal(7);
             return Uni.createFrom().item(pojo);
+        }
+
+        @Tool(description = "Use foxtrot!", structuredContent = true)
+        List<MyPojo> foxtrot() {
+            MyPojo pojo1 = new MyPojo();
+            pojo1.setVal(1);
+            MyPojo pojo2 = new MyPojo();
+            pojo2.setVal(2);
+            return List.of(pojo1, pojo2);
         }
 
     }


### PR DESCRIPTION
- OutputSchemaGenerator now accepts java.lang.reflect.Type
- the Class variant is deprecated
- ToolDefinition.generateOutputSchema(Type) added for the programmatic API
- also fixed McpTestClientBase to handle JSON array structuredContent
- fixes #894