### PR TITLE
core: include per-response serverInfo in _meta and add resultType to results

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/MetaKey.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/MetaKey.java
@@ -43,6 +43,11 @@ public record MetaKey(String prefix, String name, String key) {
     public static final MetaKey SUBSCRIPTION_ID = new MetaKey("io.modelcontextprotocol/", "subscriptionId");
 
     /**
+     * The {@code io.modelcontextprotocol/serverInfo} key.
+     */
+    public static final MetaKey SERVER_INFO = new MetaKey("io.modelcontextprotocol/", "serverInfo");
+
+    /**
      * Create a new key with the specified prefix and name.
      *
      * @param prefix the optional prefix (e.g. {@code "io.modelcontextprotocol/"})

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/ResponseServerInfo.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/ResponseServerInfo.java
@@ -1,0 +1,23 @@
+package io.quarkiverse.mcp.server;
+
+/**
+ * Controls inclusion of {@code io.modelcontextprotocol/serverInfo} in the {@code _meta}
+ * of every JSON-RPC result.
+ */
+public enum ResponseServerInfo {
+
+    /**
+     * Include only {@code name} and {@code version}.
+     */
+    LIGHT,
+
+    /**
+     * Include all available fields.
+     */
+    FULL,
+
+    /**
+     * Do not include server info in per-response {@code _meta}.
+     */
+    NONE
+}

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/CompletionMessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/CompletionMessageHandler.java
@@ -27,7 +27,7 @@ public abstract class CompletionMessageHandler extends MessageHandler {
     }
 
     Future<Void> complete(JsonObject message, Object id, JsonObject ref, JsonObject argument, Sender sender,
-            McpRequest mcpRequest) {
+            McpRequest mcpRequest, JsonObject responseMeta) {
         String referenceName = referenceName(ref);
         String argumentName = argument.getString("name");
         LOG.debugf("Complete %s for argument %s [id: %s]", referenceName, argumentName, id);
@@ -52,8 +52,9 @@ public abstract class CompletionMessageHandler extends MessageHandler {
                     completion.put("hasMore", completionResponse.hasMore());
                 }
                 result.put("completion", completion);
-                return sender.sendResult(id, result);
-            }, cause -> handleFailure(id, sender, mcpRequest, cause, LOG, "Unable to complete %s", referenceName));
+                return sender.sendResult(id, result, responseMeta);
+            }, cause -> handleFailure(id, sender, mcpRequest, cause, LOG, "Unable to complete %s", referenceName,
+                    responseMeta));
         } catch (McpException e) {
             return sender.sendError(id, e.getJsonRpcErrorCode(), e.getMessage());
         }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpMessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpMessageHandler.java
@@ -31,6 +31,7 @@ import io.quarkiverse.mcp.server.MetaKey;
 import io.quarkiverse.mcp.server.Notification.Type;
 import io.quarkiverse.mcp.server.NotificationManager;
 import io.quarkiverse.mcp.server.RequestId;
+import io.quarkiverse.mcp.server.ResponseServerInfo;
 import io.quarkiverse.mcp.server.runtime.FeatureManagerBase.FeatureExecutionContext;
 import io.quarkiverse.mcp.server.runtime.config.McpServerRuntimeConfig;
 import io.quarkiverse.mcp.server.runtime.config.McpServerRuntimeConfig.Icon;
@@ -90,6 +91,8 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
     private final McpRequestValidator mcpRequestValidator;
 
     private final CancellationRequests cancellationRequests;
+
+    private final ConcurrentHashMap<String, JsonObject> responseServerInfoCache = new ConcurrentHashMap<>();
 
     protected McpMessageHandler(McpServersRuntimeConfig config, ConnectionManager connectionManager,
             PromptManagerImpl promptManager,
@@ -412,17 +415,19 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
         }
         context.runOnContext(v -> {
             mcpRequest.contextStart();
+            JsonObject responseMeta = getResponseServerInfo(mcpRequest);
             Future<?> future = switch (method) {
-                case PROMPTS_LIST -> promptHandler.promptsList(message, mcpRequest);
-                case PROMPTS_GET -> promptHandler.promptsGet(message, mcpRequest);
-                case TOOLS_LIST -> toolHandler.toolsList(message, mcpRequest);
-                case TOOLS_CALL -> toolHandler.toolsCall(message, mcpRequest);
-                case RESOURCES_LIST -> resourceHandler.resourcesList(message, mcpRequest);
-                case RESOURCES_READ -> resourceHandler.resourcesRead(message, mcpRequest);
+                case PROMPTS_LIST -> promptHandler.promptsList(message, mcpRequest, responseMeta);
+                case PROMPTS_GET -> promptHandler.promptsGet(message, mcpRequest, responseMeta);
+                case TOOLS_LIST -> toolHandler.toolsList(message, mcpRequest, responseMeta);
+                case TOOLS_CALL -> toolHandler.toolsCall(message, mcpRequest, responseMeta);
+                case RESOURCES_LIST -> resourceHandler.resourcesList(message, mcpRequest, responseMeta);
+                case RESOURCES_READ -> resourceHandler.resourcesRead(message, mcpRequest, responseMeta);
                 case RESOURCES_SUBSCRIBE -> resourceHandler.resourcesSubscribe(message, mcpRequest);
                 case RESOURCES_UNSUBSCRIBE -> resourceHandler.resourcesUnsubscribe(message, mcpRequest);
-                case RESOURCE_TEMPLATES_LIST -> resourceTemplateHandler.resourceTemplatesList(message, mcpRequest);
-                case COMPLETION_COMPLETE -> complete(message, mcpRequest);
+                case RESOURCE_TEMPLATES_LIST ->
+                    resourceTemplateHandler.resourceTemplatesList(message, mcpRequest, responseMeta);
+                case COMPLETION_COMPLETE -> complete(message, mcpRequest, responseMeta);
                 case NOTIFICATIONS_ROOTS_LIST_CHANGED -> rootsListChanged(message, mcpRequest);
                 case NOTIFICATIONS_CANCELLED -> cancelRequest(message, mcpRequest);
                 case NOTIFICATIONS_INITIALIZED -> alreadyInitialized(mcpRequest);
@@ -546,13 +551,13 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
             } else {
                 mcpRequest.connection().setLogLevel(logLevel);
                 // Send empty result
-                return mcpRequest.sender().sendResult(id, new JsonObject());
+                return mcpRequest.sender().sendEmptyResult(id);
             }
         }
 
     }
 
-    private Future<Void> complete(JsonObject message, MCP_REQUEST mcpRequest) {
+    private Future<Void> complete(JsonObject message, MCP_REQUEST mcpRequest, JsonObject responseMeta) {
         Object id = Messages.getId(message);
         JsonObject params = Messages.getParams(message);
         JsonObject ref = params.getJsonObject("ref");
@@ -568,10 +573,11 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
                     return mcpRequest.sender().sendError(id, JsonRpcErrorCodes.INVALID_REQUEST, "Argument not found");
                 } else {
                     if (Messages.isPromptRef(referenceType)) {
-                        return promptCompleteHandler.complete(message, id, ref, argument, mcpRequest.sender(), mcpRequest);
+                        return promptCompleteHandler.complete(message, id, ref, argument, mcpRequest.sender(), mcpRequest,
+                                responseMeta);
                     } else if (Messages.isResourceRef(referenceType)) {
                         return resourceTemplateCompleteHandler.complete(message, id, ref, argument, mcpRequest.sender(),
-                                mcpRequest);
+                                mcpRequest, responseMeta);
                     } else {
                         return mcpRequest.sender().sendError(id, JsonRpcErrorCodes.INVALID_REQUEST,
                                 "Unsupported reference found: " + ref.getString("type"));
@@ -584,7 +590,7 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
     private Future<Void> ping(JsonObject message, MCP_REQUEST mcpRequest) {
         Object id = Messages.getId(message);
         LOG.debugf("Ping [id: %s]", id);
-        return mcpRequest.sender().sendResult(id, new JsonObject());
+        return mcpRequest.sender().sendEmptyResult(id);
     }
 
     private Future<Void> alreadyInitialized(MCP_REQUEST mcpRequest) {
@@ -852,7 +858,7 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
         return capabilities;
     }
 
-    private Object buildServerInfo(MCP_REQUEST mcpRequest) {
+    private Implementation resolveImplementation(MCP_REQUEST mcpRequest) {
         for (InitialResponseInfo info : initialResponseInfos) {
             Optional<Implementation> impl = info.implementation(mcpRequest.serverName());
             if (impl != null && impl.isPresent()) {
@@ -860,40 +866,91 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
             }
         }
         ServerInfo serverInfo = serverConfig(mcpRequest).serverInfo();
-        JsonObject impl = new JsonObject();
-        String serverName = serverInfo.name()
+        String name = serverInfo.name()
                 .orElse(ConfigProvider.getConfig().getOptionalValue("quarkus.application.name", String.class)
                         .orElse("N/A"));
-        impl.put("name", serverName);
-        impl.put("version", serverInfo.version()
+        String version = serverInfo.version()
                 .orElse(ConfigProvider.getConfig().getOptionalValue("quarkus.application.version", String.class)
-                        .orElse("N/A")));
-        impl.put("title", serverInfo.title().orElse(serverName));
-        if (serverInfo.description().isPresent()) {
-            impl.put("description", serverInfo.description().get());
+                        .orElse("N/A"));
+        List<io.quarkiverse.mcp.server.Icon> icons = new ArrayList<>();
+        for (Icon icon : serverInfo.icons()) {
+            icons.add(new io.quarkiverse.mcp.server.Icon(
+                    icon.src(),
+                    icon.mimeType().orElse(null),
+                    icon.sizes(),
+                    icon.theme().orElse(null)));
         }
-        if (serverInfo.websiteUrl().isPresent()) {
-            impl.put("websiteUrl", serverInfo.websiteUrl().get());
+        return new Implementation(name, version,
+                serverInfo.title().orElse(name),
+                icons,
+                serverInfo.description().orElse(null),
+                serverInfo.websiteUrl().map(Object::toString).orElse(null));
+    }
+
+    private JsonObject buildServerInfo(MCP_REQUEST mcpRequest) {
+        return implementationToJson(resolveImplementation(mcpRequest));
+    }
+
+    protected JsonObject getResponseServerInfo(MCP_REQUEST mcpRequest) {
+        ResponseServerInfo mode = serverConfig(mcpRequest).responseServerInfo();
+        if (mode == ResponseServerInfo.NONE) {
+            return null;
         }
-        if (!serverInfo.icons().isEmpty()) {
+        return responseServerInfoCache.computeIfAbsent(mcpRequest.serverName(),
+                new java.util.function.Function<String, JsonObject>() {
+                    @Override
+                    public JsonObject apply(String key) {
+                        return buildResponseServerInfo(mcpRequest, mode);
+                    }
+                });
+    }
+
+    private JsonObject buildResponseServerInfo(MCP_REQUEST mcpRequest, ResponseServerInfo mode) {
+        Implementation impl = resolveImplementation(mcpRequest);
+        JsonObject info;
+        if (mode == ResponseServerInfo.FULL) {
+            info = implementationToJson(impl);
+        } else {
+            info = new JsonObject();
+            info.put("name", impl.name());
+            info.put("version", impl.version());
+        }
+        JsonObject meta = new JsonObject();
+        meta.put(MetaKey.SERVER_INFO.toString(), info);
+        return meta;
+    }
+
+    private static JsonObject implementationToJson(Implementation impl) {
+        JsonObject info = new JsonObject();
+        info.put("name", impl.name());
+        info.put("version", impl.version());
+        if (impl.title() != null) {
+            info.put("title", impl.title());
+        }
+        if (impl.description() != null) {
+            info.put("description", impl.description());
+        }
+        if (impl.websiteUrl() != null) {
+            info.put("websiteUrl", impl.websiteUrl());
+        }
+        if (!impl.icons().isEmpty()) {
             JsonArray icons = new JsonArray();
-            for (Icon icon : serverInfo.icons()) {
-                JsonObject i = new JsonObject()
-                        .put("src", icon.src());
-                if (icon.mimeType().isPresent()) {
-                    i.put("mimeType", icon.mimeType().get());
+            for (io.quarkiverse.mcp.server.Icon icon : impl.icons()) {
+                JsonObject i = new JsonObject().put("src", icon.src());
+                if (icon.mimeType() != null) {
+                    i.put("mimeType", icon.mimeType());
                 }
-                if (icon.theme().isPresent()) {
-                    i.put("theme", icon.theme().get().toString().toLowerCase());
+                if (icon.theme() != null) {
+                    i.put("theme", icon.theme().toString().toLowerCase());
                 }
-                if (!icon.sizes().isEmpty()) {
+                if (icon.sizes() != null && !icon.sizes().isEmpty()) {
                     i.put("sizes", icon.sizes());
                 }
                 icons.add(i);
             }
-            impl.put("icons", icons);
+            info.put("icons", icons);
         }
-        return impl;
+        return info;
     }
 
     private Optional<String> buildInstructions(MCP_REQUEST mcpRequest) {

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/MessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/MessageHandler.java
@@ -27,7 +27,7 @@ public abstract class MessageHandler {
     private static final Logger LOG = Logger.getLogger(MessageHandler.class);
 
     protected Future<Void> handleFailure(Object requestId, Sender sender, McpRequest mcpRequest, Throwable cause,
-            Logger logger, String errorMessage, String featureId) {
+            Logger logger, String errorMessage, String featureId, JsonObject responseMeta) {
         if (cause instanceof InputRequiredException inputRequired) {
             JsonObject result = new JsonObject().put("resultType", "input_required");
             if (!inputRequired.inputRequests().isEmpty()) {
@@ -40,7 +40,7 @@ public abstract class MessageHandler {
             if (inputRequired.requestState() != null) {
                 result.put("requestState", inputRequired.requestState());
             }
-            return sender.sendResult(requestId, result);
+            return sender.sendResult(requestId, result, responseMeta);
         } else if (cause instanceof UrlElicitationRequiredException urlElicitation) {
             mcpRequest.setTracingErrorResponse(false, urlElicitation.getJsonRpcErrorCode(), urlElicitation.getMessage());
             JsonArray elicitations = new JsonArray();

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/PromptMessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/PromptMessageHandler.java
@@ -28,7 +28,7 @@ class PromptMessageHandler extends MessageHandler {
         this.config = config;
     }
 
-    Future<Void> promptsList(JsonObject message, McpRequest mcpRequest) {
+    Future<Void> promptsList(JsonObject message, McpRequest mcpRequest, JsonObject responseMeta) {
         Object id = Messages.getId(message);
         Cursor cursor = Messages.getCursor(message, mcpRequest.sender());
         if (cursor == null) {
@@ -54,10 +54,10 @@ class PromptMessageHandler extends MessageHandler {
             result.put("nextCursor", Cursor.encode(last.createdAt(), cursor.snapshotTimestamp()));
         }
         putCacheControl(result, serverConfig.prompts().ttlMs(), serverConfig.prompts().cacheScope());
-        return mcpRequest.sender().sendResult(id, result);
+        return mcpRequest.sender().sendResult(id, result, responseMeta);
     }
 
-    Future<Void> promptsGet(JsonObject message, McpRequest mcpRequest) {
+    Future<Void> promptsGet(JsonObject message, McpRequest mcpRequest, JsonObject responseMeta) {
         Object id = Messages.getId(message);
         JsonObject params = Messages.getParams(message);
         if (params == null) {
@@ -75,9 +75,9 @@ class PromptMessageHandler extends MessageHandler {
                     result.put("description", promptResponse.description());
                 }
                 result.put("messages", promptResponse.messages());
-                return mcpRequest.sender().sendResult(id, result);
+                return mcpRequest.sender().sendResult(id, result, responseMeta);
             }, cause -> handleFailure(id, mcpRequest.sender(), mcpRequest, cause, LOG,
-                    "Unable to obtain prompt %s", promptName));
+                    "Unable to obtain prompt %s", promptName, responseMeta));
         } catch (McpException e) {
             return mcpRequest.sender().sendError(id, e.getJsonRpcErrorCode(), e.getMessage());
         }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceMessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceMessageHandler.java
@@ -46,7 +46,7 @@ class ResourceMessageHandler extends MessageHandler {
             return mcpRequest.sender().sendError(id, e.getJsonRpcErrorCode(), e.getMessage());
         }
         // Send empty result
-        return mcpRequest.sender().sendResult(id, new JsonObject());
+        return mcpRequest.sender().sendEmptyResult(id);
     }
 
     Future<Void> resourcesUnsubscribe(JsonObject message, McpRequest mcpRequest) {
@@ -63,10 +63,10 @@ class ResourceMessageHandler extends MessageHandler {
             return mcpRequest.sender().sendError(id, e.getJsonRpcErrorCode(), e.getMessage());
         }
         // Send empty result
-        return mcpRequest.sender().sendResult(id, new JsonObject());
+        return mcpRequest.sender().sendEmptyResult(id);
     }
 
-    Future<Void> resourcesList(JsonObject message, McpRequest mcpRequest) {
+    Future<Void> resourcesList(JsonObject message, McpRequest mcpRequest, JsonObject responseMeta) {
         Object id = Messages.getId(message);
         Cursor cursor = Messages.getCursor(message, mcpRequest.sender());
         if (cursor == null) {
@@ -92,10 +92,10 @@ class ResourceMessageHandler extends MessageHandler {
             result.put("nextCursor", Cursor.encode(last.createdAt(), cursor.snapshotTimestamp()));
         }
         putCacheControl(result, serverConfig.resources().ttlMs(), serverConfig.resources().cacheScope());
-        return mcpRequest.sender().sendResult(id, result);
+        return mcpRequest.sender().sendResult(id, result, responseMeta);
     }
 
-    Future<Void> resourcesRead(JsonObject message, McpRequest mcpRequest) {
+    Future<Void> resourcesRead(JsonObject message, McpRequest mcpRequest, JsonObject responseMeta) {
         Object id = Messages.getId(message);
         JsonObject params = Messages.getParams(message);
         if (params == null) {
@@ -123,11 +123,11 @@ class ResourceMessageHandler extends MessageHandler {
                 } else {
                     ResourceResponse resolved = resolveResourceReadCacheControl(resourceResponse, resourceUri,
                             mcpRequest.serverName());
-                    return mcpRequest.sender().sendResult(id, resolved);
+                    return mcpRequest.sender().sendResult(id, JsonObject.mapFrom(resolved), responseMeta);
                 }
             },
                     cause -> handleFailure(id, mcpRequest.sender(), mcpRequest, cause, LOG,
-                            "Unable to read resource %s", resourceUri));
+                            "Unable to read resource %s", resourceUri, responseMeta));
         } catch (McpException e) {
             return mcpRequest.sender().sendError(id, e.getJsonRpcErrorCode(), e.getMessage());
         }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceTemplateMessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceTemplateMessageHandler.java
@@ -22,7 +22,7 @@ class ResourceTemplateMessageHandler extends MessageHandler {
         this.config = config;
     }
 
-    Future<Void> resourceTemplatesList(JsonObject message, McpRequest mcpRequest) {
+    Future<Void> resourceTemplatesList(JsonObject message, McpRequest mcpRequest, JsonObject responseMeta) {
         Object id = Messages.getId(message);
         Cursor cursor = Messages.getCursor(message, mcpRequest.sender());
         if (cursor == null) {
@@ -48,7 +48,7 @@ class ResourceTemplateMessageHandler extends MessageHandler {
             result.put("nextCursor", Cursor.encode(last.createdAt(), cursor.snapshotTimestamp()));
         }
         putCacheControl(result, serverConfig.resourceTemplates().ttlMs(), serverConfig.resourceTemplates().cacheScope());
-        return mcpRequest.sender().sendResult(id, result);
+        return mcpRequest.sender().sendResult(id, result, responseMeta);
     }
 
 }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/Sender.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/Sender.java
@@ -3,6 +3,8 @@ package io.quarkiverse.mcp.server.runtime;
 import static io.quarkiverse.mcp.server.runtime.Messages.newError;
 import static io.quarkiverse.mcp.server.runtime.Messages.newResult;
 
+import java.util.Map;
+
 import io.quarkiverse.mcp.server.JsonRpcErrorCodes;
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
@@ -11,8 +13,44 @@ public interface Sender {
 
     Future<Void> send(JsonObject message);
 
+    default Future<Void> sendEmptyResult(Object id) {
+        return send(newResult(id, new JsonObject()));
+    }
+
     default Future<Void> sendResult(Object id, Object result) {
-        return send(newResult(id, result));
+        return sendResult(id, result, null);
+    }
+
+    @SuppressWarnings("unchecked")
+    default Future<Void> sendResult(Object id, Object result, JsonObject responseServerInfoMeta) {
+        JsonObject message = newResult(id, result);
+        Object resultObj = message.getValue("result");
+        if (resultObj instanceof JsonObject resultJson) {
+            if (!resultJson.containsKey("resultType")) {
+                resultJson.put("resultType", "complete");
+            }
+            if (responseServerInfoMeta != null) {
+                JsonObject existingMeta = resultJson.getJsonObject("_meta");
+                if (existingMeta != null) {
+                    existingMeta.mergeIn(responseServerInfoMeta);
+                } else {
+                    resultJson.put("_meta", responseServerInfoMeta.copy());
+                }
+            }
+        } else if (resultObj instanceof Map resultMap) {
+            if (!resultMap.containsKey("resultType")) {
+                resultMap.put("resultType", "complete");
+            }
+            if (responseServerInfoMeta != null) {
+                Object existingMeta = resultMap.get("_meta");
+                if (existingMeta instanceof Map existingMetaMap) {
+                    existingMetaMap.putAll(responseServerInfoMeta.getMap());
+                } else {
+                    resultMap.put("_meta", responseServerInfoMeta.copy().getMap());
+                }
+            }
+        }
+        return send(message);
     }
 
     default Future<Void> sendError(Object id, int code, String message) {

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ToolMessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ToolMessageHandler.java
@@ -30,7 +30,7 @@ class ToolMessageHandler extends MessageHandler {
         this.config = config;
     }
 
-    Future<Void> toolsList(JsonObject message, McpRequest mcpRequest) {
+    Future<Void> toolsList(JsonObject message, McpRequest mcpRequest, JsonObject responseMeta) {
         Object id = Messages.getId(message);
         Cursor cursor = Messages.getCursor(message, mcpRequest.sender());
         if (cursor == null) {
@@ -63,10 +63,10 @@ class ToolMessageHandler extends MessageHandler {
             result.put("nextCursor", Cursor.encode(last.createdAt(), cursor.snapshotTimestamp()));
         }
         putCacheControl(result, serverConfig.tools().ttlMs(), serverConfig.tools().cacheScope());
-        return mcpRequest.sender().sendResult(id, result);
+        return mcpRequest.sender().sendResult(id, result, responseMeta);
     }
 
-    Future<Void> toolsCall(JsonObject message, McpRequest mcpRequest) {
+    Future<Void> toolsCall(JsonObject message, McpRequest mcpRequest, JsonObject responseMeta) {
         Object id = Messages.getId(message);
         JsonObject params = getParams(message);
         if (params == null) {
@@ -82,10 +82,10 @@ class ToolMessageHandler extends MessageHandler {
                 if (toolResponse.isError()) {
                     mcpRequest.setTracingErrorResponse(true, null, null);
                 }
-                return mcpRequest.sender().sendResult(id, toolResponse);
+                return mcpRequest.sender().sendResult(id, JsonObject.mapFrom(toolResponse), responseMeta);
             },
                     cause -> handleFailure(id, mcpRequest.sender(), mcpRequest, cause, LOG,
-                            "Unable to call tool %s", toolName));
+                            "Unable to call tool %s", toolName, responseMeta));
         } catch (McpException e) {
             return mcpRequest.sender().sendError(id, e.getJsonRpcErrorCode(), e.getMessage());
         }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/config/McpServerRuntimeConfig.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/config/McpServerRuntimeConfig.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 
 import io.quarkiverse.mcp.server.CacheScope;
 import io.quarkiverse.mcp.server.McpLog.LogLevel;
+import io.quarkiverse.mcp.server.ResponseServerInfo;
 import io.smallrye.config.WithDefault;
 import io.smallrye.config.WithName;
 
@@ -75,6 +76,15 @@ public interface McpServerRuntimeConfig {
      * Elicitation config.
      */
     Elicitation elicitation();
+
+    /**
+     * Controls inclusion of {@code io.modelcontextprotocol/serverInfo} in the {@code _meta} of every JSON-RPC result.
+     * <p>
+     * {@code LIGHT} includes only name and version. {@code FULL} includes all available server info fields. {@code NONE} opts
+     * out entirely.
+     */
+    @WithDefault("light")
+    ResponseServerInfo responseServerInfo();
 
     /**
      * Dev mode config.

--- a/docs/modules/ROOT/pages/includes/quarkus-mcp-server-core.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-mcp-server-core.adoc
@@ -1428,6 +1428,34 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-mcp-server-core_quarkus-mcp[icon:question-circle[title=More information about the Duration format]]
 |`+++10M+++`
 
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-response-server-info]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-response-server-info[`+++quarkus.mcp.server.response-server-info+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.response-server-info+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`+++quarkus.mcp.server."server-name".response-server-info+++`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server."server-name".response-server-info+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Controls inclusion of `io.modelcontextprotocol/serverInfo` in the `_meta` of every JSON-RPC result.
+
+`LIGHT` includes only name and version. `FULL` includes all available server info fields. `NONE` opts out entirely.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_RESPONSE_SERVER_INFO+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_RESPONSE_SERVER_INFO+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`light`, `full`, `none`
+|`+++light+++`
+
 a| [[quarkus-mcp-server-core_quarkus-mcp-server-dev-mode-dummy-init]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-dev-mode-dummy-init[`+++quarkus.mcp.server.dev-mode.dummy-init+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.mcp.server.dev-mode.dummy-init+++[]

--- a/docs/modules/ROOT/pages/includes/quarkus-mcp-server-core_quarkus.mcp.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-mcp-server-core_quarkus.mcp.adoc
@@ -1428,6 +1428,34 @@ endif::add-copy-button-to-env-var[]
 |link:https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/time/Duration.html[Duration] link:#duration-note-anchor-quarkus-mcp-server-core_quarkus-mcp[icon:question-circle[title=More information about the Duration format]]
 |`+++10M+++`
 
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-response-server-info]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-response-server-info[`+++quarkus.mcp.server.response-server-info+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.response-server-info+++[]
+endif::add-copy-button-to-config-props[]
+
+
+`+++quarkus.mcp.server."server-name".response-server-info+++`
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server."server-name".response-server-info+++[]
+endif::add-copy-button-to-config-props[]
+
+[.description]
+--
+Controls inclusion of `io.modelcontextprotocol/serverInfo` in the `_meta` of every JSON-RPC result.
+
+`LIGHT` includes only name and version. `FULL` includes all available server info fields. `NONE` opts out entirely.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_RESPONSE_SERVER_INFO+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_RESPONSE_SERVER_INFO+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`light`, `full`, `none`
+|`+++light+++`
+
 a| [[quarkus-mcp-server-core_quarkus-mcp-server-dev-mode-dummy-init]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-dev-mode-dummy-init[`+++quarkus.mcp.server.dev-mode.dummy-init+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.mcp.server.dev-mode.dummy-init+++[]

--- a/test/src/main/java/io/quarkiverse/mcp/server/test/McpTestClientBase.java
+++ b/test/src/main/java/io/quarkiverse/mcp/server/test/McpTestClientBase.java
@@ -2,7 +2,6 @@ package io.quarkiverse.mcp.server.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -1293,8 +1292,7 @@ abstract class McpTestClientBase<ASSERT extends McpAssert<ASSERT>, CLIENT extend
 
         @Override
         public void doAssert(JsonObject response) {
-            JsonObject result = assertResultResponse(request, response);
-            assertTrue(result.isEmpty());
+            assertResultResponse(request, response);
         }
 
     }

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/serverinfo/ResponseServerInfoFullTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/serverinfo/ResponseServerInfoFullTest.java
@@ -1,0 +1,93 @@
+package io.quarkiverse.mcp.server.test.serverinfo;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.MetaKey;
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkiverse.mcp.server.test.McpAssured.McpStreamableTestClient;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+public class ResponseServerInfoFullTest extends McpServerTest {
+
+    private static final String NAME = "FullServer";
+    private static final String VERSION = "3.0";
+    private static final String DESCRIPTION = "A full MCP server";
+    private static final String URL = "https://example.com";
+    private static final String ICON_URL = "https://example.com/icon.png";
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .withApplicationRoot(root -> root.addClass(MyTools.class))
+            .overrideConfigKey("quarkus.mcp.server.server-info.name", NAME)
+            .overrideConfigKey("quarkus.mcp.server.server-info.version", VERSION)
+            .overrideConfigKey("quarkus.mcp.server.server-info.description", DESCRIPTION)
+            .overrideConfigKey("quarkus.mcp.server.server-info.website-url", URL)
+            .overrideConfigKey("quarkus.mcp.server.server-info.icons[0].src", ICON_URL)
+            .overrideConfigKey("quarkus.mcp.server.server-info.icons[0].mime-type", "image/png")
+            .overrideConfigKey("quarkus.mcp.server.server-info.icons[0].theme", "dark")
+            .overrideConfigKey("quarkus.mcp.server.server-info.icons[0].sizes[0]", "48x48")
+            .overrideConfigKey("quarkus.mcp.server.response-server-info", "full");
+
+    @Test
+    public void testFullResponseServerInfo() {
+        McpStreamableTestClient client = McpAssured.newConnectedStreamableClient();
+        client.when()
+                // Verify tools/list response
+                .message(client.newRequest(McpAssured.TOOLS_LIST))
+                .withAssert(response -> {
+                    JsonObject result = response.getJsonObject("result");
+                    assertNotNull(result);
+                    assertEquals("complete", result.getString("resultType"));
+                    JsonObject meta = result.getJsonObject("_meta");
+                    assertNotNull(meta, "_meta must be present in the result");
+                    JsonObject serverInfo = meta.getJsonObject(MetaKey.SERVER_INFO.toString());
+                    assertNotNull(serverInfo, "serverInfo must be present in _meta");
+                    assertEquals(NAME, serverInfo.getString("name"));
+                    assertEquals(VERSION, serverInfo.getString("version"));
+                    assertEquals(NAME, serverInfo.getString("title"));
+                    assertEquals(DESCRIPTION, serverInfo.getString("description"));
+                    assertEquals(URL, serverInfo.getString("websiteUrl"));
+                    JsonArray icons = serverInfo.getJsonArray("icons");
+                    assertNotNull(icons, "FULL mode must include icons");
+                    assertEquals(1, icons.size());
+                    JsonObject icon = icons.getJsonObject(0);
+                    assertEquals(ICON_URL, icon.getString("src"));
+                    assertEquals("image/png", icon.getString("mimeType"));
+                    assertEquals("dark", icon.getString("theme"));
+                })
+                .send()
+                // Also verify tools/call includes the same fields
+                .toolsCall("alpha")
+                .withRawAssert(response -> {
+                    JsonObject result = response.getJsonObject("result");
+                    assertNotNull(result);
+                    assertEquals("complete", result.getString("resultType"));
+                    JsonObject meta = result.getJsonObject("_meta");
+                    assertNotNull(meta, "_meta must be present in tools/call result");
+                    JsonObject serverInfo = meta.getJsonObject(MetaKey.SERVER_INFO.toString());
+                    assertNotNull(serverInfo, "serverInfo must be present in _meta");
+                    assertEquals(NAME, serverInfo.getString("name"));
+                    assertEquals(VERSION, serverInfo.getString("version"));
+                    assertEquals(NAME, serverInfo.getString("title"));
+                    assertEquals(DESCRIPTION, serverInfo.getString("description"));
+                })
+                .send()
+                .thenAssertResults();
+    }
+
+    public static class MyTools {
+
+        @Tool
+        String alpha() {
+            return "ok";
+        }
+    }
+}

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/serverinfo/ResponseServerInfoNoneTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/serverinfo/ResponseServerInfoNoneTest.java
@@ -1,0 +1,58 @@
+package io.quarkiverse.mcp.server.test.serverinfo;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkiverse.mcp.server.test.McpAssured.McpStreamableTestClient;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.json.JsonObject;
+
+public class ResponseServerInfoNoneTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .withApplicationRoot(root -> root.addClass(MyTools.class))
+            .overrideConfigKey("quarkus.mcp.server.server-info.name", "NoneServer")
+            .overrideConfigKey("quarkus.mcp.server.server-info.version", "1.0")
+            .overrideConfigKey("quarkus.mcp.server.response-server-info", "none");
+
+    @Test
+    public void testNoneResponseServerInfo() {
+        McpStreamableTestClient client = McpAssured.newConnectedStreamableClient();
+        client.when()
+                // Verify tools/list response has no _meta serverInfo
+                .message(client.newRequest(McpAssured.TOOLS_LIST))
+                .withAssert(response -> {
+                    JsonObject result = response.getJsonObject("result");
+                    assertNotNull(result);
+                    assertEquals("complete", result.getString("resultType"));
+                    assertNull(result.getJsonObject("_meta"), "NONE mode must not include _meta");
+                })
+                .send()
+                // Also verify tools/call has no _meta serverInfo
+                .toolsCall("alpha")
+                .withRawAssert(response -> {
+                    JsonObject result = response.getJsonObject("result");
+                    assertNotNull(result);
+                    assertEquals("complete", result.getString("resultType"));
+                    assertNull(result.getJsonObject("_meta"), "NONE mode must not include _meta in tools/call");
+                })
+                .send()
+                .thenAssertResults();
+    }
+
+    public static class MyTools {
+
+        @Tool
+        String alpha() {
+            return "ok";
+        }
+    }
+}

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/serverinfo/ResponseServerInfoTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/serverinfo/ResponseServerInfoTest.java
@@ -1,0 +1,107 @@
+package io.quarkiverse.mcp.server.test.serverinfo;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.McpLog.LogLevel;
+import io.quarkiverse.mcp.server.McpMethod;
+import io.quarkiverse.mcp.server.MetaKey;
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkiverse.mcp.server.test.McpAssured.McpStreamableTestClient;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.json.JsonObject;
+
+public class ResponseServerInfoTest extends McpServerTest {
+
+    private static final String NAME = "TestServer";
+    private static final String VERSION = "2.0";
+    private static final String DESCRIPTION = "A test MCP server";
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .withApplicationRoot(root -> root.addClass(MyTools.class))
+            .overrideConfigKey("quarkus.mcp.server.server-info.name", NAME)
+            .overrideConfigKey("quarkus.mcp.server.server-info.version", VERSION)
+            .overrideConfigKey("quarkus.mcp.server.server-info.description", DESCRIPTION);
+
+    @Test
+    public void testLightResponseServerInfo() {
+        McpStreamableTestClient client = McpAssured.newConnectedStreamableClient();
+        client.when()
+                // Verify tools/list response
+                .message(client.newRequest(McpAssured.TOOLS_LIST))
+                .withAssert(response -> {
+                    JsonObject result = response.getJsonObject("result");
+                    assertNotNull(result);
+                    assertEquals("complete", result.getString("resultType"));
+                    JsonObject meta = result.getJsonObject("_meta");
+                    assertNotNull(meta, "_meta must be present in the result");
+                    JsonObject serverInfo = meta.getJsonObject(MetaKey.SERVER_INFO.toString());
+                    assertNotNull(serverInfo, "serverInfo must be present in _meta");
+                    assertEquals(NAME, serverInfo.getString("name"));
+                    assertEquals(VERSION, serverInfo.getString("version"));
+                    // LIGHT mode must not include title, description, websiteUrl, icons
+                    assertNull(serverInfo.getString("title"), "LIGHT mode must not include title");
+                    assertNull(serverInfo.getString("description"), "LIGHT mode must not include description");
+                    assertNull(serverInfo.getString("websiteUrl"), "LIGHT mode must not include websiteUrl");
+                    assertNull(serverInfo.getJsonArray("icons"), "LIGHT mode must not include icons");
+                })
+                .send()
+                // Also verify tools/call includes the same fields
+                .toolsCall("alpha")
+                .withRawAssert(response -> {
+                    JsonObject result = response.getJsonObject("result");
+                    assertNotNull(result);
+                    assertEquals("complete", result.getString("resultType"));
+                    JsonObject meta = result.getJsonObject("_meta");
+                    assertNotNull(meta, "_meta must be present in tools/call result");
+                    JsonObject serverInfo = meta.getJsonObject(MetaKey.SERVER_INFO.toString());
+                    assertNotNull(serverInfo, "serverInfo must be present in _meta");
+                    assertEquals(NAME, serverInfo.getString("name"));
+                    assertEquals(VERSION, serverInfo.getString("version"));
+                })
+                .send()
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testNoResultTypeForEmptyResults() {
+        McpStreamableTestClient client = McpAssured.newConnectedStreamableClient();
+        client.when()
+                // Verify ping response does not include resultType
+                .message(client.newRequest(McpAssured.PING))
+                .withAssert(response -> {
+                    JsonObject result = response.getJsonObject("result");
+                    assertNotNull(result);
+                    assertFalse(result.containsKey("resultType"),
+                            "ping result must not contain resultType");
+                })
+                .send()
+                // Verify logging/setLevel response does not include resultType
+                .message(client.newRequest(McpMethod.LOGGING_SET_LEVEL)
+                        .put("params", new JsonObject().put("level", LogLevel.INFO.toString().toLowerCase())))
+                .withAssert(response -> {
+                    JsonObject result = response.getJsonObject("result");
+                    assertNotNull(result);
+                    assertFalse(result.containsKey("resultType"),
+                            "logging/setLevel result must not contain resultType");
+                })
+                .send()
+                .thenAssertResults();
+    }
+
+    public static class MyTools {
+
+        @Tool
+        String alpha() {
+            return "ok";
+        }
+    }
+}

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/ToolsTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/ToolsTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.time.DayOfWeek;
 import java.util.Map;
-import java.util.Map.Entry;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -87,15 +86,15 @@ public class ToolsTest extends McpServerTest {
                     assertEquals("2025-08-26T08:40:00Z", t.annotations().lastModified());
                     assertEquals(0.5, t.annotations().priority());
                     // result _meta
-                    assertEquals(1, r._meta().size());
-                    Entry<MetaKey, Object> e = r._meta().entrySet().iterator().next();
-                    assertEquals("alpha-foo", e.getKey().toString());
-                    assertEquals(true, e.getValue());
+                    assertNotNull(r._meta());
+                    assertEquals(true, r._meta().get(MetaKey.from("alpha-foo")));
                 })
                 .toolsCall("uni_alpha", Map.of("uni_price", 1),
                         r -> {
                             assertEquals("Hello 1.0!", r.firstContent().asText().text());
-                            assertNull(r._meta());
+                            // response server info is injected by default (light mode)
+                            assertNotNull(r._meta());
+                            assertNotNull(r._meta().get(MetaKey.SERVER_INFO));
                         })
                 .toolsCall("bravo", Map.of("price", 1), r -> assertEquals("Hello 1!", r.firstContent().asText().text()))
                 .toolsCall("uni_bravo", Map.of("price", 1), r -> assertEquals("Hello 1!", r.firstContent().asText().text()))


### PR DESCRIPTION
- per the 2026-07-28 spec, include io.modelcontextprotocol/serverInfo in the _meta of every JSON-RPC result and add resultType: "complete" to successful responses
- a new ResponseServerInfo config enum (LIGHT/FULL/NONE) controls the level of detail; LIGHT (name + version only) is the default