### PR TITLE
core: generate holder class for non-simple tool argument types

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/McpServerProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/McpServerProcessor.java
@@ -765,6 +765,7 @@ class McpServerProcessor {
     void generateMetadata(McpServerRecorder recorder,
             RecorderContext recorderContext,
             BeanDiscoveryFinishedBuildItem beanDiscovery,
+            BeanArchiveIndexBuildItem beanArchiveIndex,
             List<FeatureMethodBuildItem> featureMethods,
             List<DefaultValueConverterBuildItem> defaultValueConverters,
             List<ServerNameBuildItem> serverNames,
@@ -915,7 +916,8 @@ class McpServerProcessor {
         MethodCreator toolArgumentHolders = metadataCreator.getMethodCreator("toolArgumentHolders", Map.class);
         ResultHandle holders = Gizmo.newHashMap(toolArgumentHolders);
         for (FeatureMethodBuildItem tool : featureMethods.stream().filter(FeatureMethodBuildItem::isTool).toList()) {
-            generateToolArgsHolder(toolArgumentHolders, holders, tool, classOutput, reflectiveClasses);
+            generateToolArgsHolder(toolArgumentHolders, holders, tool, classOutput, reflectiveClasses,
+                    beanArchiveIndex.getIndex());
         }
         toolArgumentHolders.returnValue(holders);
 
@@ -930,21 +932,43 @@ class McpServerProcessor {
 
     private static final char[] INVALID_JVM_FIELD_NAME_CHARS = { '.', ';', '[', '/' };
 
+    private static boolean isSimpleType(org.jboss.jandex.Type type, IndexView index) {
+        if (type.kind() == Kind.PRIMITIVE) {
+            return true;
+        }
+        if (PrimitiveType.isBox(type)) {
+            return true;
+        }
+        DotName name = type.name();
+        if (DotNames.STRING.equals(name)) {
+            return true;
+        }
+        if (DotNames.OPTIONAL.equals(name)) {
+            return isSimpleType(type.asParameterizedType().arguments().get(0), index);
+        }
+        ClassInfo classInfo = index.getClassByName(name);
+        return classInfo != null && classInfo.isEnum();
+    }
+
     private void generateToolArgsHolder(MethodCreator toolArgumentHolders, ResultHandle holders, FeatureMethodBuildItem tool,
-            ClassOutput classOutput, BuildProducer<ReflectiveClassBuildItem> reflectiveClasses) {
-        // Generate a holder for each tool with at least one argument that is:
-        // - serialized
-        // - annotated with any other annotation than @ToolArg and @P
+            ClassOutput classOutput, BuildProducer<ReflectiveClassBuildItem> reflectiveClasses, IndexView index) {
+        // Generate a holder for each tool with at least one serialized argument that either:
+        // - is annotated with any other annotation than @ToolArg and @P
+        // - has a non-simple type (i.e. not a primitive, wrapper, String, enum, or Optional of those)
         boolean generateHolder = false;
         List<MethodParameterInfo> serializedArguments = new ArrayList<>();
         for (MethodParameterInfo param : tool.getMethod().parameters()) {
             if (providerFrom(param.type()) == Provider.PARAMS) {
                 serializedArguments.add(param);
-                List<AnnotationInstance> annotations = param.declaredAnnotations();
-                if (!annotations.isEmpty()
-                        && annotations.stream().anyMatch(a -> !a.name().equals(DotNames.TOOL_ARG)
-                                && !a.name().equals(DotNames.LANGCHAIN4J_P))) {
-                    generateHolder = true;
+                if (!generateHolder) {
+                    List<AnnotationInstance> annotations = param.declaredAnnotations();
+                    if (!annotations.isEmpty()
+                            && annotations.stream().anyMatch(a -> !a.name().equals(DotNames.TOOL_ARG)
+                                    && !a.name().equals(DotNames.LANGCHAIN4J_P))) {
+                        generateHolder = true;
+                    } else if (!isSimpleType(param.type(), index)) {
+                        generateHolder = true;
+                    }
                 }
             }
         }
@@ -963,9 +987,13 @@ class McpServerProcessor {
             for (MethodParameterInfo param : serializedArguments) {
                 String fieldName = resolveEffectiveArgName(param, argAnnotationName);
                 validateFieldName(fieldName, param, tool);
-                FieldCreator paramField = argumentsHolder.getFieldCreator(fieldName, param.type().name().toString());
+                org.jboss.jandex.Type paramType = param.type();
+                if (DotNames.OPTIONAL.equals(paramType.name())) {
+                    paramType = paramType.asParameterizedType().arguments().get(0);
+                }
+                FieldCreator paramField = argumentsHolder.getFieldCreator(fieldName, paramType.name().toString());
                 paramField.setModifiers(Modifier.PUBLIC);
-                setSignature(paramField, param.type());
+                setSignature(paramField, paramType);
                 param.declaredAnnotations().forEach(paramField::addAnnotation);
             }
             argumentsHolder.close();

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/DefaultSchemaGenerator.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/DefaultSchemaGenerator.java
@@ -69,7 +69,7 @@ public class DefaultSchemaGenerator implements GlobalInputSchemaGenerator, Globa
             return new InputSchemaImpl(schema);
 
         } else {
-            // Fallback for individual primitives (no complex recursive types expected here)
+            // Fallback for simple types (primitives, wrappers, String, enums)
             JsonObject properties = new JsonObject();
             for (ToolArgument a : tool.arguments()) {
                 properties.put(a.name(), generateSchema(a.type(), a.description(), a.defaultValue()));

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/ToolComplexArgumentTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/ToolComplexArgumentTest.java
@@ -49,6 +49,7 @@ public class ToolComplexArgumentTest extends McpServerTest {
         client.when()
                 .toolsList(page -> {
                     // Test processOrder tool with multiple complex types and references
+                    // A holder class is generated for non-simple types, so $defs land at the schema root
                     JsonObject schema = page.findByName("processOrder").inputSchema();
                     assertNotNull(schema, "Schema should not be null");
 
@@ -58,15 +59,12 @@ public class ToolComplexArgumentTest extends McpServerTest {
                     assertNotNull(properties.getJsonObject("billingAddress"));
                     assertNotNull(properties.getJsonObject("shippingAddress"));
 
-                    JsonObject customerProp = properties.getJsonObject("customer");
-                    JsonObject customerDefs = customerProp.getJsonObject("$defs");
-                    assertNotNull(customerDefs,
-                            "Nested $defs in customer property must be preserved (issue #539 fix)");
+                    // $defs should be at the root of the schema
+                    JsonObject defs = schema.getJsonObject("$defs");
+                    assertNotNull(defs, "$defs should be at the schema root");
 
-                    // Verify Address definition is in the nested $defs
-                    JsonObject addressDef = customerDefs.getJsonObject("Address");
-                    assertNotNull(addressDef,
-                            "Address type should be defined in customer's $defs");
+                    JsonObject addressDef = defs.getJsonObject("Address");
+                    assertNotNull(addressDef, "Address type should be defined in $defs");
                     assertEquals("object", addressDef.getString("type"));
 
                     JsonObject addressProps = addressDef.getJsonObject("properties");
@@ -75,7 +73,15 @@ public class ToolComplexArgumentTest extends McpServerTest {
                     assertNotNull(addressProps.getJsonObject("city"));
                     assertNotNull(addressProps.getJsonObject("zipCode"));
 
-                    JsonObject customerProps = customerProp.getJsonObject("properties");
+                    // customer property should reference the Customer definition
+                    JsonObject customerProp = properties.getJsonObject("customer");
+                    assertNotNull(customerProp);
+                    assertEquals("#/$defs/Customer", customerProp.getString("$ref"));
+
+                    // Customer definition should reference Address for defaultAddress
+                    JsonObject customerDef = defs.getJsonObject("Customer");
+                    assertNotNull(customerDef, "Customer type should be defined in $defs");
+                    JsonObject customerProps = customerDef.getJsonObject("properties");
                     assertNotNull(customerProps);
                     JsonObject defaultAddressProp = customerProps.getJsonObject("defaultAddress");
                     assertNotNull(defaultAddressProp);

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/ToolRecursiveArgumentTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/ToolRecursiveArgumentTest.java
@@ -1,0 +1,87 @@
+package io.quarkiverse.mcp.server.test.tools;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolArg;
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkiverse.mcp.server.test.McpAssured.McpStreamableTestClient;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.json.JsonObject;
+
+public class ToolRecursiveArgumentTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .withApplicationRoot(
+                    root -> root.addClasses(MyTools.class));
+
+    @Test
+    public void testRecursiveArgument() {
+        McpStreamableTestClient client = McpAssured.newConnectedStreamableClient();
+        client.when()
+                .toolsList(page -> {
+                    JsonObject schema = page.findByName("analyzeTree").inputSchema();
+                    assertNotNull(schema);
+
+                    // $defs must be at the schema root, not nested under properties.root
+                    JsonObject defs = schema.getJsonObject("$defs");
+                    assertNotNull(defs, "$defs should be at the schema root");
+
+                    JsonObject nodeDef = defs.getJsonObject("Node");
+                    assertNotNull(nodeDef, "Node type should be defined in $defs");
+                    JsonObject nodeProps = nodeDef.getJsonObject("properties");
+                    assertNotNull(nodeProps);
+                    assertNotNull(nodeProps.getJsonObject("name"));
+                    JsonObject childrenProp = nodeProps.getJsonObject("children");
+                    assertNotNull(childrenProp);
+                    assertEquals("array", childrenProp.getString("type"));
+                    // children items must $ref back to the root-level Node definition
+                    JsonObject items = childrenProp.getJsonObject("items");
+                    assertNotNull(items);
+                    assertEquals("#/$defs/Node", items.getString("$ref"));
+
+                    JsonObject properties = schema.getJsonObject("properties");
+                    assertNotNull(properties);
+
+                    JsonObject rootProp = properties.getJsonObject("root");
+                    assertNotNull(rootProp);
+                    assertEquals("#/$defs/Node", rootProp.getString("$ref"));
+                    assertNull(rootProp.getJsonObject("$defs"),
+                            "$defs should not be nested under properties.root");
+
+                    JsonObject verboseProp = properties.getJsonObject("verbose");
+                    assertNotNull(verboseProp);
+                    assertEquals("boolean", verboseProp.getString("type"));
+                })
+                .toolsCall("analyzeTree",
+                        Map.of("root", new Node("parent", List.of(new Node("child", List.of()))),
+                                "verbose", true),
+                        r -> {
+                            assertEquals("parent:1", r.content().get(0).asText().text());
+                        })
+                .thenAssertResults();
+    }
+
+    public record Node(String name, List<Node> children) {
+    }
+
+    public static class MyTools {
+
+        @Tool
+        String analyzeTree(@ToolArg(description = "tree root") Node root,
+                @ToolArg(description = "verbose output") boolean verbose) {
+            return root.name() + ":" + root.children().size();
+        }
+    }
+
+}


### PR DESCRIPTION
- fix broken $ref pointers for recursive types used as @ToolArg parameters
- invert the holder generation logic: always generate a holder unless all arguments are simple types (primitives, wrappers, String, enums, or Optional of those)
- also unwrap Optional<T> to T in the holder field type to avoid victools generating nullable types
- resolves #919