### PR TITLE
http: match Origin host exactly in DNS rebinding protection

### DIFF
--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/dnsrebinding/DnsRebindingTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/dnsrebinding/DnsRebindingTest.java
@@ -1,10 +1,15 @@
 package io.quarkiverse.mcp.server.test.dnsrebinding;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import java.net.URI;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkiverse.mcp.server.McpConnection;
+import io.quarkiverse.mcp.server.Tool;
 import io.quarkiverse.mcp.server.test.McpAssured;
 import io.quarkiverse.mcp.server.test.McpAssured.McpStreamableTestClient;
 import io.quarkiverse.mcp.server.test.McpServerTest;
@@ -17,7 +22,9 @@ public class DnsRebindingTest extends McpServerTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = defaultConfig()
-            .withEmptyApplication();
+            .withApplicationRoot(
+                    root -> root.addClasses(MyTools.class))
+            .overrideConfigKey("quarkus.mcp.server.http.streamable.auto-init", "true");
 
     @Test
     public void testNonLocalhostRequestRejected() {
@@ -35,6 +42,80 @@ public class DnsRebindingTest extends McpServerTest {
                 .post(endpoint)
                 .then()
                 .statusCode(403);
+    }
+
+    @Test
+    public void testLocalhostSubdomainOriginRejected() {
+        McpStreamableTestClient client = McpAssured.newConnectedStreamableClient();
+        URI endpoint = client.mcpEndpoint();
+        RestAssured.given()
+                .when()
+                .headers(HttpHeaders.HOST + "", "localhost.evil.example",
+                        HttpHeaders.ORIGIN, "http://localhost.evil.example")
+                .body(new JsonObject()
+                        .put("jsonrpc", "2.0")
+                        .put("method", McpAssured.TOOLS_CALL)
+                        .put("id", 1)
+                        .put("params", new JsonObject().put("name", "foo")).encode())
+                .post(endpoint)
+                .then()
+                .statusCode(403);
+    }
+
+    @Test
+    public void testLocalhostOriginAccepted() {
+        McpStreamableTestClient client = McpAssured.newConnectedStreamableClient();
+        URI endpoint = client.mcpEndpoint();
+        client.terminateSession();
+        client.disconnect();
+        String origin = endpoint.getScheme() + "://" + endpoint.getAuthority();
+        JsonObject response = new JsonObject(RestAssured.given()
+                .when()
+                .headers(HttpHeaders.ORIGIN + "", origin,
+                        HttpHeaders.ACCEPT, "application/json, text/event-stream")
+                .body(new JsonObject()
+                        .put("jsonrpc", "2.0")
+                        .put("method", McpAssured.TOOLS_CALL)
+                        .put("id", 1)
+                        .put("params", new JsonObject().put("name", "foo")).encode())
+                .post(endpoint)
+                .then()
+                .statusCode(200)
+                .extract().body().asString());
+        assertNotNull(response.getJsonObject("result").getJsonArray("content").getJsonObject(0).getString("text"));
+        assertFalse(response.getJsonObject("result").getBoolean("isError"));
+    }
+
+    @Test
+    public void testIpv6LocalhostOriginAccepted() {
+        McpStreamableTestClient client = McpAssured.newConnectedStreamableClient();
+        URI endpoint = client.mcpEndpoint();
+        client.terminateSession();
+        client.disconnect();
+        JsonObject response = new JsonObject(RestAssured.given()
+                .when()
+                .headers(HttpHeaders.ORIGIN + "", "http://[::1]:8080",
+                        HttpHeaders.ACCEPT, "application/json, text/event-stream")
+                .body(new JsonObject()
+                        .put("jsonrpc", "2.0")
+                        .put("method", McpAssured.TOOLS_CALL)
+                        .put("id", 1)
+                        .put("params", new JsonObject().put("name", "foo")).encode())
+                .post(endpoint)
+                .then()
+                .statusCode(200)
+                .extract().body().asString());
+        assertNotNull(response.getJsonObject("result").getJsonArray("content").getJsonObject(0).getString("text"));
+        assertFalse(response.getJsonObject("result").getBoolean("isError"));
+    }
+
+    public static class MyTools {
+
+        @Tool
+        String foo(McpConnection connection) {
+            return connection.id();
+        }
+
     }
 
 }

--- a/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/HttpMcpServerRecorder.java
+++ b/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/HttpMcpServerRecorder.java
@@ -2,11 +2,13 @@ package io.quarkiverse.mcp.server.http.runtime;
 
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.VarHandle;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -300,24 +302,20 @@ public class HttpMcpServerRecorder {
     }
 
     private static final Set<String> LOCAL_HOSTNAMES = Set.of("localhost", "127.0.0.1", "[::1]", "::1");
-    private static final Set<String> ORIGIN_LOCAL_HOSTS;
-
-    static {
-        Set<String> originLocalHosts = new HashSet<String>();
-        for (String hostname : LOCAL_HOSTNAMES) {
-            originLocalHosts.add("http://" + hostname);
-            originLocalHosts.add("https://" + hostname);
-        }
-        ORIGIN_LOCAL_HOSTS = Set.copyOf(originLocalHosts);
-    }
 
     private boolean isLocalhost(String origin) {
-        for (String host : ORIGIN_LOCAL_HOSTS) {
-            if (origin.startsWith(host)) {
-                return true;
-            }
+        URI uri;
+        try {
+            uri = new URI(origin);
+        } catch (URISyntaxException e) {
+            return false;
         }
-        return false;
+        String scheme = uri.getScheme();
+        if (!"http".equalsIgnoreCase(scheme) && !"https".equalsIgnoreCase(scheme)) {
+            return false;
+        }
+        String host = uri.getHost();
+        return host != null && LOCAL_HOSTNAMES.contains(host.toLowerCase(Locale.ROOT));
     }
 
 }


### PR DESCRIPTION
## What this does

Hardens the Streamable HTTP transport's DNS rebinding origin check so that it matches the `Origin` host exactly, instead of by string prefix.

`isLocalhost()` compared the `Origin` header with `String.startsWith` against `http://localhost`, `https://localhost`, `http://127.0.0.1`, and so on. Because it was a prefix match, any origin whose host merely *begins* with an allowed value was accepted. For example `http://localhost.evil.example` starts with `http://localhost`, so a page served from an attacker-controlled `localhost.evil.example` (rebound to `127.0.0.1`) passed the check, which is the DNS rebinding case the check is meant to stop.

The fix parses the `Origin` as a `java.net.URI` and compares its host exactly (case-insensitive) against the allowed localhost values, keeping the original http/https-only constraint. This matches the exact-hostname comparison used by the MCP Conformance suite's own [`isLocalhostUrl()`](https://github.com/modelcontextprotocol/conformance/blob/main/src/scenarios/server/dns-rebinding.ts).

## Scope and framing

This is a correctness/hardening fix to the origin check, which is **defense-in-depth that complements the CORS filter** (the server already warns at startup to enable CORS), not a standalone security boundary. Within the browser trust model that DNS rebinding targets, a precise host check is what makes the difference; this PR makes that check precise.

## Changes

- `HttpMcpServerRecorder.isLocalhost()` rewritten to parse the Origin and compare the host exactly; the derived `ORIGIN_LOCAL_HOSTS` set and its static initializer are removed (the existing `LOCAL_HOSTNAMES` set is reused).
- `DnsRebindingTest` extended: a regression test for the subdomain bypass (`http://localhost.evil.example` -> 403), plus acceptance tests for a valid localhost origin and a bracketed IPv6 localhost origin (`http://[::1]:...`) -> 200. The existing non-localhost rejection test is unchanged.

## Verification

- Red/green: the new subdomain test fails on the current code (the request is accepted and reaches MCP handling, returning 400 rather than 403), and passes after the fix.
- `mvn -pl transports/http/deployment test -Dtest='DnsRebindingTest,DnsRebindingDisabledTest'` is green: evil origin -> 403, subdomain -> 403, valid localhost -> 200, bracketed IPv6 -> 200, check-disabled -> 200.
- The change only makes rejection stricter; genuine localhost origins are accepted exactly as before, so the conformance suite's accepted case does not regress. One deliberate, minor behavior change: a bare unbracketed `http://::1` origin is now rejected as malformed, which no browser sends.

## Background

- MCP Conformance DNS rebinding scenario: https://github.com/modelcontextprotocol/conformance/blob/main/src/scenarios/server/dns-rebinding.ts
- MCP spec: https://modelcontextprotocol.io/specification/2025-11-25/basic/security_best_practices#local-mcp-server-compromise and https://modelcontextprotocol.io/specification/2025-11-25/basic/transports#security-warning
- Related advisory referenced by the scenario: GHSA-w48q-cv73-mx4w

## Open question for maintainers

The check inspects only the `Origin` header, and only when it is present. A request without an `Origin` (some simple CORS requests) is not caught by this check today; the `Host` header would catch a rebind in that case. Adding a `Host`-header check has false-positive risk for reverse-proxy and custom-hostname deployments, so I have left it out of this PR. Happy to follow up separately if you want to pursue it.

Follows up the email discussion with @mkouba and @sberyozkin.
