### PR TITLE
core: register ResourceResponseMixin for reflection

### DIFF
--- a/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/McpServerProcessor.java
+++ b/core/deployment/src/main/java/io/quarkiverse/mcp/server/deployment/McpServerProcessor.java
@@ -1311,7 +1311,8 @@ class McpServerProcessor {
                 ModelHint.class,
                 IncludeContext.class,
                 SamplingRequestImpl.class,
-                Icon.class)
+                Icon.class,
+                McpObjectMapperCustomizer.ResourceResponseMixin.class)
                 .methods().build());
         reflectiveHierarchies.produce(ReflectiveHierarchyBuildItem.builder(List.class).build());
         reflectiveHierarchies.produce(ReflectiveHierarchyBuildItem.builder(Map.class).build());

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpObjectMapperCustomizer.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpObjectMapperCustomizer.java
@@ -55,11 +55,12 @@ public class McpObjectMapperCustomizer implements ObjectMapperCustomizer {
     }
 
     @JsonInclude(Include.NON_NULL)
-    static abstract class ResourceResponseMixin {
+    public static abstract class ResourceResponseMixin {
         // The cache control hints are serialized as flat top-level fields (ttlMs/cacheScope) by
         // ResourceMessageHandler#resourcesRead; the record property itself must never be serialized.
-        // A method-level annotation is used intentionally so that native image reflection registration
-        // (which registers the accessors via .methods()) is sufficient to honor it.
+        // A method-level annotation is used intentionally: it needs only this mixin registered for
+        // reflection, whereas a field-level one also needs ResourceResponse.fields() and the
+        // CacheControl/CacheScope types (see McpServerProcessor#registerForReflection).
         @JsonIgnore
         abstract CacheControl cacheControl();
     }

--- a/transports/http/integration-tests/src/main/java/io/quarkiverse/mcp/server/sse/it/ServerFeatures.java
+++ b/transports/http/integration-tests/src/main/java/io/quarkiverse/mcp/server/sse/it/ServerFeatures.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import jakarta.inject.Inject;
 
 import io.quarkiverse.mcp.server.BlobResourceContents;
+import io.quarkiverse.mcp.server.CacheControl;
 import io.quarkiverse.mcp.server.CacheScope;
 import io.quarkiverse.mcp.server.Elicitation;
 import io.quarkiverse.mcp.server.ElicitationRequest;
@@ -20,10 +21,12 @@ import io.quarkiverse.mcp.server.PromptArg;
 import io.quarkiverse.mcp.server.PromptMessage;
 import io.quarkiverse.mcp.server.RequestUri;
 import io.quarkiverse.mcp.server.Resource;
+import io.quarkiverse.mcp.server.ResourceResponse;
 import io.quarkiverse.mcp.server.Sampling;
 import io.quarkiverse.mcp.server.SamplingMessage;
 import io.quarkiverse.mcp.server.SamplingRequest;
 import io.quarkiverse.mcp.server.TextContent;
+import io.quarkiverse.mcp.server.TextResourceContents;
 import io.quarkiverse.mcp.server.Tool;
 import io.quarkiverse.mcp.server.ToolManager;
 import io.smallrye.mutiny.Uni;
@@ -51,6 +54,12 @@ public class ServerFeatures {
     @Resource(uri = "file:///project/alpha", cacheControl = @Resource.CacheControl(ttlMs = 15000, cacheScope = CacheScope.PUBLIC))
     BlobResourceContents alpha(RequestUri uri) {
         return BlobResourceContents.create(uri.value(), "data".getBytes());
+    }
+
+    @Resource(uri = "file:///project/bravo")
+    ResourceResponse bravo(RequestUri uri) {
+        return new ResourceResponse(List.of(TextResourceContents.create(uri.value(), "data")), null,
+                new CacheControl(15000, CacheScope.PRIVATE));
     }
 
     @Tool

--- a/transports/http/integration-tests/src/test/java/io/quarkiverse/mcp/server/sse/it/ServerFeaturesTest.java
+++ b/transports/http/integration-tests/src/test/java/io/quarkiverse/mcp/server/sse/it/ServerFeaturesTest.java
@@ -95,8 +95,9 @@ class ServerFeaturesTest {
         McpStreamableTestClient client = McpAssured.newConnectedStreamableClient();
         client.when()
                 .resourcesList(p -> {
-                    assertEquals(1, p.size());
+                    assertEquals(2, p.size());
                     assertEquals("alpha", p.findByUri("file:///project/alpha").name());
+                    assertEquals("bravo", p.findByUri("file:///project/bravo").name());
                 })
                 .resourcesRead("file:///project/alpha", r -> {
                     assertEquals(Base64.getMimeEncoder().encodeToString("data".getBytes()),
@@ -112,6 +113,17 @@ class ServerFeaturesTest {
                             "cacheControl must not be nested; expected flat ttlMs/cacheScope");
                     assertEquals(15000L, result.getLong("ttlMs"));
                     assertEquals("public", result.getString("cacheScope"));
+                })
+                .send()
+                // bravo has a non-null cacheControl, so only @JsonIgnore keeps it off the wire
+                .resourcesRead("file:///project/bravo")
+                .withRawAssert(response -> {
+                    JsonObject result = response.getJsonObject("result");
+                    assertNotNull(result);
+                    assertFalse(result.containsKey("cacheControl"),
+                            "cacheControl must not be nested; expected flat ttlMs/cacheScope");
+                    assertEquals(15000L, result.getLong("ttlMs"));
+                    assertEquals("private", result.getString("cacheScope"));
                 })
                 .send()
                 .thenAssertResults();


### PR DESCRIPTION
Follow-up to #958 — tested that patch against our native setup as requested. It fixes the missing flat fields, but native and JVM still don't agree.

Envelope keys for `resources/read`, measured on `999-SNAPSHOT` (77bfb3b) in our app with our local `@RegisterForReflection` workaround removed:

| | keys |
|---|---|
| JVM | `[_meta, cacheScope, contents, resultType, ttlMs]` |
| native | `[_meta, cacheControl, cacheScope, contents, resultType, ttlMs]` |
| native + this PR | matches JVM |

The `@JsonIgnore` is on `ResourceResponseMixin`, and that class isn't in the reflection list, so native-image can't read its declared methods and the annotation is dropped. `ttlMs`/`cacheScope` are fine regardless since `putCacheControl` writes them directly — it's only the leftover `cacheControl` property.

**Why the new native assertion doesn't catch it:** `file:///project/alpha` gets its cache control from `@Resource`, so the `ResourceResponse` the framework builds has a null `cacheControl`. `@JsonInclude(NON_NULL)` drops a null property anyway, with or without the `@JsonIgnore` — so that assertion passes either way. Added `file:///project/bravo`, which returns a `ResourceResponse` with a non-null `cacheControl`; there the `@JsonIgnore` is the only thing stopping the property from being serialized.

The mixin is made public so it can be referenced as a class literal alongside the other entries in that list.

Verified locally: `CacheControlTest` 10/10 and `ServerFeaturesTest` 7/7 in JVM mode. The native before/after in the table is from our own app, where registering exactly this class removed the extra key. I could not run `ServerFeaturesIT` here — a container-built Linux binary won't launch on macOS — so `bravo`'s native behaviour is inferred from that same mechanism and gets its first native run in CI.
