### PR TITLE
core: fix tools args holder class generation

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/McpServerProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/McpServerProcessor.java
@@ -17,6 +17,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -1135,6 +1136,8 @@ class McpServerProcessor {
     private record ManagerUsage(boolean resources, boolean resourceTemplates, boolean prompts, boolean tools) {
     }
 
+    private static final char[] INVALID_JVM_FIELD_NAME_CHARS = { '.', ';', '[', '/' };
+
     private String generateToolArgsHolder(Gizmo gizmo, FeatureMethodBuildItem tool,
             ClassOutput classOutput, BuildProducer<ReflectiveClassBuildItem> reflectiveClasses, IndexView index) {
         // Generate a holder for each tool with at least one argument that is:
@@ -1157,6 +1160,13 @@ class McpServerProcessor {
         if (!generateHolder) {
             return null;
         }
+
+        DotName argAnnotationName = tool.getMethod().hasDeclaredAnnotation(DotNames.LANGCHAIN4J_TOOL)
+                ? DotNames.LANGCHAIN4J_P
+                : tool.getMethod().hasDeclaredAnnotation(DotNames.MCPJAVA_TOOL)
+                        ? DotNames.MCPJAVA_TOOL_ARG
+                        : DotNames.TOOL_ARG;
+
         // org.example.MyTool_foo
         String className = tool.getMethod().declaringClass().name().toString() + "_" + tool.getName();
         LOG.debugf("Generate tool arguments holder: %s", className);
@@ -1164,7 +1174,9 @@ class McpServerProcessor {
         gizmo.class_(className, cc -> {
             cc.defaultConstructor();
             for (MethodParameterInfo param : serializedArguments) {
-                cc.field(param.name(), fc -> {
+                String fieldName = resolveEffectiveArgName(param, argAnnotationName);
+                validateFieldName(fieldName, param, tool);
+                cc.field(fieldName, fc -> {
                     fc.public_();
                     fc.setType(Jandex2Gizmo.genericTypeOf(param.type()));
                     for (AnnotationInstance annotation : param.declaredAnnotations()) {
@@ -1174,6 +1186,38 @@ class McpServerProcessor {
             }
         });
         return className;
+    }
+
+    private String resolveEffectiveArgName(MethodParameterInfo param, DotName argAnnotationName) {
+        AnnotationInstance argAnnotation = param.declaredAnnotation(argAnnotationName);
+        if (argAnnotation != null) {
+            AnnotationValue nameValue;
+            if (DotNames.LANGCHAIN4J_P.equals(argAnnotationName)) {
+                nameValue = argAnnotation.value();
+            } else {
+                nameValue = argAnnotation.value("name");
+            }
+            if (nameValue != null && !ToolArg.ELEMENT_NAME.equals(nameValue.asString())) {
+                return nameValue.asString();
+            }
+        }
+        return param.name();
+    }
+
+    private void validateFieldName(String name, MethodParameterInfo param, FeatureMethodBuildItem tool) {
+        if (name == null || name.isEmpty()) {
+            return;
+        }
+        for (char invalid : INVALID_JVM_FIELD_NAME_CHARS) {
+            if (name.indexOf(invalid) >= 0) {
+                throw new IllegalStateException(
+                        "Invalid argument name '%s' for parameter '%s' of method %s#%s() - the name must not contain '%c'"
+                                .formatted(name, param.name(),
+                                        tool.getMethod().declaringClass().name(),
+                                        tool.getMethod().name(),
+                                        invalid));
+            }
+        }
     }
 
     @BuildStep
@@ -1314,6 +1358,7 @@ class McpServerProcessor {
 
             mc.body(bc -> {
                 LocalVar args = bc.localVar("args", List.class, bc.new_(ArrayList.class));
+                Set<String> argNames = new HashSet<>();
 
                 for (MethodParameterInfo param : featureMethod.getMethod().parameters()) {
                     String name = param.name();
@@ -1373,6 +1418,16 @@ class McpServerProcessor {
                                                 explicitAnnotation));
                     }
 
+                    FeatureArgument.Provider provider = FeatureArguments.providerFrom(param.type());
+                    if (provider == FeatureArgument.Provider.PARAMS
+                            && !argNames.add(name)) {
+                        throw new IllegalStateException(
+                                "Duplicate argument name '%s' in method %s#%s()"
+                                        .formatted(name,
+                                                featureMethod.getMethod().declaringClass().name(),
+                                                featureMethod.getMethod().name()));
+                    }
+
                     LocalVar type = RuntimeTypeCreator.of(bc).withIndex(index).create(param.type());
                     // new FeatureArgument(String name, String title, String description, boolean
                     // required, Type type, String defaultValue, Provider provider)
@@ -1383,7 +1438,7 @@ class McpServerProcessor {
                             Const.of(required),
                             type,
                             defaultValue != null ? Const.of(defaultValue) : Const.ofNull(String.class),
-                            Const.of(FeatureArguments.providerFrom(param.type()))));
+                            Const.of(provider)));
                     bc.withList(args).add(arg);
                 }
 

--- a/hibernate-validator/deployment/src/test/java/io/quarkiverse/mcp/server/hibernate/validator/test/ToolArgNameWithValidationTest.java
+++ b/hibernate-validator/deployment/src/test/java/io/quarkiverse/mcp/server/hibernate/validator/test/ToolArgNameWithValidationTest.java
@@ -1,0 +1,95 @@
+package io.quarkiverse.mcp.server.hibernate.validator.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Size;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolArg;
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkiverse.mcp.server.test.McpAssured.McpStreamableTestClient;
+import io.quarkiverse.mcp.server.test.McpAssured.ToolInfo;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+public class ToolArgNameWithValidationTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .withApplicationRoot(
+                    root -> root.addClasses(MyTools.class));
+
+    @Test
+    public void testToolArgNameWithValidation() {
+        McpStreamableTestClient client = McpAssured.newConnectedStreamableClient();
+        client.when()
+                .toolsList(page -> {
+                    ToolInfo findProduct = page.findByName("findProduct");
+                    JsonObject schema = findProduct.inputSchema();
+                    JsonObject properties = schema.getJsonObject("properties");
+
+                    // Property should be keyed by the @ToolArg name, not the Java param name
+                    assertNotNull(properties.getJsonObject("sku_code"), properties.toString());
+                    assertNull(properties.getJsonObject("skuCode"), properties.toString());
+
+                    // @Size(min = 3) should be reflected on the correctly named property
+                    assertEquals(3, properties.getJsonObject("sku_code").getInteger("minLength"));
+
+                    // "required" should only contain the @ToolArg name
+                    JsonArray required = schema.getJsonArray("required");
+                    assertTrue(required.contains("sku_code"), required.toString());
+                    assertFalse(required.contains("skuCode"), required.toString());
+
+                    ToolInfo getPrice = page.findByName("getPrice");
+                    JsonObject priceSchema = getPrice.inputSchema();
+                    JsonObject priceProperties = priceSchema.getJsonObject("properties");
+
+                    assertNotNull(priceProperties.getJsonObject("product_price"), priceProperties.toString());
+                    assertNull(priceProperties.getJsonObject("price"), priceProperties.toString());
+                    assertEquals(1, priceProperties.getJsonObject("product_price").getInteger("minimum"));
+                })
+                .toolsCall("findProduct", Map.of("sku_code", "ABC-123"), toolResponse -> {
+                    assertFalse(toolResponse.isError());
+                    assertEquals("found:ABC-123", toolResponse.firstContent().asText().text());
+                })
+                .toolsCall("findProduct", Map.of("sku_code", "AB"), toolResponse -> {
+                    // @Size(min = 3) violation
+                    assertTrue(toolResponse.isError());
+                })
+                .toolsCall("getPrice", Map.of("product_price", 10), toolResponse -> {
+                    assertFalse(toolResponse.isError());
+                    assertEquals("price:10", toolResponse.firstContent().asText().text());
+                })
+                .toolsCall("getPrice", Map.of("product_price", 0), toolResponse -> {
+                    // @Min(1) violation
+                    assertTrue(toolResponse.isError());
+                })
+                .thenAssertResults();
+    }
+
+    public static class MyTools {
+
+        @Tool(description = "Look up a product by its stock-keeping unit")
+        String findProduct(
+                @ToolArg(description = "Stock-keeping unit", name = "sku_code") @Size(min = 3) String skuCode) {
+            return "found:" + skuCode;
+        }
+
+        @Tool(description = "Get product price")
+        String getPrice(
+                @ToolArg(name = "product_price") @Min(1) Integer price) {
+            return "price:" + price;
+        }
+    }
+}

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/DuplicateToolArgNameTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/DuplicateToolArgNameTest.java
@@ -1,0 +1,34 @@
+package io.quarkiverse.mcp.server.test.tools;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolArg;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class DuplicateToolArgNameTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .withApplicationRoot(root -> root.addClasses(MyTools.class))
+            .setExpectedException(IllegalStateException.class, true);
+
+    @Test
+    public void test() {
+        fail();
+    }
+
+    public static class MyTools {
+
+        @Tool
+        String findProduct(
+                @ToolArg(name = "code") String skuCode,
+                @ToolArg(name = "code") String barCode) {
+            return skuCode + barCode;
+        }
+    }
+}

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/InvalidToolArgNameTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/InvalidToolArgNameTest.java
@@ -1,0 +1,35 @@
+package io.quarkiverse.mcp.server.test.tools;
+
+import static org.junit.jupiter.api.Assertions.fail;
+
+import jakarta.validation.constraints.NotBlank;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolArg;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+
+public class InvalidToolArgNameTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .withApplicationRoot(root -> root.addClasses(MyTools.class))
+            .setExpectedException(IllegalStateException.class, true);
+
+    @Test
+    public void test() {
+        fail();
+    }
+
+    public static class MyTools {
+
+        @Tool
+        String findProduct(
+                @ToolArg(name = "sku.code") @NotBlank String skuCode) {
+            return skuCode;
+        }
+    }
+}


### PR DESCRIPTION
- the generated tool arguments holder class used the Java parameter name for its fields; when a tool specified a different name (ToolArg, etc.), the victools-generated schema property key didn't match the name used by the required array and runtime argument binding
- in the fix we use the effective argument name as the holder field name, we also validate that the name does not contain a JVM-forbidden field name characters and duplicate argument names at build time
- fixes #918