### PR TITLE
fix: Add default message to OperationCancellationException

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/Cancellation.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/Cancellation.java
@@ -68,6 +68,10 @@ public interface Cancellation {
 
         private static final long serialVersionUID = 1L;
 
+        public OperationCancellationException() {
+            super("Operation cancelled");
+        }
+
     }
 
 }

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/cancel/CancellationTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/cancel/CancellationTest.java
@@ -57,6 +57,30 @@ public class CancellationTest extends McpServerTest {
                 .thenAssertResults();
     }
 
+    @Test
+    public void testCancellationErrorMessage() throws InterruptedException {
+        McpStreamableTestClient client = McpAssured.newConnectedStreamableClient();
+        MyTools.CANCELLED.set(false);
+        MyTools.CANCEL_REASON.set(null);
+
+        JsonObject request = client.newRequest("tools/call")
+                .put("params", new JsonObject()
+                        .put("name", "alpha"));
+        client.sendAndForget(request);
+
+        assertTrue(MyTools.ALPHA_LATCH.await(5, TimeUnit.SECONDS));
+
+        JsonObject notification = client.newMessage("notifications/cancelled").put("params",
+                new JsonObject()
+                        .put("requestId", request.getValue("id"))
+                        .put("reason", "Test cancellation"));
+
+        client.sendAndForget(notification);
+        Awaitility.await().until(() -> MyTools.CANCELLED.get());
+
+        assertTrue(MyTools.CANCELLED.get(), "Tool should have been cancelled");
+    }
+
     private void assertCancellationMultipleActions() throws InterruptedException {
         McpStreamableTestClient client = McpAssured.newConnectedStreamableClient();
         MyTools.CANCELLED.set(false);


### PR DESCRIPTION
OperationCancellationException had no constructor, causing getMessage() to return null.
When wrapped in ToolCallException and converted to a ToolResponse via ToolResponse.error(tce.getMessage()), this resulted in IllegalArgumentException from TextContent which requires non-null text.

* Added no-arg constructor with "Operation cancelled" default message.
* Added test to verify cancellation doesn't throw IllegalArgumentException due to null message.
