### PR TITLE
http: honor the current log level for the subsidiary SSE debug notification

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/McpLog.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/McpLog.java
@@ -88,6 +88,14 @@ public interface McpLog {
         ALERT,
         EMERGENCY;
 
+        /**
+         * @param threshold the minimum level
+         * @return {@code true} if this level is at least the given threshold
+         */
+        public boolean isAtLeast(LogLevel threshold) {
+            return this.ordinal() >= threshold.ordinal();
+        }
+
         public static LogLevel from(String val) {
             if (val == null || val.isBlank()) {
                 return null;

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpLogImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpLogImpl.java
@@ -30,7 +30,7 @@ class McpLogImpl implements McpLog {
 
     @Override
     public void send(LogLevel level, Object data) {
-        if (isEnabled(Objects.requireNonNull(level))) {
+        if (Objects.requireNonNull(level).isAtLeast(level())) {
             sender.send(Messages.newNotification(McpMethod.NOTIFICATIONS_MESSAGE.jsonRpcName(),
                     Messages.newLog(level, mcpLoggerName, encode(data))));
         }
@@ -38,7 +38,7 @@ class McpLogImpl implements McpLog {
 
     @Override
     public void send(LogLevel level, String format, Object... params) {
-        if (isEnabled(Objects.requireNonNull(level))) {
+        if (Objects.requireNonNull(level).isAtLeast(level())) {
             sender.send(Messages.newNotification(McpMethod.NOTIFICATIONS_MESSAGE.jsonRpcName(),
                     Messages.newLog(level, mcpLoggerName, format.formatted(params))));
         }
@@ -71,10 +71,6 @@ class McpLogImpl implements McpLog {
     public void error(Throwable t, String format, Object... params) {
         logger.errorf(t, format, params);
         send(LogLevel.ERROR, format, params);
-    }
-
-    private boolean isEnabled(LogLevel level) {
-        return level().ordinal() <= level.ordinal();
     }
 
     private Object encode(Object data) {

--- a/core/runtime/src/test/java/io/quarkiverse/mcp/server/LogLevelTest.java
+++ b/core/runtime/src/test/java/io/quarkiverse/mcp/server/LogLevelTest.java
@@ -1,0 +1,26 @@
+package io.quarkiverse.mcp.server;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import io.quarkiverse.mcp.server.McpLog.LogLevel;
+
+public class LogLevelTest {
+
+    @Test
+    public void testIsAtLeast() {
+        assertTrue(LogLevel.DEBUG.isAtLeast(LogLevel.DEBUG));
+        assertFalse(LogLevel.DEBUG.isAtLeast(LogLevel.INFO));
+        assertFalse(LogLevel.DEBUG.isAtLeast(LogLevel.EMERGENCY));
+
+        assertTrue(LogLevel.INFO.isAtLeast(LogLevel.DEBUG));
+        assertTrue(LogLevel.INFO.isAtLeast(LogLevel.INFO));
+        assertFalse(LogLevel.INFO.isAtLeast(LogLevel.WARNING));
+
+        assertTrue(LogLevel.EMERGENCY.isAtLeast(LogLevel.DEBUG));
+        assertTrue(LogLevel.EMERGENCY.isAtLeast(LogLevel.EMERGENCY));
+    }
+
+}

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/McpServerTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/McpServerTest.java
@@ -25,6 +25,8 @@ public abstract class McpServerTest {
             config.overrideConfigKey("quarkus.mcp.server.traffic-logging.enabled", "true");
             config.overrideConfigKey("quarkus.mcp.server.traffic-logging.text-limit", "" + textLimit);
         }
+        // Set the default log level to DEBUG so that the subsidiary SSE debug notification is sent
+        config.overrideRuntimeConfigKey("quarkus.mcp.server.client-logging.default-level", "DEBUG");
         // Disable all input schema generators by default
         config.overrideRuntimeConfigKey("quarkus.mcp.server.schema-generator.jackson.enabled", "false");
         config.overrideRuntimeConfigKey("quarkus.mcp.server.schema-generator.jakarta-validation.enabled", "false");

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/logging/LoggingSetLevelTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/logging/LoggingSetLevelTest.java
@@ -22,6 +22,7 @@ public class LoggingSetLevelTest extends McpServerTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = defaultConfig()
+            .overrideRuntimeConfigKey("quarkus.mcp.server.client-logging.default-level", "INFO")
             .withApplicationRoot(root -> root.addClass(MyTools.class));
 
     @Test

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/logging/LoggingStreamableTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/logging/LoggingStreamableTest.java
@@ -20,6 +20,7 @@ public class LoggingStreamableTest extends McpServerTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = defaultConfig()
+            .overrideRuntimeConfigKey("quarkus.mcp.server.client-logging.default-level", "INFO")
             .withApplicationRoot(root -> root.addClass(MyTools.class));
 
     @Test

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/logging/LoggingTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/logging/LoggingTest.java
@@ -20,6 +20,7 @@ public class LoggingTest extends McpServerTest {
 
     @RegisterExtension
     static final QuarkusUnitTest config = defaultConfig()
+            .overrideRuntimeConfigKey("quarkus.mcp.server.client-logging.default-level", "INFO")
             .withApplicationRoot(root -> root.addClass(MyTools.class));
 
     @Test

--- a/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/StreamableHttpMcpMessageHandler.java
+++ b/transports/http/runtime/src/main/java/io/quarkiverse/mcp/server/http/runtime/StreamableHttpMcpMessageHandler.java
@@ -550,13 +550,15 @@ public class StreamableHttpMcpMessageHandler extends McpMessageHandler<HttpMcpRe
         SseStream sse = new SseStream(ConnectionManager.connectionId(), response);
         streamableConnection.addSse(sse);
 
-        // Send log notification to the client
-        JsonObject log = Messages.newNotification(McpMethod.NOTIFICATIONS_MESSAGE.jsonRpcName(),
-                Messages.newLog(McpLog.LogLevel.DEBUG, "SseStream",
-                        "Subsidiary SSE opened [%s]".formatted(connection.id())));
+        // Send log notification to the client if the log level allows it
+        if (McpLog.LogLevel.DEBUG.isAtLeast(connection.logLevel())) {
+            JsonObject log = Messages.newNotification(McpMethod.NOTIFICATIONS_MESSAGE.jsonRpcName(),
+                    Messages.newLog(McpLog.LogLevel.DEBUG, "SseStream",
+                            "Subsidiary SSE opened [%s]".formatted(connection.id())));
 
-        trafficListeners.messageSent(log, connection);
-        sse.sendEvent("message", log.encode());
+            trafficListeners.messageSent(log, connection);
+            sse.sendEvent("message", log.encode());
+        }
 
         HttpMcpServerRecorder.setCloseHandler(request, () -> {
             if (streamableConnection.removeSse(sse.id())) {


### PR DESCRIPTION
- the server no longer sends an unconditional DEBUG log notification when a subsidiary SSE stream opens
- instead, it checks the connection's current log level and only sends the notification if the level permits it
- resolves #910