### PR TITLE
core: generate holder class for non-simple tool argument types

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/McpServerProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/McpServerProcessor.java
@@ -96,6 +96,7 @@ import io.quarkiverse.mcp.server.runtime.DefaultSchemaGenerator;
 import io.quarkiverse.mcp.server.runtime.Feature;
 import io.quarkiverse.mcp.server.runtime.FeatureArgument;
 import io.quarkiverse.mcp.server.runtime.FeatureArgument.Provider;
+import io.quarkiverse.mcp.server.runtime.FeatureKey;
 import io.quarkiverse.mcp.server.runtime.FeatureMetadata;
 import io.quarkiverse.mcp.server.runtime.FeatureMethodInfo;
 import io.quarkiverse.mcp.server.runtime.JsonTextContentEncoder;
@@ -1097,7 +1098,11 @@ class McpServerProcessor {
                         String generatedClassName = generateToolArgsHolder(gizmo, tool, classOutput, reflectiveClasses,
                                 beanArchiveIndex.getIndex());
                         if (generatedClassName != null) {
-                            bc.withMap(ret).put(Const.of(tool.getName()), Const.of(ClassDesc.of(generatedClassName)));
+                            for (String server : tool.getServers()) {
+                                bc.withMap(ret).put(
+                                        bc.new_(FeatureKey.class, Const.of(tool.getName()), Const.of(server)),
+                                        Const.of(ClassDesc.of(generatedClassName)));
+                            }
                         }
                     }
                     bc.return_(ret);

--- a/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/McpServerProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/McpServerProcessor.java
@@ -43,6 +43,7 @@ import org.jboss.jandex.DotName;
 import org.jboss.jandex.IndexView;
 import org.jboss.jandex.MethodInfo;
 import org.jboss.jandex.MethodParameterInfo;
+import org.jboss.jandex.PrimitiveType;
 import org.jboss.jandex.Type;
 import org.jboss.jandex.Type.Kind;
 import org.jboss.jandex.gizmo2.Jandex2Gizmo;
@@ -1138,22 +1139,48 @@ class McpServerProcessor {
 
     private static final char[] INVALID_JVM_FIELD_NAME_CHARS = { '.', ';', '[', '/' };
 
+    private static boolean isSimpleType(Type type, IndexView index) {
+        if (type.kind() == Kind.PRIMITIVE) {
+            return true;
+        }
+        if (PrimitiveType.isBox(type)) {
+            return true;
+        }
+        DotName name = type.name();
+        if (DotNames.STRING.equals(name)) {
+            return true;
+        }
+        if (FeatureArguments.isOptionalType(name)) {
+            if (DotNames.OPTIONAL.equals(name)) {
+                return isSimpleType(type.asParameterizedType().arguments().get(0), index);
+            }
+            // OptionalInt, OptionalLong, OptionalDouble
+            return true;
+        }
+        ClassInfo classInfo = index.getClassByName(name);
+        return classInfo != null && classInfo.isEnum();
+    }
+
     private String generateToolArgsHolder(Gizmo gizmo, FeatureMethodBuildItem tool,
             ClassOutput classOutput, BuildProducer<ReflectiveClassBuildItem> reflectiveClasses, IndexView index) {
-        // Generate a holder for each tool with at least one argument that is:
-        // - serialized
-        // - annotated with any other annotation than @ToolArg and @P
+        // Generate a holder for each tool with at least one serialized argument that either:
+        // - is annotated with any other annotation than @ToolArg, @P, @McpJavaToolArg
+        // - has a non-simple type (i.e. not a primitive, wrapper, String, enum, or Optional of those)
         boolean generateHolder = false;
         List<MethodParameterInfo> serializedArguments = new ArrayList<>();
         for (MethodParameterInfo param : tool.getMethod().parameters()) {
             if (FeatureArguments.providerFrom(param.type()) == Provider.PARAMS) {
                 serializedArguments.add(param);
-                List<AnnotationInstance> annotations = param.declaredAnnotations();
-                if (!annotations.isEmpty()
-                        && annotations.stream().anyMatch(a -> !a.name().equals(DotNames.TOOL_ARG)
-                                && !a.name().equals(DotNames.LANGCHAIN4J_P)
-                                && !a.name().equals(DotNames.MCPJAVA_TOOL_ARG))) {
-                    generateHolder = true;
+                if (!generateHolder) {
+                    List<AnnotationInstance> annotations = param.declaredAnnotations();
+                    if (!annotations.isEmpty()
+                            && annotations.stream().anyMatch(a -> !a.name().equals(DotNames.TOOL_ARG)
+                                    && !a.name().equals(DotNames.LANGCHAIN4J_P)
+                                    && !a.name().equals(DotNames.MCPJAVA_TOOL_ARG))) {
+                        generateHolder = true;
+                    } else if (!isSimpleType(param.type(), index)) {
+                        generateHolder = true;
+                    }
                 }
             }
         }
@@ -1178,7 +1205,12 @@ class McpServerProcessor {
                 validateFieldName(fieldName, param, tool);
                 cc.field(fieldName, fc -> {
                     fc.public_();
-                    fc.setType(Jandex2Gizmo.genericTypeOf(param.type()));
+                    // Unwrap Optional<T> to T so that victools does not generate a nullable type
+                    Type paramType = param.type();
+                    if (DotNames.OPTIONAL.equals(paramType.name())) {
+                        paramType = paramType.asParameterizedType().arguments().get(0);
+                    }
+                    fc.setType(Jandex2Gizmo.genericTypeOf(paramType));
                     for (AnnotationInstance annotation : param.declaredAnnotations()) {
                         Jandex2Gizmo.addAnnotation(fc, annotation, index);
                     }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/DefaultSchemaGenerator.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/DefaultSchemaGenerator.java
@@ -31,7 +31,7 @@ public class DefaultSchemaGenerator implements GlobalInputSchemaGenerator, Globa
 
     private final SchemaGenerator schemaGenerator;
 
-    private final Map<String, Class<?>> toolArgumentHolders;
+    private final Map<FeatureKey, Class<?>> toolArgumentHolders;
 
     final Map<Type, DefaultValueConverter<?>> defaultValueConverters;
 
@@ -45,7 +45,7 @@ public class DefaultSchemaGenerator implements GlobalInputSchemaGenerator, Globa
 
     @Override
     public InputSchema generate(ToolInfo tool) {
-        Class<?> holder = toolArgumentHolders.get(tool.name());
+        Class<?> holder = toolArgumentHolders.get(new FeatureKey(tool.name(), tool.serverNames().iterator().next()));
 
         if (holder != null) {
             JsonNode jsonNode = generateSchema(holder, tool.arguments());

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/DefaultSchemaGenerator.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/DefaultSchemaGenerator.java
@@ -71,7 +71,7 @@ public class DefaultSchemaGenerator implements GlobalInputSchemaGenerator, Globa
             return new InputSchemaImpl(schema);
 
         } else {
-            // Fallback for individual primitives (no complex recursive types expected here)
+            // Fallback for simple types (primitives, wrappers, String, enums)
             JsonObject properties = new JsonObject();
             for (ToolArgument a : tool.arguments()) {
                 properties.put(a.name(), generateSchema(a.type(), a.description(), a.defaultValue()));

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpMetadata.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpMetadata.java
@@ -39,7 +39,7 @@ public interface McpMetadata {
 
     Map<Type, DefaultValueConverter<?>> defaultValueConverters();
 
-    Map<String, Class<?>> toolArgumentHolders();
+    Map<FeatureKey, Class<?>> toolArgumentHolders();
 
     static <T> FeatureMetadata<T> findFeature(List<FeatureMetadata<T>> features, String name, String serverName) {
         return features.stream().filter(fm -> fm.info().name().equals(name) && fm.info().serverNames().contains(serverName))

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/mcpservers/SameNameDifferentServersTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/mcpservers/SameNameDifferentServersTest.java
@@ -2,6 +2,9 @@ package io.quarkiverse.mcp.server.test.mcpservers;
 
 import static io.quarkiverse.mcp.server.McpServer.DEFAULT;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -18,6 +21,7 @@ import io.quarkiverse.mcp.server.test.McpAssured;
 import io.quarkiverse.mcp.server.test.McpAssured.McpStreamableTestClient;
 import io.quarkiverse.mcp.server.test.McpServerTest;
 import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.json.JsonObject;
 
 /**
  * Tests that the same feature name can be used on different servers.
@@ -41,10 +45,20 @@ public class SameNameDifferentServersTest extends McpServerTest {
 
         client.when()
                 .toolsList(page -> {
-                    assertEquals(1, page.size());
-                    assertEquals("query", page.tools().get(0).name());
+                    assertEquals(2, page.size());
+                    assertEquals("query", page.tools().get(1).name());
+
+                    // Verify the schema uses AlphaItem (has "label" property)
+                    JsonObject schema = page.findByName("analyze").inputSchema();
+                    JsonObject properties = schema.getJsonObject("properties");
+                    assertNotNull(properties);
+                    JsonObject itemProps = properties.getJsonObject("item").getJsonObject("properties");
+                    assertNotNull(itemProps.getJsonObject("label"),
+                            "Alpha's analyze tool should use AlphaItem with 'label' property");
                 })
                 .toolsCall("query", r -> assertEquals("alpha_result", r.firstContent().asText().text()))
+                .toolsCall("analyze", Map.of("item", new AlphaItem("test")),
+                        r -> assertEquals("alpha:test", r.firstContent().asText().text()))
                 .promptsGet("summarize", r -> assertEquals("alpha_prompt", r.messages().get(0).content().asText().text()))
                 .resourcesRead("file://data", r -> assertEquals("alpha_data", r.contents().get(0).asText().text()))
                 .thenAssertResults();
@@ -59,13 +73,29 @@ public class SameNameDifferentServersTest extends McpServerTest {
 
         client.when()
                 .toolsList(page -> {
-                    assertEquals(1, page.size());
-                    assertEquals("query", page.tools().get(0).name());
+                    assertEquals(2, page.size());
+                    assertEquals("query", page.tools().get(1).name());
+
+                    // Verify the schema uses BravoItem (has "code" property)
+                    JsonObject schema = page.findByName("analyze").inputSchema();
+                    JsonObject properties = schema.getJsonObject("properties");
+                    assertNotNull(properties);
+                    JsonObject itemProps = properties.getJsonObject("item").getJsonObject("properties");
+                    assertNotNull(itemProps.getJsonObject("code"),
+                            "Bravo's analyze tool should use BravoItem with 'code' property");
                 })
                 .toolsCall("query", r -> assertEquals("bravo_result", r.firstContent().asText().text()))
+                .toolsCall("analyze", Map.of("item", new BravoItem(42)),
+                        r -> assertEquals("bravo:42", r.firstContent().asText().text()))
                 .promptsGet("summarize", r -> assertEquals("bravo_prompt", r.messages().get(0).content().asText().text()))
                 .resourcesRead("file://data", r -> assertEquals("bravo_data", r.contents().get(0).asText().text()))
                 .thenAssertResults();
+    }
+
+    public record AlphaItem(String label) {
+    }
+
+    public record BravoItem(int code) {
     }
 
     @McpServer(DEFAULT)
@@ -74,6 +104,11 @@ public class SameNameDifferentServersTest extends McpServerTest {
         @Tool
         ToolResponse query() {
             return ToolResponse.success("alpha_result");
+        }
+
+        @Tool
+        String analyze(AlphaItem item) {
+            return "alpha:" + item.label();
         }
 
         @Prompt
@@ -93,6 +128,11 @@ public class SameNameDifferentServersTest extends McpServerTest {
         @Tool
         ToolResponse query() {
             return ToolResponse.success("bravo_result");
+        }
+
+        @Tool
+        String analyze(BravoItem item) {
+            return "bravo:" + item.code();
         }
 
         @Prompt

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/ToolComplexArgumentTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/ToolComplexArgumentTest.java
@@ -49,6 +49,7 @@ public class ToolComplexArgumentTest extends McpServerTest {
         client.when()
                 .toolsList(page -> {
                     // Test processOrder tool with multiple complex types and references
+                    // A holder class is generated for non-simple types, so $defs land at the schema root
                     JsonObject schema = page.findByName("processOrder").inputSchema();
                     assertNotNull(schema, "Schema should not be null");
 
@@ -58,15 +59,12 @@ public class ToolComplexArgumentTest extends McpServerTest {
                     assertNotNull(properties.getJsonObject("billingAddress"));
                     assertNotNull(properties.getJsonObject("shippingAddress"));
 
-                    JsonObject customerProp = properties.getJsonObject("customer");
-                    JsonObject customerDefs = customerProp.getJsonObject("$defs");
-                    assertNotNull(customerDefs,
-                            "Nested $defs in customer property must be preserved (issue #539 fix)");
+                    // $defs should be at the root of the schema
+                    JsonObject defs = schema.getJsonObject("$defs");
+                    assertNotNull(defs, "$defs should be at the schema root");
 
-                    // Verify Address definition is in the nested $defs
-                    JsonObject addressDef = customerDefs.getJsonObject("Address");
-                    assertNotNull(addressDef,
-                            "Address type should be defined in customer's $defs");
+                    JsonObject addressDef = defs.getJsonObject("Address");
+                    assertNotNull(addressDef, "Address type should be defined in $defs");
                     assertEquals("object", addressDef.getString("type"));
 
                     JsonObject addressProps = addressDef.getJsonObject("properties");
@@ -75,7 +73,15 @@ public class ToolComplexArgumentTest extends McpServerTest {
                     assertNotNull(addressProps.getJsonObject("city"));
                     assertNotNull(addressProps.getJsonObject("zipCode"));
 
-                    JsonObject customerProps = customerProp.getJsonObject("properties");
+                    // customer property should reference the Customer definition
+                    JsonObject customerProp = properties.getJsonObject("customer");
+                    assertNotNull(customerProp);
+                    assertEquals("#/$defs/Customer", customerProp.getString("$ref"));
+
+                    // Customer definition should reference Address for defaultAddress
+                    JsonObject customerDef = defs.getJsonObject("Customer");
+                    assertNotNull(customerDef, "Customer type should be defined in $defs");
+                    JsonObject customerProps = customerDef.getJsonObject("properties");
                     assertNotNull(customerProps);
                     JsonObject defaultAddressProp = customerProps.getJsonObject("defaultAddress");
                     assertNotNull(defaultAddressProp);

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/ToolRecursiveArgumentTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/ToolRecursiveArgumentTest.java
@@ -1,0 +1,87 @@
+package io.quarkiverse.mcp.server.test.tools;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolArg;
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkiverse.mcp.server.test.McpAssured.McpStreamableTestClient;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.json.JsonObject;
+
+public class ToolRecursiveArgumentTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .withApplicationRoot(
+                    root -> root.addClasses(MyTools.class));
+
+    @Test
+    public void testRecursiveArgument() {
+        McpStreamableTestClient client = McpAssured.newConnectedStreamableClient();
+        client.when()
+                .toolsList(page -> {
+                    JsonObject schema = page.findByName("analyzeTree").inputSchema();
+                    assertNotNull(schema);
+
+                    // $defs must be at the schema root, not nested under properties.root
+                    JsonObject defs = schema.getJsonObject("$defs");
+                    assertNotNull(defs, "$defs should be at the schema root");
+
+                    JsonObject nodeDef = defs.getJsonObject("Node");
+                    assertNotNull(nodeDef, "Node type should be defined in $defs");
+                    JsonObject nodeProps = nodeDef.getJsonObject("properties");
+                    assertNotNull(nodeProps);
+                    assertNotNull(nodeProps.getJsonObject("name"));
+                    JsonObject childrenProp = nodeProps.getJsonObject("children");
+                    assertNotNull(childrenProp);
+                    assertEquals("array", childrenProp.getString("type"));
+                    // children items must $ref back to the root-level Node definition
+                    JsonObject items = childrenProp.getJsonObject("items");
+                    assertNotNull(items);
+                    assertEquals("#/$defs/Node", items.getString("$ref"));
+
+                    JsonObject properties = schema.getJsonObject("properties");
+                    assertNotNull(properties);
+
+                    JsonObject rootProp = properties.getJsonObject("root");
+                    assertNotNull(rootProp);
+                    assertEquals("#/$defs/Node", rootProp.getString("$ref"));
+                    assertNull(rootProp.getJsonObject("$defs"),
+                            "$defs should not be nested under properties.root");
+
+                    JsonObject verboseProp = properties.getJsonObject("verbose");
+                    assertNotNull(verboseProp);
+                    assertEquals("boolean", verboseProp.getString("type"));
+                })
+                .toolsCall("analyzeTree",
+                        Map.of("root", new Node("parent", List.of(new Node("child", List.of()))),
+                                "verbose", true),
+                        r -> {
+                            assertEquals("parent:1", r.firstContent().asText().text());
+                        })
+                .thenAssertResults();
+    }
+
+    public record Node(String name, List<Node> children) {
+    }
+
+    public static class MyTools {
+
+        @Tool
+        String analyzeTree(@ToolArg(description = "tree root") Node root,
+                @ToolArg(description = "verbose output") boolean verbose) {
+            return root.name() + ":" + root.children().size();
+        }
+    }
+
+}


### PR DESCRIPTION
- fix broken $ref pointers for recursive types used as @ToolArg parameters
- invert the holder generation logic: always generate a holder unless
 all arguments are simple types (primitives, wrappers, String, enums,
 or Optional of those)
- also unwrap Optional<T> to T in the holder field type to avoid victools
 generating nullable types
- resolves https://github.com/quarkiverse/quarkus-mcp-server/issues/919