### PR TITLE
core: emit required ttlMs/cacheScope cache-control fields for 2026-07-28

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/CacheControl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/CacheControl.java
@@ -4,17 +4,20 @@ package io.quarkiverse.mcp.server;
  * Caching hints for MCP results.
  * <p>
  * {@code ttlMs} is a freshness hint (in milliseconds) indicating how long clients may consider the result fresh before
- * re-fetching. If {@code 0}, the response should be considered immediately stale. If negative, the value is treated as unset.
+ * re-fetching. If {@code 0}, the response should be considered immediately stale. Must not be negative.
  * <p>
  * {@code cacheScope} controls whether shared intermediaries may cache the response.
  *
- * @param ttlMs time-to-live in milliseconds
+ * @param ttlMs time-to-live in milliseconds; must not be negative
  * @param cacheScope the cache scope
  * @see CacheScope
  */
 public record CacheControl(long ttlMs, CacheScope cacheScope) {
 
     public CacheControl {
+        if (ttlMs < 0) {
+            throw new IllegalArgumentException("ttlMs must not be negative");
+        }
         if (cacheScope == null) {
             throw new IllegalArgumentException("cacheScope must not be null");
         }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpMessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpMessageHandler.java
@@ -818,12 +818,8 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
             ret.put("instructions", instructions.get());
         }
         McpServerRuntimeConfig.Discover discover = serverConfig(mcpRequest).discover();
-        if (discover.ttlMs() >= 0) {
-            ret.put("ttlMs", discover.ttlMs());
-        }
-        if (discover.cacheScope().isPresent()) {
-            ret.put("cacheScope", discover.cacheScope().get().getName());
-        }
+        ret.put("ttlMs", discover.ttlMs());
+        ret.put("cacheScope", discover.cacheScope().getName());
         return mcpRequest.sender().sendResult(id, ret);
     }
 

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/MessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/MessageHandler.java
@@ -91,12 +91,27 @@ public abstract class MessageHandler {
         throw new IllegalArgumentException("Unknown input request entry type: " + entry.getClass());
     }
 
-    static void putCacheControl(JsonObject result, long ttlMs, Optional<CacheScope> cacheScope) {
+    /**
+     * Adds the {@code ttlMs} and {@code cacheScope} cache control fields to a {@code CacheableResult}.
+     * <p>
+     * Both fields are required as of protocol version {@code 2026-07-28}. When they are not
+     * explicitly configured and the negotiated protocol version requires them ({@code stateless}), spec-valid defaults
+     * are emitted: {@code ttlMs: 0} (immediately stale) and {@code cacheScope: public}. For earlier protocol versions
+     * the fields are omitted unless explicitly configured.
+     *
+     * @param stateless whether the negotiated protocol version requires the cache control fields (i.e.
+     *        {@code >= 2026-07-28})
+     */
+    static void putCacheControl(JsonObject result, long ttlMs, Optional<CacheScope> cacheScope, boolean stateless) {
         if (ttlMs >= 0) {
             result.put("ttlMs", ttlMs);
+        } else if (stateless) {
+            result.put("ttlMs", 0);
         }
         if (cacheScope.isPresent()) {
             result.put("cacheScope", cacheScope.get().getName());
+        } else if (stateless) {
+            result.put("cacheScope", CacheScope.PUBLIC.getName());
         }
     }
 }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/PromptMessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/PromptMessageHandler.java
@@ -53,7 +53,8 @@ class PromptMessageHandler extends MessageHandler {
             PromptManager.PromptInfo last = page.lastInfo();
             result.put("nextCursor", Cursor.encode(last.createdAt(), cursor.snapshotTimestamp()));
         }
-        putCacheControl(result, serverConfig.prompts().ttlMs(), serverConfig.prompts().cacheScope());
+        putCacheControl(result, serverConfig.prompts().ttlMs(), serverConfig.prompts().cacheScope(),
+                mcpRequest.protocolVersion().isStateless());
         return mcpRequest.sender().sendResult(id, result, responseMeta);
     }
 

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceMessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceMessageHandler.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import org.jboss.logging.Logger;
 
 import io.quarkiverse.mcp.server.CacheControl;
+import io.quarkiverse.mcp.server.CacheScope;
 import io.quarkiverse.mcp.server.JsonRpcErrorCodes;
 import io.quarkiverse.mcp.server.McpException;
 import io.quarkiverse.mcp.server.ResourceManager.ResourceInfo;
@@ -91,7 +92,8 @@ class ResourceMessageHandler extends MessageHandler {
             ResourceInfo last = page.lastInfo();
             result.put("nextCursor", Cursor.encode(last.createdAt(), cursor.snapshotTimestamp()));
         }
-        putCacheControl(result, serverConfig.resources().ttlMs(), serverConfig.resources().cacheScope());
+        putCacheControl(result, serverConfig.resources().ttlMs(), serverConfig.resources().cacheScope(),
+                mcpRequest.protocolVersion().isStateless());
         return mcpRequest.sender().sendResult(id, result, responseMeta);
     }
 
@@ -122,7 +124,7 @@ class ResourceMessageHandler extends MessageHandler {
                             "Resource not found: " + resourceUri);
                 } else {
                     ResourceResponse resolved = resolveResourceReadCacheControl(resourceResponse, resourceUri,
-                            mcpRequest.serverName());
+                            mcpRequest.serverName(), mcpRequest.protocolVersion().isStateless());
                     return mcpRequest.sender().sendResult(id, JsonObject.mapFrom(resolved), responseMeta);
                 }
             },
@@ -133,9 +135,9 @@ class ResourceMessageHandler extends MessageHandler {
         }
     }
 
-    // Precedence: ResourceResponse cache control > resource/template cache control
+    // Precedence: ResourceResponse cache control > resource/template cache control > protocol default
     private ResourceResponse resolveResourceReadCacheControl(ResourceResponse response, String resourceUri,
-            String serverName) {
+            String serverName, boolean stateless) {
         if (response.cacheControl() != null) {
             return response;
         }
@@ -151,6 +153,11 @@ class ResourceMessageHandler extends MessageHandler {
         }
         if (cc.isPresent()) {
             return new ResourceResponse(response.contents(), response._meta(), cc.get());
+        }
+        if (stateless) {
+            // ttlMs/cacheScope are required fields of ReadResourceResult as of protocol version 2026-07-28;
+            // default to a non-cacheable result (immediately stale, public) when nothing else is configured
+            return new ResourceResponse(response.contents(), response._meta(), new CacheControl(0, CacheScope.PUBLIC));
         }
         return response;
     }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceTemplateMessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceTemplateMessageHandler.java
@@ -47,7 +47,8 @@ class ResourceTemplateMessageHandler extends MessageHandler {
             ResourceTemplateManager.ResourceTemplateInfo last = page.lastInfo();
             result.put("nextCursor", Cursor.encode(last.createdAt(), cursor.snapshotTimestamp()));
         }
-        putCacheControl(result, serverConfig.resourceTemplates().ttlMs(), serverConfig.resourceTemplates().cacheScope());
+        putCacheControl(result, serverConfig.resourceTemplates().ttlMs(), serverConfig.resourceTemplates().cacheScope(),
+                mcpRequest.protocolVersion().isStateless());
         return mcpRequest.sender().sendResult(id, result, responseMeta);
     }
 

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ToolMessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ToolMessageHandler.java
@@ -62,7 +62,8 @@ class ToolMessageHandler extends MessageHandler {
             ToolManager.ToolInfo last = page.lastInfo();
             result.put("nextCursor", Cursor.encode(last.createdAt(), cursor.snapshotTimestamp()));
         }
-        putCacheControl(result, serverConfig.tools().ttlMs(), serverConfig.tools().cacheScope());
+        putCacheControl(result, serverConfig.tools().ttlMs(), serverConfig.tools().cacheScope(),
+                mcpRequest.protocolVersion().isStateless());
         return mcpRequest.sender().sendResult(id, result, responseMeta);
     }
 

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/config/McpServerRuntimeConfig.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/config/McpServerRuntimeConfig.java
@@ -382,16 +382,23 @@ public interface McpServerRuntimeConfig {
 
         /**
          * The time-to-live in milliseconds for the {@code server/discover} result. Clients may consider the result fresh for
-         * this duration. A value of {@code 0} means immediately stale. A negative value (default) means the field is not
-         * included in the response.
+         * this duration. A value of {@code 0} (default) means immediately stale.
+         * <p>
+         * {@code ttlMs} is a required field of {@code DiscoverResult}, which is why it defaults to {@code 0} and is always
+         * included; {@code server/discover} was introduced in protocol version {@code 2026-07-28} where the field is mandatory.
          */
-        @WithDefault("-1")
+        @WithDefault("0")
         long ttlMs();
 
         /**
-         * The cache scope for the {@code server/discover} result. If not set, the field is not included in the response.
+         * The cache scope for the {@code server/discover} result.
+         * <p>
+         * {@code cacheScope} is a required field of {@code DiscoverResult}, which is why it defaults to {@code public} and is
+         * always included; {@code server/discover} was introduced in protocol version {@code 2026-07-28} where the field is
+         * mandatory.
          */
-        Optional<CacheScope> cacheScope();
+        @WithDefault("PUBLIC")
+        CacheScope cacheScope();
 
     }
 

--- a/core/runtime/src/test/java/io/quarkiverse/mcp/server/runtime/CacheControlTest.java
+++ b/core/runtime/src/test/java/io/quarkiverse/mcp/server/runtime/CacheControlTest.java
@@ -16,10 +16,21 @@ public class CacheControlTest {
     }
 
     @Test
+    public void testTtlMsNotNegative() {
+        assertThrows(IllegalArgumentException.class, () -> new CacheControl(-1, CacheScope.PUBLIC));
+    }
+
+    @Test
     public void testValidCacheControl() {
         CacheControl cc = new CacheControl(5000, CacheScope.PUBLIC);
         assertEquals(5000, cc.ttlMs());
         assertEquals(CacheScope.PUBLIC, cc.cacheScope());
+    }
+
+    @Test
+    public void testZeroTtlMsIsValid() {
+        CacheControl cc = new CacheControl(0, CacheScope.PUBLIC);
+        assertEquals(0, cc.ttlMs());
     }
 
 }

--- a/docs/modules/ROOT/pages/concepts-mcp-protocol.adoc
+++ b/docs/modules/ROOT/pages/concepts-mcp-protocol.adoc
@@ -206,7 +206,9 @@ The server responds with its supported versions, capabilities, and server info:
     "serverInfo": {
       "name": "acme-quarkus-server",
       "version": "1.0.0"
-    }
+    },
+    "ttlMs": 0,
+    "cacheScope": "public"
   }
 }
 ----
@@ -214,7 +216,8 @@ The server responds with its supported versions, capabilities, and server info:
 No `initialized` notification is sent. Each subsequent request is self-contained.
 See xref:concepts-transports.adoc#_stateless_mode[Stateless Mode] for details on required headers and `_meta` fields.
 
-The `server/discover` result can include optional caching hints, configured via application properties:
+The `server/discover` result carries caching hints (`ttlMs` and `cacheScope`), which are required fields of this result.
+They default to `ttlMs = 0` (immediately stale) and `cacheScope = public`, and can be configured via application properties:
 
 [source,properties]
 ----

--- a/docs/modules/ROOT/pages/guides-implementing-resources.adoc
+++ b/docs/modules/ROOT/pages/guides-implementing-resources.adoc
@@ -224,8 +224,18 @@ BlobResourceContents largeFile(McpLog log, Progress progress) throws Exception {
 
 == Cache Control
 
-MCP supports optional caching hints (`ttlMs` and `cacheScope`) in results, allowing clients to reuse responses without re-fetching.
+MCP supports caching hints (`ttlMs` and `cacheScope`) in results, allowing clients to reuse responses without re-fetching.
 Cache control can be applied to `resources/list`, `resources/templates/list`, and `resources/read` results.
+
+`ttlMs` is a freshness hint in milliseconds; `0` means the result should be considered immediately stale, and the value must not be negative.
+`cacheScope` controls whether shared intermediaries may cache the response — `PUBLIC` (any cache) or `PRIVATE` (same authorization context only).
+
+[NOTE]
+====
+As of protocol version `2026-07-28`, `ttlMs` and `cacheScope` are *required* fields of these results.
+When no cache control is configured (via annotation, programmatically, or application properties), the server emits spec-valid defaults — `ttlMs = 0` (immediately stale) and `cacheScope = public` — for clients that negotiated `2026-07-28` or later.
+For earlier protocol versions, where the fields are not part of the schema, they are omitted unless explicitly configured.
+====
 
 === List Results
 
@@ -262,9 +272,6 @@ public class MyResources {
     }
 }
 ----
-
-`ttlMs` is a freshness hint in milliseconds.
-`cacheScope` controls whether shared intermediaries may cache the response — `PUBLIC` (any cache) or `PRIVATE` (same authorization context only).
 
 ==== Programmatic
 

--- a/docs/modules/ROOT/pages/includes/attributes.adoc
+++ b/docs/modules/ROOT/pages/includes/attributes.adoc
@@ -2,4 +2,4 @@
 
 :examples-dir: ./../examples/
 :spec-version: 2025-11-25
-:quarkus-version: 3.33.3
+:quarkus-version: 3.33.3.1

--- a/docs/modules/ROOT/pages/includes/quarkus-mcp-server-core.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-mcp-server-core.adoc
@@ -1285,7 +1285,9 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-The time-to-live in milliseconds for the `server/discover` result. Clients may consider the result fresh for this duration. A value of `0` means immediately stale. A negative value (default) means the field is not included in the response.
+The time-to-live in milliseconds for the `server/discover` result. Clients may consider the result fresh for this duration. A value of `0` (default) means immediately stale.
+
+`ttlMs` is a required field of `DiscoverResult`, which is why it defaults to `0` and is always included; `server/discover` was introduced in protocol version `2026-07-28` where the field is mandatory.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -1296,7 +1298,7 @@ Environment variable: `+++QUARKUS_MCP_SERVER_DISCOVER_TTL_MS+++`
 endif::add-copy-button-to-env-var[]
 --
 |long
-|`+++-1+++`
+|`+++0+++`
 
 a| [[quarkus-mcp-server-core_quarkus-mcp-server-discover-cache-scope]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-discover-cache-scope[`+++quarkus.mcp.server.discover.cache-scope+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -1311,7 +1313,9 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-The cache scope for the `server/discover` result. If not set, the field is not included in the response.
+The cache scope for the `server/discover` result.
+
+`cacheScope` is a required field of `DiscoverResult`, which is why it defaults to `public` and is always included; `server/discover` was introduced in protocol version `2026-07-28` where the field is mandatory.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -1322,7 +1326,7 @@ Environment variable: `+++QUARKUS_MCP_SERVER_DISCOVER_CACHE_SCOPE+++`
 endif::add-copy-button-to-env-var[]
 --
 a|`public`, `private`
-|
+|`+++public+++`
 
 a| [[quarkus-mcp-server-core_quarkus-mcp-server-sampling-default-timeout]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-sampling-default-timeout[`+++quarkus.mcp.server.sampling.default-timeout+++`]##
 ifdef::add-copy-button-to-config-props[]

--- a/docs/modules/ROOT/pages/includes/quarkus-mcp-server-core_quarkus.mcp.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-mcp-server-core_quarkus.mcp.adoc
@@ -1285,7 +1285,9 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-The time-to-live in milliseconds for the `server/discover` result. Clients may consider the result fresh for this duration. A value of `0` means immediately stale. A negative value (default) means the field is not included in the response.
+The time-to-live in milliseconds for the `server/discover` result. Clients may consider the result fresh for this duration. A value of `0` (default) means immediately stale.
+
+`ttlMs` is a required field of `DiscoverResult`, which is why it defaults to `0` and is always included; `server/discover` was introduced in protocol version `2026-07-28` where the field is mandatory.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -1296,7 +1298,7 @@ Environment variable: `+++QUARKUS_MCP_SERVER_DISCOVER_TTL_MS+++`
 endif::add-copy-button-to-env-var[]
 --
 |long
-|`+++-1+++`
+|`+++0+++`
 
 a| [[quarkus-mcp-server-core_quarkus-mcp-server-discover-cache-scope]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-discover-cache-scope[`+++quarkus.mcp.server.discover.cache-scope+++`]##
 ifdef::add-copy-button-to-config-props[]
@@ -1311,7 +1313,9 @@ endif::add-copy-button-to-config-props[]
 
 [.description]
 --
-The cache scope for the `server/discover` result. If not set, the field is not included in the response.
+The cache scope for the `server/discover` result.
+
+`cacheScope` is a required field of `DiscoverResult`, which is why it defaults to `public` and is always included; `server/discover` was introduced in protocol version `2026-07-28` where the field is mandatory.
 
 
 ifdef::add-copy-button-to-env-var[]
@@ -1322,7 +1326,7 @@ Environment variable: `+++QUARKUS_MCP_SERVER_DISCOVER_CACHE_SCOPE+++`
 endif::add-copy-button-to-env-var[]
 --
 a|`public`, `private`
-|
+|`+++public+++`
 
 a| [[quarkus-mcp-server-core_quarkus-mcp-server-sampling-default-timeout]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-sampling-default-timeout[`+++quarkus.mcp.server.sampling.default-timeout+++`]##
 ifdef::add-copy-button-to-config-props[]

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/cachecontrol/CacheControlTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/cachecontrol/CacheControlTest.java
@@ -91,6 +91,7 @@ public class CacheControlTest extends McpServerTest {
 
     @Test
     public void testResourceReadNoAnnotationNoCacheControl() {
+        // Default client negotiates 2025-11-25 (stateful), where ttlMs/cacheScope are not part of the schema
         McpStreamableTestClient client = McpAssured.newConnectedStreamableClient();
         client.when()
                 // bravo has no @CacheControl and no programmatic override - no cache control in response
@@ -99,6 +100,33 @@ public class CacheControlTest extends McpServerTest {
                     assertNull(r.cacheControl());
                 })
                 .thenAssertResults();
+    }
+
+    @Test
+    public void testResourceReadDefaultCacheControlStateless() {
+        // Under a negotiated 2026-07-28 (stateless) session, ttlMs/cacheScope are required
+        // fields of ReadResourceResult, so a resource without any configured cache control must still emit spec-valid
+        // defaults (immediately stale, public) instead of omitting the fields.
+        McpStreamableTestClient client = McpAssured.newStreamableClient()
+                .setStateless()
+                .build()
+                .connect();
+        client.when()
+                // bravo has no @CacheControl and no programmatic override - defaults are emitted
+                .resourcesRead("file:///cc/bravo", r -> {
+                    assertEquals("bravo", r.contents().get(0).asText().text());
+                    assertNotNull(r.cacheControl());
+                    assertEquals(0L, r.cacheControl().ttlMs());
+                    assertEquals(CacheScope.PUBLIC, r.cacheControl().cacheScope());
+                })
+                // alpha has an explicit @CacheControl which must still take precedence over the default
+                .resourcesRead("file:///cc/alpha", r -> {
+                    assertEquals("alpha", r.contents().get(0).asText().text());
+                    assertEquals(5000L, r.cacheControl().ttlMs());
+                    assertEquals(CacheScope.PRIVATE, r.cacheControl().cacheScope());
+                })
+                .thenAssertResults();
+        client.disconnect();
     }
 
     @Test

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/cachecontrol/DefaultCacheControlTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/cachecontrol/DefaultCacheControlTest.java
@@ -1,0 +1,128 @@
+package io.quarkiverse.mcp.server.test.cachecontrol;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.CacheControl;
+import io.quarkiverse.mcp.server.CacheScope;
+import io.quarkiverse.mcp.server.Prompt;
+import io.quarkiverse.mcp.server.PromptMessage;
+import io.quarkiverse.mcp.server.PromptResponse;
+import io.quarkiverse.mcp.server.RequestUri;
+import io.quarkiverse.mcp.server.Resource;
+import io.quarkiverse.mcp.server.ResourceResponse;
+import io.quarkiverse.mcp.server.ResourceTemplate;
+import io.quarkiverse.mcp.server.Role;
+import io.quarkiverse.mcp.server.TextContent;
+import io.quarkiverse.mcp.server.TextResourceContents;
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkiverse.mcp.server.test.McpAssured.McpStreamableTestClient;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+
+/**
+ * Without any configured cache control, the {@code CacheableResult} fields are omitted for
+ * pre-2026-07-28 protocol versions but emitted with spec-valid defaults (immediately stale, public) as of 2026-07-28,
+ * where they are required.
+ */
+public class DefaultCacheControlTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .withApplicationRoot(root -> root.addClasses(Features.class));
+
+    @Test
+    public void testListsDefaultStateful() {
+        // Default client negotiates 2025-11-25 (stateful) - fields are not part of the schema and must be omitted
+        McpStreamableTestClient client = McpAssured.newConnectedStreamableClient();
+        client.when()
+                .toolsList(p -> assertNull(p.cacheControl()))
+                .promptsList(p -> assertNull(p.cacheControl()))
+                .resourcesList(p -> assertNull(p.cacheControl()))
+                .resourcesTemplatesList(p -> assertNull(p.cacheControl()))
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testListsDefaultStateless() {
+        // Stateless client negotiates 2026-07-28 - fields are required and default to (0, public)
+        McpStreamableTestClient client = McpAssured.newStreamableClient()
+                .setStateless()
+                .build()
+                .connect();
+        client.when()
+                .toolsList(p -> assertDefault(p.cacheControl()))
+                .promptsList(p -> assertDefault(p.cacheControl()))
+                .resourcesList(p -> assertDefault(p.cacheControl()))
+                .resourcesTemplatesList(p -> assertDefault(p.cacheControl()))
+                .thenAssertResults();
+        client.disconnect();
+    }
+
+    @Test
+    public void testResourceReadDefaultStateless() {
+        McpStreamableTestClient client = McpAssured.newStreamableClient()
+                .setStateless()
+                .build()
+                .connect();
+        client.when()
+                .resourcesRead("file:///default/res", r -> {
+                    assertEquals("res", r.contents().get(0).asText().text());
+                    assertDefault(r.cacheControl());
+                })
+                .resourcesRead("file:///default/tmpl/1", r -> {
+                    assertEquals("tmpl-1", r.contents().get(0).asText().text());
+                    assertDefault(r.cacheControl());
+                })
+                .thenAssertResults();
+        client.disconnect();
+    }
+
+    @Test
+    public void testDiscoverDefaultCacheControl() {
+        McpAssured.newStreamableClient()
+                .setStateless()
+                .build()
+                .connect(initResult -> {
+                    // server/discover is a 2026-07-28+ method - ttlMs/cacheScope default to (0, public)
+                    assertDefault(initResult.cacheControl());
+                })
+                .disconnect();
+    }
+
+    private static void assertDefault(CacheControl cacheControl) {
+        assertNotNull(cacheControl);
+        assertEquals(0L, cacheControl.ttlMs());
+        assertEquals(CacheScope.PUBLIC, cacheControl.cacheScope());
+    }
+
+    public static class Features {
+
+        @Resource(uri = "file:///default/res")
+        ResourceResponse res(RequestUri uri) {
+            return new ResourceResponse(List.of(new TextResourceContents(uri.value(), "res", null)));
+        }
+
+        @ResourceTemplate(uriTemplate = "file:///default/tmpl/{id}")
+        TextResourceContents tmpl(String id, RequestUri uri) {
+            return new TextResourceContents(uri.value(), "tmpl-" + id, null);
+        }
+
+        @Tool
+        String echo(String message) {
+            return message;
+        }
+
+        @Prompt
+        PromptResponse prompt() {
+            return new PromptResponse("default", List.of(new PromptMessage(Role.USER, new TextContent("hi"))));
+        }
+    }
+}


### PR DESCRIPTION
- these fields are required on every CacheableResult as of 2026-07-28, but null cacheControl is serialized as absent, so hosts that validate the schema rejected the results
- emit spec-valid defaults (ttlMs=0, cacheScope=public) when unset, but only for negotiated versions >= 2026-07-28
- also reject negative ttlMs to match the spec minimum
- fixes #948