### PR TITLE
refactor: never wrap control-flow exceptions in WrapBusinessErrorInterceptor

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/InputRequiredException.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/InputRequiredException.java
@@ -48,9 +48,10 @@ public class InputRequiredException extends RuntimeException {
     }
 
     /**
+     * @return a new builder
      * @see MrtrRequest#inputRequired()
      */
-    static Builder builder() {
+    public static Builder builder() {
         return new Builder();
     }
 

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/WrapBusinessErrorInterceptor.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/WrapBusinessErrorInterceptor.java
@@ -5,8 +5,11 @@ import jakarta.interceptor.AroundInvoke;
 import jakarta.interceptor.Interceptor;
 import jakarta.interceptor.InvocationContext;
 
+import io.quarkiverse.mcp.server.Cancellation;
+import io.quarkiverse.mcp.server.InputRequiredException;
 import io.quarkiverse.mcp.server.Tool;
 import io.quarkiverse.mcp.server.ToolCallException;
+import io.quarkiverse.mcp.server.UrlElicitationRequiredException;
 import io.quarkiverse.mcp.server.WrapBusinessError;
 import io.smallrye.mutiny.Uni;
 
@@ -31,6 +34,10 @@ public class WrapBusinessErrorInterceptor {
     }
 
     private Throwable wrapIfNecessary(Throwable t, InvocationContext context) {
+        if (isControlFlowException(t)) {
+            return t;
+        }
+
         if (context.getMethod().isAnnotationPresent(Tool.class) && matches(t, context)) {
             return new ToolCallException(t);
         }
@@ -50,6 +57,14 @@ public class WrapBusinessErrorInterceptor {
             }
         }
         return false;
+    }
+
+    private boolean isControlFlowException(Throwable t) {
+        return t instanceof ToolCallException
+                || t instanceof Cancellation.OperationCancellationException
+                || t instanceof org.mcpjava.server.Cancellation.OperationCancelledException
+                || t instanceof InputRequiredException
+                || t instanceof UrlElicitationRequiredException;
     }
 
     @SuppressWarnings("unchecked")

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/WrapBusinessErrorInterceptor.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/WrapBusinessErrorInterceptor.java
@@ -33,8 +33,8 @@ public class WrapBusinessErrorInterceptor {
         }
     }
 
-    private Throwable wrapIfNecessary(Throwable t, InvocationContext context) {
-        if (isControlFlowException(t)) {
+    static Throwable wrapIfNecessary(Throwable t, InvocationContext context) {
+        if (isUnwrappable(t)) {
             return t;
         }
 
@@ -44,7 +44,7 @@ public class WrapBusinessErrorInterceptor {
         return t;
     }
 
-    private boolean matches(Throwable t, InvocationContext context) {
+    private static boolean matches(Throwable t, InvocationContext context) {
         WrapBusinessError businessError = context.getInterceptorBinding(WrapBusinessError.class);
         for (Class<? extends Throwable> e : businessError.unless()) {
             if (e.isAssignableFrom(t.getClass())) {
@@ -59,7 +59,7 @@ public class WrapBusinessErrorInterceptor {
         return false;
     }
 
-    private boolean isControlFlowException(Throwable t) {
+    private static boolean isUnwrappable(Throwable t) {
         return t instanceof ToolCallException
                 || t instanceof Cancellation.OperationCancellationException
                 || t instanceof org.mcpjava.server.Cancellation.OperationCancelledException

--- a/core/runtime/src/test/java/io/quarkiverse/mcp/server/runtime/WrapBusinessErrorInterceptorTest.java
+++ b/core/runtime/src/test/java/io/quarkiverse/mcp/server/runtime/WrapBusinessErrorInterceptorTest.java
@@ -1,0 +1,213 @@
+package io.quarkiverse.mcp.server.runtime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+
+import jakarta.interceptor.InvocationContext;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import io.quarkiverse.mcp.server.Cancellation;
+import io.quarkiverse.mcp.server.InputRequiredException;
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.ToolCallException;
+import io.quarkiverse.mcp.server.UrlElicitationRequiredException;
+import io.quarkiverse.mcp.server.WrapBusinessError;
+
+class WrapBusinessErrorInterceptorTest {
+
+    private WrapBusinessErrorInterceptor interceptor;
+
+    @BeforeEach
+    void setUp() {
+        interceptor = new WrapBusinessErrorInterceptor();
+    }
+
+    @Test
+    void testToolCallExceptionNotWrapped() throws Exception {
+        ToolCallException original = new ToolCallException("Already a tool error");
+
+        Throwable result = invokeWrapIfNecessary(original, TestTools.class.getMethod("toolWithWrapBusinessError"));
+
+        assertSame(original, result, "ToolCallException should not be wrapped");
+    }
+
+    @Test
+    void testOperationCancellationExceptionNotWrapped() throws Exception {
+        Cancellation.OperationCancellationException original = new Cancellation.OperationCancellationException();
+
+        Throwable result = invokeWrapIfNecessary(original, TestTools.class.getMethod("toolWithWrapBusinessError"));
+
+        assertSame(original, result, "OperationCancellationException should not be wrapped");
+    }
+
+    @Test
+    void testMcpJavaOperationCancelledExceptionNotWrapped() throws Exception {
+        org.mcpjava.server.Cancellation.OperationCancelledException original = new org.mcpjava.server.Cancellation.OperationCancelledException();
+
+        Throwable result = invokeWrapIfNecessary(original, TestTools.class.getMethod("toolWithWrapBusinessError"));
+
+        assertSame(original, result, "mcpjava OperationCancelledException should not be wrapped");
+    }
+
+    @Test
+    void testInputRequiredExceptionNotWrapped() throws Exception {
+        InputRequiredException original = createInputRequiredException();
+
+        Throwable result = invokeWrapIfNecessary(original, TestTools.class.getMethod("toolWithWrapBusinessError"));
+
+        assertSame(original, result, "InputRequiredException should not be wrapped");
+    }
+
+    @Test
+    void testUrlElicitationRequiredExceptionNotWrapped() throws Exception {
+        UrlElicitationRequiredException original = createUrlElicitationRequiredException();
+
+        Throwable result = invokeWrapIfNecessary(original, TestTools.class.getMethod("toolWithWrapBusinessError"));
+
+        assertSame(original, result, "UrlElicitationRequiredException should not be wrapped");
+    }
+
+    @Test
+    void testRegularExceptionIsWrapped() throws Exception {
+        IllegalArgumentException original = new IllegalArgumentException("Business error");
+
+        Throwable result = invokeWrapIfNecessary(original, TestTools.class.getMethod("toolWithWrapBusinessError"));
+
+        assertNotSame(original, result, "Regular exception should be wrapped");
+        assertInstanceOf(ToolCallException.class, result, "Should be wrapped in ToolCallException");
+        assertEquals(original, result.getCause(), "Original exception should be the cause");
+    }
+
+    @Test
+    void testControlFlowExceptionNotWrappedEvenWhenMatching() throws Exception {
+        Cancellation.OperationCancellationException cancellation = new Cancellation.OperationCancellationException();
+
+        Throwable result = invokeWrapIfNecessary(cancellation, TestTools.class.getMethod("toolWithWrapBusinessError"));
+
+        assertSame(cancellation, result,
+                "Control-flow exception should not be wrapped even when matching @WrapBusinessError filter");
+    }
+
+    @Test
+    void testNonToolMethodDoesNotWrap() throws Exception {
+        IllegalArgumentException original = new IllegalArgumentException("Error");
+
+        Throwable result = invokeWrapIfNecessary(original, TestTools.class.getMethod("nonToolMethod"));
+
+        assertSame(original, result, "Non-@Tool method should not wrap exceptions");
+    }
+
+    private InputRequiredException createInputRequiredException() throws Exception {
+        Method builderMethod = InputRequiredException.class.getDeclaredMethod("builder");
+        builderMethod.setAccessible(true);
+        Object builder = builderMethod.invoke(null);
+
+        Method addRootsMethod = builder.getClass().getMethod("addRootsRequest", String.class);
+        addRootsMethod.invoke(builder, "test-roots");
+
+        Method buildMethod = builder.getClass().getMethod("build");
+        return (InputRequiredException) buildMethod.invoke(builder);
+    }
+
+    private UrlElicitationRequiredException createUrlElicitationRequiredException() throws Exception {
+        Method builderMethod = UrlElicitationRequiredException.class.getDeclaredMethod("builder");
+        builderMethod.setAccessible(true);
+        Object builder = builderMethod.invoke(null);
+
+        Method setMessageMethod = builder.getClass().getMethod("setMessage", String.class);
+        setMessageMethod.invoke(builder, "URL elicitation required");
+
+        Method addElicitationMethod = builder.getClass().getMethod("addElicitation", String.class, String.class);
+        addElicitationMethod.invoke(builder, "https://example.com/auth", "Auth needed");
+
+        Method buildMethod = builder.getClass().getMethod("build");
+        return (UrlElicitationRequiredException) buildMethod.invoke(builder);
+    }
+
+    private Throwable invokeWrapIfNecessary(Throwable t, Method toolMethod) throws Exception {
+        InvocationContext context = new TestInvocationContext(toolMethod);
+
+        Method method = WrapBusinessErrorInterceptor.class.getDeclaredMethod(
+                "wrapIfNecessary", Throwable.class, InvocationContext.class);
+        method.setAccessible(true);
+        return (Throwable) method.invoke(interceptor, t, context);
+    }
+
+    private static class TestInvocationContext implements InvocationContext {
+        private final Method method;
+
+        TestInvocationContext(Method method) {
+            this.method = method;
+        }
+
+        @Override
+        public Method getMethod() {
+            return method;
+        }
+
+        @Override
+        public <T extends Annotation> T getInterceptorBinding(Class<T> annotationClass) {
+            return method.getAnnotation(annotationClass);
+        }
+
+        @Override
+        public Object getTarget() {
+            return null;
+        }
+
+        @Override
+        public Object getTimer() {
+            return null;
+        }
+
+        @Override
+        public Object[] getParameters() {
+            return new Object[0];
+        }
+
+        @Override
+        public void setParameters(Object[] params) {
+        }
+
+        @Override
+        public java.util.Map<String, Object> getContextData() {
+            return null;
+        }
+
+        @Override
+        public Object proceed() throws Exception {
+            return null;
+        }
+
+        @Override
+        public <T extends Annotation> java.util.Set<T> getInterceptorBindings(Class<T> annotationClass) {
+            return null;
+        }
+
+        @Override
+        public java.lang.reflect.Constructor<?> getConstructor() {
+            return null;
+        }
+    }
+
+    public static class TestTools {
+
+        @Tool
+        @WrapBusinessError(Exception.class)
+        public void toolWithWrapBusinessError() {
+            // Tool method
+        }
+
+        @WrapBusinessError(Exception.class)
+        public void nonToolMethod() {
+            // Not a Tool method
+        }
+    }
+}

--- a/core/runtime/src/test/java/io/quarkiverse/mcp/server/runtime/WrapBusinessErrorInterceptorTest.java
+++ b/core/runtime/src/test/java/io/quarkiverse/mcp/server/runtime/WrapBusinessErrorInterceptorTest.java
@@ -10,7 +10,6 @@ import java.lang.reflect.Method;
 
 import jakarta.interceptor.InvocationContext;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import io.quarkiverse.mcp.server.Cancellation;
@@ -21,13 +20,6 @@ import io.quarkiverse.mcp.server.UrlElicitationRequiredException;
 import io.quarkiverse.mcp.server.WrapBusinessError;
 
 class WrapBusinessErrorInterceptorTest {
-
-    private WrapBusinessErrorInterceptor interceptor;
-
-    @BeforeEach
-    void setUp() {
-        interceptor = new WrapBusinessErrorInterceptor();
-    }
 
     @Test
     void testToolCallExceptionNotWrapped() throws Exception {
@@ -104,40 +96,22 @@ class WrapBusinessErrorInterceptorTest {
         assertSame(original, result, "Non-@Tool method should not wrap exceptions");
     }
 
-    private InputRequiredException createInputRequiredException() throws Exception {
-        Method builderMethod = InputRequiredException.class.getDeclaredMethod("builder");
-        builderMethod.setAccessible(true);
-        Object builder = builderMethod.invoke(null);
-
-        Method addRootsMethod = builder.getClass().getMethod("addRootsRequest", String.class);
-        addRootsMethod.invoke(builder, "test-roots");
-
-        Method buildMethod = builder.getClass().getMethod("build");
-        return (InputRequiredException) buildMethod.invoke(builder);
+    private InputRequiredException createInputRequiredException() {
+        return InputRequiredException.builder()
+                .addRootsRequest("test-roots")
+                .build();
     }
 
-    private UrlElicitationRequiredException createUrlElicitationRequiredException() throws Exception {
-        Method builderMethod = UrlElicitationRequiredException.class.getDeclaredMethod("builder");
-        builderMethod.setAccessible(true);
-        Object builder = builderMethod.invoke(null);
-
-        Method setMessageMethod = builder.getClass().getMethod("setMessage", String.class);
-        setMessageMethod.invoke(builder, "URL elicitation required");
-
-        Method addElicitationMethod = builder.getClass().getMethod("addElicitation", String.class, String.class);
-        addElicitationMethod.invoke(builder, "https://example.com/auth", "Auth needed");
-
-        Method buildMethod = builder.getClass().getMethod("build");
-        return (UrlElicitationRequiredException) buildMethod.invoke(builder);
+    private UrlElicitationRequiredException createUrlElicitationRequiredException() {
+        UrlElicitationRequiredException.Builder builder = UrlElicitationRequiredException.builder();
+        builder.setMessage("URL elicitation required");
+        builder.addElicitation("https://example.com/auth", "Auth needed");
+        return builder.build();
     }
 
-    private Throwable invokeWrapIfNecessary(Throwable t, Method toolMethod) throws Exception {
+    private Throwable invokeWrapIfNecessary(Throwable t, Method toolMethod) {
         InvocationContext context = new TestInvocationContext(toolMethod);
-
-        Method method = WrapBusinessErrorInterceptor.class.getDeclaredMethod(
-                "wrapIfNecessary", Throwable.class, InvocationContext.class);
-        method.setAccessible(true);
-        return (Throwable) method.invoke(interceptor, t, context);
+        return WrapBusinessErrorInterceptor.wrapIfNecessary(t, context);
     }
 
     private static class TestInvocationContext implements InvocationContext {

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/McpJavaControlFlowTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/McpJavaControlFlowTest.java
@@ -1,0 +1,51 @@
+package io.quarkiverse.mcp.server.test.tools;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.concurrent.TimeUnit;
+
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.Tool;
+import io.quarkiverse.mcp.server.WrapBusinessError;
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkiverse.mcp.server.test.McpAssured.McpStreamableTestClient;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.json.JsonObject;
+
+public class McpJavaControlFlowTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .withApplicationRoot(
+                    root -> root.addClasses(MyTools.class));
+
+    @Test
+    public void testMcpJavaOperationCancelledNeverWrapped() {
+        McpStreamableTestClient client = McpAssured.newConnectedStreamableClient();
+
+        JsonObject request = client.newRequest("tools/call")
+                .put("params", new JsonObject()
+                        .put("name", "juliet"));
+        client.sendAndForget(request);
+
+        Awaitility.await()
+                .atMost(2, TimeUnit.SECONDS)
+                .pollInterval(50, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    assertEquals(1, client.snapshot().responses().size());
+                });
+    }
+
+    public static class MyTools {
+
+        @WrapBusinessError(Exception.class)
+        @Tool
+        String juliet() {
+            throw new org.mcpjava.server.Cancellation.OperationCancelledException();
+        }
+    }
+}

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/ToolBusinessErrorTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/ToolBusinessErrorTest.java
@@ -4,10 +4,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
+import io.quarkiverse.mcp.server.Cancellation;
 import io.quarkiverse.mcp.server.JsonRpcErrorCodes;
 import io.quarkiverse.mcp.server.McpException;
 import io.quarkiverse.mcp.server.TextContent;
@@ -16,9 +19,11 @@ import io.quarkiverse.mcp.server.ToolCallException;
 import io.quarkiverse.mcp.server.WrapBusinessError;
 import io.quarkiverse.mcp.server.test.McpAssured;
 import io.quarkiverse.mcp.server.test.McpAssured.McpSseTestClient;
+import io.quarkiverse.mcp.server.test.McpAssured.McpStreamableTestClient;
 import io.quarkiverse.mcp.server.test.McpServerTest;
 import io.quarkus.test.QuarkusUnitTest;
 import io.smallrye.mutiny.Uni;
+import io.vertx.core.json.JsonObject;
 
 public class ToolBusinessErrorTest extends McpServerTest {
 
@@ -52,6 +57,23 @@ public class ToolBusinessErrorTest extends McpServerTest {
                 .thenAssertResults();
     }
 
+    @Test
+    public void testControlFlowExceptionsNeverWrapped() {
+        McpStreamableTestClient client = McpAssured.newConnectedStreamableClient();
+
+        JsonObject request = client.newRequest("tools/call")
+                .put("params", new JsonObject()
+                        .put("name", "foxtrot"));
+        client.sendAndForget(request);
+
+        Awaitility.await()
+                .atMost(2, TimeUnit.SECONDS)
+                .pollInterval(50, TimeUnit.MILLISECONDS)
+                .untilAsserted(() -> {
+                    assertEquals(1, client.snapshot().responses().size());
+                });
+    }
+
     public static class MyTools {
 
         @Tool
@@ -75,6 +97,12 @@ public class ToolBusinessErrorTest extends McpServerTest {
         @Tool
         String echo() {
             throw new McpException("Testik", JsonRpcErrorCodes.INTERNAL_ERROR);
+        }
+
+        @WrapBusinessError(value = Exception.class, unless = ToolCallException.class)
+        @Tool
+        String foxtrot() {
+            throw new Cancellation.OperationCancellationException();
         }
 
     }


### PR DESCRIPTION
Prevents `WrapBusinessErrorInterceptor` from wrapping control-flow exceptions that are handled specially by `MessageHandler`, even when they match `@WrapBusinessError` annotation filters.

This resolves the issue identified in #955 where using `@WrapBusinessError(value = Exception.class, unless = ToolCallException.class)` would wrap `OperationCancellationException`.

## Control-Flow Exceptions Never Wrapped

  1. `ToolCallException` - Already a tool error wrapper (prevents double-wrapping)
  2. `Cancellation.OperationCancellationException` - Cancellation signal
  3. `org.mcpjava.server.Cancellation.OperationCancelledException` - mcpjava cancellation variant
  4. `InputRequiredException` - Multi-round-trip input request
  5. `UrlElicitationRequiredException` - URL elicitation request
