### PR TITLE
core: fix native image nesting resources/read cacheControl

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpObjectMapperCustomizer.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpObjectMapperCustomizer.java
@@ -2,9 +2,9 @@ package io.quarkiverse.mcp.server.runtime;
 
 import jakarta.enterprise.context.Dependent;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
-import com.fasterxml.jackson.annotation.JsonUnwrapped;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import io.quarkiverse.mcp.server.AudioContent;
@@ -56,8 +56,12 @@ public class McpObjectMapperCustomizer implements ObjectMapperCustomizer {
 
     @JsonInclude(Include.NON_NULL)
     static abstract class ResourceResponseMixin {
-        @JsonUnwrapped
-        CacheControl cacheControl;
+        // The cache control hints are serialized as flat top-level fields (ttlMs/cacheScope) by
+        // ResourceMessageHandler#resourcesRead; the record property itself must never be serialized.
+        // A method-level annotation is used intentionally so that native image reflection registration
+        // (which registers the accessors via .methods()) is sufficient to honor it.
+        @JsonIgnore
+        abstract CacheControl cacheControl();
     }
 
 }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceMessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceMessageHandler.java
@@ -7,7 +7,6 @@ import java.util.Optional;
 import org.jboss.logging.Logger;
 
 import io.quarkiverse.mcp.server.CacheControl;
-import io.quarkiverse.mcp.server.CacheScope;
 import io.quarkiverse.mcp.server.JsonRpcErrorCodes;
 import io.quarkiverse.mcp.server.McpException;
 import io.quarkiverse.mcp.server.ResourceManager.ResourceInfo;
@@ -123,9 +122,14 @@ class ResourceMessageHandler extends MessageHandler {
                                     : JsonRpcErrorCodes.RESOURCE_NOT_FOUND,
                             "Resource not found: " + resourceUri);
                 } else {
-                    ResourceResponse resolved = resolveResourceReadCacheControl(resourceResponse, resourceUri,
-                            mcpRequest.serverName(), mcpRequest.protocolVersion().isStateless());
-                    return mcpRequest.sender().sendResult(id, JsonObject.mapFrom(resolved), responseMeta);
+                    // The cacheControl record property is ignored; the cache control hints are emitted
+                    // as flat top-level ttlMs/cacheScope fields
+                    JsonObject result = JsonObject.mapFrom(resourceResponse);
+                    Optional<CacheControl> cacheControl = resolveResourceReadCacheControl(resourceResponse, resourceUri,
+                            mcpRequest.serverName());
+                    putCacheControl(result, cacheControl.map(CacheControl::ttlMs).orElse(-1L),
+                            cacheControl.map(CacheControl::cacheScope), mcpRequest.protocolVersion().isStateless());
+                    return mcpRequest.sender().sendResult(id, result, responseMeta);
                 }
             },
                     cause -> handleFailure(id, mcpRequest.sender(), mcpRequest, cause, LOG,
@@ -135,31 +139,21 @@ class ResourceMessageHandler extends MessageHandler {
         }
     }
 
-    // Precedence: ResourceResponse cache control > resource/template cache control > protocol default
-    private ResourceResponse resolveResourceReadCacheControl(ResourceResponse response, String resourceUri,
-            String serverName, boolean stateless) {
+    // Precedence: ResourceResponse cache control > resource/template cache control > none
+    private Optional<CacheControl> resolveResourceReadCacheControl(ResourceResponse response, String resourceUri,
+            String serverName) {
         if (response.cacheControl() != null) {
-            return response;
+            return Optional.of(response.cacheControl());
         }
-        Optional<CacheControl> cc = Optional.empty();
         ResourceInfo info = manager.getResource(resourceUri, serverName);
         if (info != null) {
-            cc = info.cacheControl();
-        } else {
-            ResourceTemplateInfo templateInfo = manager.resourceTemplateManager.findMatching(resourceUri, serverName);
-            if (templateInfo != null) {
-                cc = templateInfo.cacheControl();
-            }
+            return info.cacheControl();
         }
-        if (cc.isPresent()) {
-            return new ResourceResponse(response.contents(), response._meta(), cc.get());
+        ResourceTemplateInfo templateInfo = manager.resourceTemplateManager.findMatching(resourceUri, serverName);
+        if (templateInfo != null) {
+            return templateInfo.cacheControl();
         }
-        if (stateless) {
-            // ttlMs/cacheScope are required fields of ReadResourceResult as of protocol version 2026-07-28;
-            // default to a non-cacheable result (immediately stale, public) when nothing else is configured
-            return new ResourceResponse(response.contents(), response._meta(), new CacheControl(0, CacheScope.PUBLIC));
-        }
-        return response;
+        return Optional.empty();
     }
 
 }

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/cachecontrol/CacheControlTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/cachecontrol/CacheControlTest.java
@@ -1,6 +1,7 @@
 package io.quarkiverse.mcp.server.test.cachecontrol;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
@@ -12,6 +13,7 @@ import io.quarkiverse.mcp.server.test.McpAssured;
 import io.quarkiverse.mcp.server.test.McpAssured.McpStreamableTestClient;
 import io.quarkiverse.mcp.server.test.McpServerTest;
 import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.json.JsonObject;
 
 public class CacheControlTest extends McpServerTest {
 
@@ -86,6 +88,17 @@ public class CacheControlTest extends McpServerTest {
                     assertEquals(5000L, r.cacheControl().ttlMs());
                     assertEquals(CacheScope.PRIVATE, r.cacheControl().cacheScope());
                 })
+                // Verify the wire shape: cache control must be flat top-level fields, never nested under cacheControl
+                .resourcesRead("file:///cc/alpha")
+                .withRawAssert(response -> {
+                    JsonObject result = response.getJsonObject("result");
+                    assertNotNull(result);
+                    assertFalse(result.containsKey("cacheControl"),
+                            "cacheControl must not be nested; expected flat ttlMs/cacheScope");
+                    assertEquals(5000L, result.getLong("ttlMs"));
+                    assertEquals("private", result.getString("cacheScope"));
+                })
+                .send()
                 .thenAssertResults();
     }
 
@@ -99,6 +112,16 @@ public class CacheControlTest extends McpServerTest {
                     assertEquals("bravo", r.contents().get(0).asText().text());
                     assertNull(r.cacheControl());
                 })
+                // Verify no cache control fields are emitted at all (neither flat nor nested)
+                .resourcesRead("file:///cc/bravo")
+                .withRawAssert(response -> {
+                    JsonObject result = response.getJsonObject("result");
+                    assertNotNull(result);
+                    assertFalse(result.containsKey("cacheControl"), "cacheControl must not be present");
+                    assertNull(result.getLong("ttlMs"), "ttlMs must not be present");
+                    assertNull(result.getString("cacheScope"), "cacheScope must not be present");
+                })
+                .send()
                 .thenAssertResults();
     }
 
@@ -119,6 +142,17 @@ public class CacheControlTest extends McpServerTest {
                     assertEquals(0L, r.cacheControl().ttlMs());
                     assertEquals(CacheScope.PUBLIC, r.cacheControl().cacheScope());
                 })
+                // Verify the required defaults are emitted as flat top-level fields, never nested
+                .resourcesRead("file:///cc/bravo")
+                .withRawAssert(response -> {
+                    JsonObject result = response.getJsonObject("result");
+                    assertNotNull(result);
+                    assertFalse(result.containsKey("cacheControl"),
+                            "cacheControl must not be nested; expected flat ttlMs/cacheScope");
+                    assertEquals(0L, result.getLong("ttlMs"));
+                    assertEquals("public", result.getString("cacheScope"));
+                })
+                .send()
                 // alpha has an explicit @CacheControl which must still take precedence over the default
                 .resourcesRead("file:///cc/alpha", r -> {
                     assertEquals("alpha", r.contents().get(0).asText().text());

--- a/transports/http/integration-tests/src/main/java/io/quarkiverse/mcp/server/sse/it/ServerFeatures.java
+++ b/transports/http/integration-tests/src/main/java/io/quarkiverse/mcp/server/sse/it/ServerFeatures.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import jakarta.inject.Inject;
 
 import io.quarkiverse.mcp.server.BlobResourceContents;
+import io.quarkiverse.mcp.server.CacheScope;
 import io.quarkiverse.mcp.server.Elicitation;
 import io.quarkiverse.mcp.server.ElicitationRequest;
 import io.quarkiverse.mcp.server.ElicitationRequest.StringSchema;
@@ -47,7 +48,7 @@ public class ServerFeatures {
         return PromptMessage.withUserRole(new TextContent(codeService.assist(language)));
     }
 
-    @Resource(uri = "file:///project/alpha")
+    @Resource(uri = "file:///project/alpha", cacheControl = @Resource.CacheControl(ttlMs = 15000, cacheScope = CacheScope.PUBLIC))
     BlobResourceContents alpha(RequestUri uri) {
         return BlobResourceContents.create(uri.value(), "data".getBytes());
     }

--- a/transports/http/integration-tests/src/test/java/io/quarkiverse/mcp/server/sse/it/ServerFeaturesTest.java
+++ b/transports/http/integration-tests/src/test/java/io/quarkiverse/mcp/server/sse/it/ServerFeaturesTest.java
@@ -102,6 +102,18 @@ class ServerFeaturesTest {
                     assertEquals(Base64.getMimeEncoder().encodeToString("data".getBytes()),
                             r.contents().get(0).asBlob().blob());
                 })
+                // Verify the cache control wire shape (also exercised against the native image via ServerFeaturesIT):
+                // ttlMs/cacheScope must be flat top-level fields, never nested under a cacheControl object
+                .resourcesRead("file:///project/alpha")
+                .withRawAssert(response -> {
+                    JsonObject result = response.getJsonObject("result");
+                    assertNotNull(result);
+                    assertFalse(result.containsKey("cacheControl"),
+                            "cacheControl must not be nested; expected flat ttlMs/cacheScope");
+                    assertEquals(15000L, result.getLong("ttlMs"));
+                    assertEquals("public", result.getString("cacheScope"));
+                })
+                .send()
                 .thenAssertResults();
     }
 


### PR DESCRIPTION
- the flat top-level ttlMs/cacheScope required by ReadResourceResult relied on a field-level @JsonUnwrapped whose reflection registration was missing in native image, so the directive nested under a cacheControl object
- emit the fields explicitly instead: @JsonIgnore the cacheControl accessor and append flat ttlMs/cacheScope via putCacheControl directly
- resolves #956