### PR TITLE
http: fix incorrect config phase for McpHttpServersRuntimeConfig [1.10.x]

### DIFF
--- a/docs/modules/ROOT/pages/includes/quarkus-mcp-server-http.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-mcp-server-http.adoc
@@ -62,7 +62,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++false+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-mcp-server-http_quarkus-mcp-server-http-dns-rebinding-check-enabled]] [.property-path]##link:#quarkus-mcp-server-http_quarkus-mcp-server-http-dns-rebinding-check-enabled[`+++quarkus.mcp.server.http.dns-rebinding-check.enabled+++`]##
+a| [[quarkus-mcp-server-http_quarkus-mcp-server-http-dns-rebinding-check-enabled]] [.property-path]##link:#quarkus-mcp-server-http_quarkus-mcp-server-http-dns-rebinding-check-enabled[`+++quarkus.mcp.server.http.dns-rebinding-check.enabled+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.mcp.server.http.dns-rebinding-check.enabled+++[]
 endif::add-copy-button-to-config-props[]
@@ -88,7 +88,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-mcp-server-http_quarkus-mcp-server-http-streamable-dummy-init]] [.property-path]##link:#quarkus-mcp-server-http_quarkus-mcp-server-http-streamable-dummy-init[`+++quarkus.mcp.server.http.streamable.dummy-init+++`]##
+a| [[quarkus-mcp-server-http_quarkus-mcp-server-http-streamable-dummy-init]] [.property-path]##link:#quarkus-mcp-server-http_quarkus-mcp-server-http-streamable-dummy-init[`+++quarkus.mcp.server.http.streamable.dummy-init+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.mcp.server.http.streamable.dummy-init+++[]
 endif::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-mcp-server-http_quarkus.mcp.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-mcp-server-http_quarkus.mcp.adoc
@@ -62,7 +62,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++false+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-mcp-server-http_quarkus-mcp-server-http-dns-rebinding-check-enabled]] [.property-path]##link:#quarkus-mcp-server-http_quarkus-mcp-server-http-dns-rebinding-check-enabled[`+++quarkus.mcp.server.http.dns-rebinding-check.enabled+++`]##
+a| [[quarkus-mcp-server-http_quarkus-mcp-server-http-dns-rebinding-check-enabled]] [.property-path]##link:#quarkus-mcp-server-http_quarkus-mcp-server-http-dns-rebinding-check-enabled[`+++quarkus.mcp.server.http.dns-rebinding-check.enabled+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.mcp.server.http.dns-rebinding-check.enabled+++[]
 endif::add-copy-button-to-config-props[]
@@ -88,7 +88,7 @@ endif::add-copy-button-to-env-var[]
 |boolean
 |`+++true+++`
 
-a|icon:lock[title=Fixed at build time] [[quarkus-mcp-server-http_quarkus-mcp-server-http-streamable-dummy-init]] [.property-path]##link:#quarkus-mcp-server-http_quarkus-mcp-server-http-streamable-dummy-init[`+++quarkus.mcp.server.http.streamable.dummy-init+++`]##
+a| [[quarkus-mcp-server-http_quarkus-mcp-server-http-streamable-dummy-init]] [.property-path]##link:#quarkus-mcp-server-http_quarkus-mcp-server-http-streamable-dummy-init[`+++quarkus.mcp.server.http.streamable.dummy-init+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.mcp.server.http.streamable.dummy-init+++[]
 endif::add-copy-button-to-config-props[]

--- a/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/config/McpHttpServersRuntimeConfig.java
+++ b/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/config/McpHttpServersRuntimeConfig.java
@@ -11,7 +11,7 @@ import io.smallrye.config.WithDefaults;
 import io.smallrye.config.WithParentName;
 import io.smallrye.config.WithUnnamedKey;
 
-@ConfigRoot(phase = ConfigPhase.BUILD_AND_RUN_TIME_FIXED)
+@ConfigRoot(phase = ConfigPhase.RUN_TIME)
 @ConfigMapping(prefix = "quarkus.mcp.server")
 public interface McpHttpServersRuntimeConfig {
 


### PR DESCRIPTION
- McpHttpServersRuntimeConfig used BUILD_AND_RUN_TIME_FIXED but all its properties (dns-rebinding-check.enabled, auto-init, lazy-sse-init) are purely runtime in nature
- changed to RUN_TIME to match the other runtime configs and allow these properties to be overridden at startup.
- resolves quarkiverse#904