### PR TITLE
http: disable Micrometer at build time in deployment tests

### DIFF
--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -2,4 +2,4 @@
 
 :examples-dir: ./../examples/
 :spec-version: 2025-11-25
-:quarkus-version: 3.33.3
+:quarkus-version: 3.33.3.1

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/McpServerTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/McpServerTest.java
@@ -18,8 +18,9 @@ public abstract class McpServerTest {
 
     public static QuarkusUnitTest defaultConfig(int textLimit) {
         QuarkusUnitTest config = new QuarkusUnitTest();
-        // Disable OTel by default
+        // Disable OTel and Micrometer by default
         config.overrideConfigKey("quarkus.otel.enabled", "false");
+        config.overrideConfigKey("quarkus.micrometer.enabled", "false");
         // Enabled traffic logging if -DlogTraffic is used
         if (System.getProperty("logTraffic") != null) {
             config.overrideConfigKey("quarkus.mcp.server.traffic-logging.enabled", "true");

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/metrics/MetricsDisabledTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/metrics/MetricsDisabledTest.java
@@ -24,7 +24,8 @@ public class MetricsDisabledTest extends McpServerTest {
     @RegisterExtension
     static final QuarkusUnitTest test = defaultConfig()
             .withApplicationRoot(root -> root
-                    .addClasses(MyFeatures.class));
+                    .addClasses(MyFeatures.class))
+            .overrideConfigKey("quarkus.micrometer.enabled", "true");
 
     @Inject
     MeterRegistry registry;

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/metrics/MetricsTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/metrics/MetricsTest.java
@@ -39,6 +39,7 @@ public class MetricsTest extends McpServerTest {
     static final QuarkusUnitTest test = defaultConfig()
             .withApplicationRoot(root -> root
                     .addClasses(MyFeatures.class))
+            .overrideConfigKey("quarkus.micrometer.enabled", "true")
             .overrideConfigKey("quarkus.mcp.server.metrics.enabled", "true");
 
     @Inject


### PR DESCRIPTION
- only 2 of 217 test classes need Micrometer
- disable it via quarkus.micrometer.enabled=false in defaultConfig() to skip the build steps during augmentation for all other tests
- the two metrics tests explicitly re-enable it