### PR TITLE
core: add targeted notifyListChanged(Predicate<McpConnection>) to feature managers

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/PromptManager.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/PromptManager.java
@@ -2,6 +2,7 @@ package io.quarkiverse.mcp.server;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Predicate;
 
 import io.quarkiverse.mcp.server.PromptManager.PromptInfo;
 
@@ -59,6 +60,17 @@ public interface PromptManager extends FeatureManager<PromptInfo> {
      * @see #removePrompt(String, String)
      */
     PromptInfo removePrompt(String name);
+
+    /**
+     * Sends a {@code notifications/prompts/list_changed} notification to the connections that match the given filter.
+     * <p>
+     * Unlike {@link PromptDefinition#register()} and {@link #removePrompt(String)}, which broadcast to all connections,
+     * this method allows targeted notification delivery. This is useful when the effective prompt list changes for specific
+     * connections only, for example due to a {@link PromptFilter} state change.
+     *
+     * @param filter the predicate used to select connections to notify
+     */
+    void notifyListChanged(Predicate<McpConnection> filter);
 
     /**
      * Prompt info.

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/ResourceManager.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/ResourceManager.java
@@ -3,6 +3,7 @@ package io.quarkiverse.mcp.server;
 import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
+import java.util.function.Predicate;
 
 import io.quarkiverse.mcp.server.ResourceManager.ResourceInfo;
 
@@ -62,6 +63,17 @@ public interface ResourceManager extends FeatureManager<ResourceInfo> {
      * @see #removeResource(String, String)
      */
     ResourceInfo removeResource(String uri);
+
+    /**
+     * Sends a {@code notifications/resources/list_changed} notification to the connections that match the given filter.
+     * <p>
+     * Unlike {@link ResourceDefinition#register()} and {@link #removeResource(String)}, which broadcast to all connections,
+     * this method allows targeted notification delivery. This is useful when the effective resource list changes for specific
+     * connections only, for example due to a {@link ResourceFilter} state change.
+     *
+     * @param filter the predicate used to select connections to notify
+     */
+    void notifyListChanged(Predicate<McpConnection> filter);
 
     /**
      * Resource info.

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/ToolManager.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/ToolManager.java
@@ -4,6 +4,7 @@ import java.lang.reflect.Type;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 import io.quarkiverse.mcp.server.ToolManager.ToolInfo;
 
@@ -61,6 +62,17 @@ public interface ToolManager extends FeatureManager<ToolInfo> {
      * @see #removeTool(String, String)
      */
     ToolInfo removeTool(String name);
+
+    /**
+     * Sends a {@code notifications/tools/list_changed} notification to the connections that match the given filter.
+     * <p>
+     * Unlike {@link ToolDefinition#register()} and {@link #removeTool(String)}, which broadcast to all connections,
+     * this method allows targeted notification delivery. This is useful when the effective tool list changes for specific
+     * connections only, for example due to a {@link ToolFilter} state change.
+     *
+     * @param filter the predicate used to select connections to notify
+     */
+    void notifyListChanged(Predicate<McpConnection> filter);
 
     /**
      * Tool info.

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/FeatureManagerBase.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/FeatureManagerBase.java
@@ -24,6 +24,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 
 import jakarta.enterprise.inject.Instance;
@@ -381,9 +382,17 @@ public abstract class FeatureManagerBase<RESULT, INFO extends FeatureManager.Fea
     }
 
     protected void notifyConnections(McpMethod method) {
+        notifyConnections(method, null);
+    }
+
+    protected void notifyConnections(McpMethod method, Predicate<McpConnection> filter) {
+        Objects.requireNonNull(method);
         JsonObject notification = Messages.newNotification(method.jsonRpcName());
         for (McpConnectionBase c : connectionManager) {
             if (c.status() != McpConnection.Status.IN_OPERATION) {
+                continue;
+            }
+            if (filter != null && !filter.test(c)) {
                 continue;
             }
             if (c.supportsSubscriptionsListen()) {

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/PromptManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/PromptManagerImpl.java
@@ -5,11 +5,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -25,6 +27,7 @@ import io.quarkiverse.mcp.server.FilterContext;
 import io.quarkiverse.mcp.server.Icon;
 import io.quarkiverse.mcp.server.IconsProvider;
 import io.quarkiverse.mcp.server.JsonRpcErrorCodes;
+import io.quarkiverse.mcp.server.McpConnection;
 import io.quarkiverse.mcp.server.McpException;
 import io.quarkiverse.mcp.server.McpLog;
 import io.quarkiverse.mcp.server.McpMethod;
@@ -138,6 +141,11 @@ public class PromptManagerImpl extends FeatureManagerBase<PromptResponse, Prompt
             notifyConnections(McpMethod.NOTIFICATIONS_PROMPTS_LIST_CHANGED);
         }
         return removed.get();
+    }
+
+    @Override
+    public void notifyListChanged(Predicate<McpConnection> filter) {
+        notifyConnections(McpMethod.NOTIFICATIONS_PROMPTS_LIST_CHANGED, Objects.requireNonNull(filter));
     }
 
     IllegalArgumentException promptWithNameAlreadyExists(String name, String serverName) {

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceManagerImpl.java
@@ -13,6 +13,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -31,6 +32,7 @@ import io.quarkiverse.mcp.server.FilterContext;
 import io.quarkiverse.mcp.server.Icon;
 import io.quarkiverse.mcp.server.IconsProvider;
 import io.quarkiverse.mcp.server.JsonRpcErrorCodes;
+import io.quarkiverse.mcp.server.McpConnection;
 import io.quarkiverse.mcp.server.McpException;
 import io.quarkiverse.mcp.server.McpLog;
 import io.quarkiverse.mcp.server.McpMethod;
@@ -216,6 +218,11 @@ public class ResourceManagerImpl extends FeatureManagerBase<ResourceResponse, Re
             notifyConnections(McpMethod.NOTIFICATIONS_RESOURCES_LIST_CHANGED);
         }
         return removed.get();
+    }
+
+    @Override
+    public void notifyListChanged(Predicate<McpConnection> filter) {
+        notifyConnections(McpMethod.NOTIFICATIONS_RESOURCES_LIST_CHANGED, Objects.requireNonNull(filter));
     }
 
     @SuppressWarnings("unchecked")

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ToolManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ToolManagerImpl.java
@@ -15,6 +15,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
@@ -208,6 +209,11 @@ public class ToolManagerImpl extends FeatureManagerBase<ToolResponse, ToolInfo> 
             toolRemovedEvent.fire(new ToolRemoved(removedTool));
         }
         return removedTool;
+    }
+
+    @Override
+    public void notifyListChanged(Predicate<McpConnection> filter) {
+        notifyConnections(McpMethod.NOTIFICATIONS_TOOLS_LIST_CHANGED, Objects.requireNonNull(filter));
     }
 
     @SuppressWarnings("unchecked")

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -2,4 +2,4 @@
 
 :examples-dir: ./../examples/
 :spec-version: 2025-11-25
-:quarkus-version: 3.33.3
+:quarkus-version: 3.33.3.1

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/filter/PromptNotifyListChangedTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/filter/PromptNotifyListChangedTest.java
@@ -1,0 +1,143 @@
+package io.quarkiverse.mcp.server.test.filter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.McpConnection;
+import io.quarkiverse.mcp.server.Prompt;
+import io.quarkiverse.mcp.server.PromptFilter;
+import io.quarkiverse.mcp.server.PromptManager;
+import io.quarkiverse.mcp.server.PromptManager.PromptInfo;
+import io.quarkiverse.mcp.server.PromptMessage;
+import io.quarkiverse.mcp.server.PromptResponse;
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkiverse.mcp.server.test.McpAssured.McpStreamableTestClient;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.json.JsonObject;
+
+public class PromptNotifyListChangedTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .withApplicationRoot(
+                    root -> root.addClasses(MyPrompts.class, MyPromptFilter.class));
+
+    @Inject
+    PromptManager promptManager;
+
+    @Inject
+    MyPromptFilter myFilter;
+
+    @Test
+    public void testStateful() {
+        McpStreamableTestClient client1 = McpAssured.newStreamableClient()
+                .setOpenSubsidiarySse(true)
+                .build()
+                .connect();
+        McpStreamableTestClient client2 = McpAssured.newStreamableClient()
+                .setOpenSubsidiarySse(true)
+                .build()
+                .connect();
+
+        // Wait for the subsidiary SSE debug log notification
+        client1.waitForNotifications(1);
+        client2.waitForNotifications(1);
+
+        // Both clients see only "visible" initially
+        client1.when()
+                .promptsList(page -> {
+                    assertEquals(1, page.size());
+                    assertEquals("visible", page.prompts().get(0).name());
+                })
+                .thenAssertResults();
+
+        client2.when()
+                .promptsList(page -> {
+                    assertEquals(1, page.size());
+                    assertEquals("visible", page.prompts().get(0).name());
+                })
+                .thenAssertResults();
+
+        // Enable "hidden" for client1 only
+        myFilter.enabledConnections.add(client1.mcpSessionId());
+
+        // Notify only client1
+        promptManager.notifyListChanged(conn -> conn.id().equals(client1.mcpSessionId()));
+
+        // Client1 should receive the notification (2nd notification after the debug log)
+        List<JsonObject> notifications = client1.waitForNotifications(2).notifications();
+        assertEquals("notifications/prompts/list_changed", notifications.get(1).getString("method"));
+
+        // Client1 now sees both prompts
+        client1.when()
+                .promptsList(page -> assertEquals(2, page.size()))
+                .thenAssertResults();
+
+        // Client2 should still have only the initial debug log notification
+        assertEquals(1, client2.snapshot().notifications().size());
+
+        client1.disconnect();
+        client2.disconnect();
+    }
+
+    @Test
+    public void testStateless() {
+        McpStreamableTestClient client1 = McpAssured.newStreamableClient()
+                .setStateless()
+                .build()
+                .connect();
+
+        // Subscribe to prompts/list_changed
+        JsonObject listenRequest = client1.newRequest("subscriptions/listen");
+        listenRequest.put("params", new JsonObject()
+                .put("notifications", new JsonObject().put("promptsListChanged", true)));
+        McpAssured.injectStatelessMeta(listenRequest);
+        client1.sendAndForget(listenRequest);
+        client1.waitForNotifications(1); // acknowledged
+
+        // Notify all connections
+        promptManager.notifyListChanged(conn -> true);
+
+        List<JsonObject> notifications = client1.waitForNotifications(2).notifications();
+        assertEquals("notifications/prompts/list_changed", notifications.get(1).getString("method"));
+
+        client1.disconnect();
+    }
+
+    public static class MyPrompts {
+
+        @Prompt
+        PromptResponse hidden() {
+            return PromptResponse.withMessages(PromptMessage.withUserRole("hidden"));
+        }
+
+        @Prompt
+        PromptResponse visible() {
+            return PromptResponse.withMessages(PromptMessage.withUserRole("visible"));
+        }
+    }
+
+    @Singleton
+    public static class MyPromptFilter implements PromptFilter {
+
+        final Set<String> enabledConnections = ConcurrentHashMap.newKeySet();
+
+        @Override
+        public boolean test(PromptInfo prompt, McpConnection connection) {
+            if (prompt.name().equals("hidden")) {
+                return enabledConnections.contains(connection.id());
+            }
+            return true;
+        }
+    }
+}

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/filter/ResourceNotifyListChangedTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/filter/ResourceNotifyListChangedTest.java
@@ -1,0 +1,143 @@
+package io.quarkiverse.mcp.server.test.filter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.McpConnection;
+import io.quarkiverse.mcp.server.RequestUri;
+import io.quarkiverse.mcp.server.Resource;
+import io.quarkiverse.mcp.server.ResourceFilter;
+import io.quarkiverse.mcp.server.ResourceManager;
+import io.quarkiverse.mcp.server.ResourceManager.ResourceInfo;
+import io.quarkiverse.mcp.server.TextResourceContents;
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkiverse.mcp.server.test.McpAssured.McpStreamableTestClient;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.json.JsonObject;
+
+public class ResourceNotifyListChangedTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .withApplicationRoot(
+                    root -> root.addClasses(MyResources.class, MyResourceFilter.class));
+
+    @Inject
+    ResourceManager resourceManager;
+
+    @Inject
+    MyResourceFilter myFilter;
+
+    @Test
+    public void testStateful() {
+        McpStreamableTestClient client1 = McpAssured.newStreamableClient()
+                .setOpenSubsidiarySse(true)
+                .build()
+                .connect();
+        McpStreamableTestClient client2 = McpAssured.newStreamableClient()
+                .setOpenSubsidiarySse(true)
+                .build()
+                .connect();
+
+        // Wait for the subsidiary SSE debug log notification
+        client1.waitForNotifications(1);
+        client2.waitForNotifications(1);
+
+        // Both clients see only "open" initially
+        client1.when()
+                .resourcesList(page -> {
+                    assertEquals(1, page.size());
+                    assertEquals("open", page.resources().get(0).name());
+                })
+                .thenAssertResults();
+
+        client2.when()
+                .resourcesList(page -> {
+                    assertEquals(1, page.size());
+                    assertEquals("open", page.resources().get(0).name());
+                })
+                .thenAssertResults();
+
+        // Enable "restricted" for client1 only
+        myFilter.enabledConnections.add(client1.mcpSessionId());
+
+        // Notify only client1
+        resourceManager.notifyListChanged(conn -> conn.id().equals(client1.mcpSessionId()));
+
+        // Client1 should receive the notification (2nd notification after the debug log)
+        List<JsonObject> notifications = client1.waitForNotifications(2).notifications();
+        assertEquals("notifications/resources/list_changed", notifications.get(1).getString("method"));
+
+        // Client1 now sees both resources
+        client1.when()
+                .resourcesList(page -> assertEquals(2, page.size()))
+                .thenAssertResults();
+
+        // Client2 should still have only the initial debug log notification
+        assertEquals(1, client2.snapshot().notifications().size());
+
+        client1.disconnect();
+        client2.disconnect();
+    }
+
+    @Test
+    public void testStateless() {
+        McpStreamableTestClient client1 = McpAssured.newStreamableClient()
+                .setStateless()
+                .build()
+                .connect();
+
+        // Subscribe to resources/list_changed
+        JsonObject listenRequest = client1.newRequest("subscriptions/listen");
+        listenRequest.put("params", new JsonObject()
+                .put("notifications", new JsonObject().put("resourcesListChanged", true)));
+        McpAssured.injectStatelessMeta(listenRequest);
+        client1.sendAndForget(listenRequest);
+        client1.waitForNotifications(1); // acknowledged
+
+        // Notify all connections
+        resourceManager.notifyListChanged(conn -> true);
+
+        List<JsonObject> notifications = client1.waitForNotifications(2).notifications();
+        assertEquals("notifications/resources/list_changed", notifications.get(1).getString("method"));
+
+        client1.disconnect();
+    }
+
+    public static class MyResources {
+
+        @Resource(uri = "file:///restricted")
+        TextResourceContents restricted(RequestUri uri) {
+            return TextResourceContents.create(uri.value(), "restricted content");
+        }
+
+        @Resource(uri = "file:///open")
+        TextResourceContents open(RequestUri uri) {
+            return TextResourceContents.create(uri.value(), "open content");
+        }
+    }
+
+    @Singleton
+    public static class MyResourceFilter implements ResourceFilter {
+
+        final Set<String> enabledConnections = ConcurrentHashMap.newKeySet();
+
+        @Override
+        public boolean test(ResourceInfo resource, McpConnection connection) {
+            if (resource.name().equals("restricted")) {
+                return enabledConnections.contains(connection.id());
+            }
+            return true;
+        }
+    }
+}

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/filter/ToolNotifyListChangedTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/filter/ToolNotifyListChangedTest.java
@@ -1,0 +1,163 @@
+package io.quarkiverse.mcp.server.test.filter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+import jakarta.inject.Inject;
+import jakarta.inject.Singleton;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.McpConnection;
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolFilter;
+import io.quarkiverse.mcp.server.ToolManager;
+import io.quarkiverse.mcp.server.ToolManager.ToolInfo;
+import io.quarkiverse.mcp.server.ToolResponse;
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkiverse.mcp.server.test.McpAssured.McpStreamableTestClient;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.json.JsonObject;
+
+public class ToolNotifyListChangedTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .withApplicationRoot(
+                    root -> root.addClasses(MyTools.class, MyToolFilter.class));
+
+    @Inject
+    ToolManager toolManager;
+
+    @Inject
+    MyToolFilter myFilter;
+
+    @Test
+    public void testStateful() {
+        McpStreamableTestClient client1 = McpAssured.newStreamableClient()
+                .setOpenSubsidiarySse(true)
+                .build()
+                .connect();
+        McpStreamableTestClient client2 = McpAssured.newStreamableClient()
+                .setOpenSubsidiarySse(true)
+                .build()
+                .connect();
+
+        // Wait for the subsidiary SSE debug log notification
+        client1.waitForNotifications(1);
+        client2.waitForNotifications(1);
+
+        // Both clients see only "bravo" initially
+        client1.when()
+                .toolsList(page -> {
+                    assertEquals(1, page.size());
+                    assertEquals("bravo", page.tools().get(0).name());
+                })
+                .thenAssertResults();
+
+        client2.when()
+                .toolsList(page -> {
+                    assertEquals(1, page.size());
+                    assertEquals("bravo", page.tools().get(0).name());
+                })
+                .thenAssertResults();
+
+        // Enable "alpha" for client1 only
+        myFilter.enabledConnections.add(client1.mcpSessionId());
+
+        // Notify only client1
+        toolManager.notifyListChanged(conn -> conn.id().equals(client1.mcpSessionId()));
+
+        // Client1 should receive the notification (2nd notification after the debug log)
+        List<JsonObject> notifications = client1.waitForNotifications(2).notifications();
+        assertEquals("notifications/tools/list_changed", notifications.get(1).getString("method"));
+
+        // Client1 now sees both tools
+        client1.when()
+                .toolsList(page -> assertEquals(2, page.size()))
+                .thenAssertResults();
+
+        // Client2 should still have only the initial debug log notification
+        assertEquals(1, client2.snapshot().notifications().size());
+
+        client1.disconnect();
+        client2.disconnect();
+    }
+
+    @Test
+    public void testStateless() {
+        McpStreamableTestClient client1 = McpAssured.newStreamableClient()
+                .setStateless()
+                .build()
+                .connect();
+        McpStreamableTestClient client2 = McpAssured.newStreamableClient()
+                .setStateless()
+                .build()
+                .connect();
+
+        // Subscribe client1 to tools/list_changed
+        JsonObject listenRequest1 = client1.newRequest("subscriptions/listen");
+        listenRequest1.put("params", new JsonObject()
+                .put("notifications", new JsonObject().put("toolsListChanged", true)));
+        McpAssured.injectStatelessMeta(listenRequest1);
+        client1.sendAndForget(listenRequest1);
+        client1.waitForNotifications(1); // acknowledged
+
+        // Subscribe client2 to tools/list_changed
+        JsonObject listenRequest2 = client2.newRequest("subscriptions/listen");
+        listenRequest2.put("params", new JsonObject()
+                .put("notifications", new JsonObject().put("toolsListChanged", true)));
+        McpAssured.injectStatelessMeta(listenRequest2);
+        client2.sendAndForget(listenRequest2);
+        client2.waitForNotifications(1); // acknowledged
+
+        // Notify all connections — both should receive
+        toolManager.notifyListChanged(conn -> true);
+
+        List<JsonObject> notifications1 = client1.waitForNotifications(2).notifications();
+        assertEquals("notifications/tools/list_changed", notifications1.get(1).getString("method"));
+        // Verify subscriptionId is injected
+        JsonObject meta1 = notifications1.get(1).getJsonObject("params").getJsonObject("_meta");
+        assertNotNull(meta1);
+        assertNotNull(meta1.getValue("io.modelcontextprotocol/subscriptionId"));
+
+        List<JsonObject> notifications2 = client2.waitForNotifications(2).notifications();
+        assertEquals("notifications/tools/list_changed", notifications2.get(1).getString("method"));
+
+        client1.disconnect();
+        client2.disconnect();
+    }
+
+    public static class MyTools {
+
+        @Tool
+        ToolResponse alpha(String value) {
+            return ToolResponse.success(value);
+        }
+
+        @Tool
+        ToolResponse bravo(String value) {
+            return ToolResponse.success(value);
+        }
+    }
+
+    @Singleton
+    public static class MyToolFilter implements ToolFilter {
+
+        final Set<String> enabledConnections = ConcurrentHashMap.newKeySet();
+
+        @Override
+        public boolean test(ToolInfo tool, McpConnection connection) {
+            if (tool.name().equals("alpha")) {
+                return enabledConnections.contains(connection.id());
+            }
+            return true;
+        }
+    }
+}


### PR DESCRIPTION
- adds a way to send list_changed notifications to a subset of connections, selected by a predicate
- this is useful when the effective feature list changes for specific connections, e.g. due to a filter state change
- resolves #943