### PR TITLE
core: send resources/list_changed for resource template changes

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/ResourceTemplateManager.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/ResourceTemplateManager.java
@@ -2,6 +2,7 @@ package io.quarkiverse.mcp.server;
 
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Predicate;
 
 import io.quarkiverse.mcp.server.ResourceTemplateManager.ResourceTemplateInfo;
 
@@ -62,6 +63,17 @@ public interface ResourceTemplateManager extends FeatureManager<ResourceTemplate
      * @see #removeResourceTemplate(String, String)
      */
     ResourceTemplateInfo removeResourceTemplate(String name);
+
+    /**
+     * Sends a {@code notifications/resources/list_changed} notification to the connections that match the given filter.
+     * <p>
+     * Unlike {@link ResourceTemplateDefinition#register()} and {@link #removeResourceTemplate(String)}, which broadcast to all
+     * connections, this method allows targeted notification delivery. This is useful when the effective resource template list
+     * changes for specific connections only, for example due to a {@link ResourceTemplateFilter} state change.
+     *
+     * @param filter the predicate used to select connections to notify
+     */
+    void notifyListChanged(Predicate<McpConnection> filter);
 
     /**
      * Resource template info.

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceTemplateManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceTemplateManagerImpl.java
@@ -12,6 +12,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -32,6 +33,7 @@ import io.quarkiverse.mcp.server.FilterContext;
 import io.quarkiverse.mcp.server.Icon;
 import io.quarkiverse.mcp.server.IconsProvider;
 import io.quarkiverse.mcp.server.JsonRpcErrorCodes;
+import io.quarkiverse.mcp.server.McpConnection;
 import io.quarkiverse.mcp.server.McpException;
 import io.quarkiverse.mcp.server.McpLog;
 import io.quarkiverse.mcp.server.McpMethod;
@@ -140,6 +142,7 @@ public class ResourceTemplateManagerImpl extends FeatureManagerBase<ResourceResp
         templates.computeIfPresent(key, (k, value) -> {
             if (!value.info().isMethod()) {
                 removed.set(value.info());
+                notifyConnections(McpMethod.NOTIFICATIONS_RESOURCES_LIST_CHANGED);
                 return null;
             }
             return value;
@@ -157,7 +160,15 @@ public class ResourceTemplateManagerImpl extends FeatureManagerBase<ResourceResp
             }
             return false;
         });
+        if (removed.get() != null) {
+            notifyConnections(McpMethod.NOTIFICATIONS_RESOURCES_LIST_CHANGED);
+        }
         return removed.get();
+    }
+
+    @Override
+    public void notifyListChanged(Predicate<McpConnection> filter) {
+        notifyConnections(McpMethod.NOTIFICATIONS_RESOURCES_LIST_CHANGED, Objects.requireNonNull(filter));
     }
 
     private VariableMatcher getVariableMatcher(String name, String serverName) {
@@ -605,6 +616,7 @@ public class ResourceTemplateManagerImpl extends FeatureManagerBase<ResourceResp
             } finally {
                 registrationLock.unlock();
             }
+            notifyConnections(McpMethod.NOTIFICATIONS_RESOURCES_LIST_CHANGED);
             return ret;
         }
     }

--- a/docs/modules/ROOT/pages/guides-implementing-resources.adoc
+++ b/docs/modules/ROOT/pages/guides-implementing-resources.adoc
@@ -511,9 +511,11 @@ public class MyResourceTemplates {
 <1> The injected manager can be used to obtain metadata and register a new resource template programmatically.
 <2> Ensure that `addResourceTemplate` is executed when the application starts.
 <3> The `ResourceTemplateManager#newResourceTemplate(String)` method returns `ResourceTemplateDefinition`, a builder-like API.
-<4> Registers the resource template definition.
+<4> Registers the resource template definition and sends the `notifications/resources/list_changed` notification to all connected clients.
 
-The programmatic API also allows you to remove existing resource templates at runtime (using `removeResourceTemplate(String name)`), which is not possible with the annotation-based approach.
+The programmatic API also allows you to remove existing resource templates at runtime (using `removeResourceTemplate(String name)`, which also sends the `notifications/resources/list_changed` notification), which is not possible with the annotation-based approach.
+
+NOTE: The MCP specification does not define a dedicated notification for resource template list changes. Therefore, the `notifications/resources/list_changed` notification is reused; clients that support it should re-fetch both the resource list and the resource template list.
 
 TIP: When using the Streamable HTTP transport, features added programmatically always force SSE initialization because it's not possible to determine whether SSE-dependent functionality (such as `Progress`, `McpLog`, `Sampling`, `Roots`, or `Elicitation`) will be used. If your handler does not use any of these, you can add the `TransportHint.STREAMABLE_HTTP_SKIP_SSE_INIT` hint via `addHint(TransportHint.STREAMABLE_HTTP_SKIP_SSE_INIT)` to skip the SSE initialization and improve performance.
 

--- a/docs/modules/ROOT/pages/release-notes.adoc
+++ b/docs/modules/ROOT/pages/release-notes.adoc
@@ -28,7 +28,7 @@ include::./includes/attributes.adoc[]
 [[version-2-0-features]]
 === New Features
 
-* [2.0.0] Targeted `notifyListChanged(Predicate<McpConnection>)` on `ToolManager`, `PromptManager`, and `ResourceManager`. Sends a `list_changed` notification only to connections matching the predicate, instead of broadcasting to all connections. This is useful when the effective feature list changes for specific connections, e.g. due to a filter state change. (https://github.com/quarkiverse/quarkus-mcp-server/issues/943[#943])
+* [2.0.0] Targeted `notifyListChanged(Predicate<McpConnection>)` on `ToolManager`, `PromptManager`, `ResourceManager`, and `ResourceTemplateManager`. Sends a `list_changed` notification only to connections matching the predicate, instead of broadcasting to all connections. This is useful when the effective feature list changes for specific connections, e.g. due to a filter state change. (https://github.com/quarkiverse/quarkus-mcp-server/issues/943[#943])
 
 * [2.0.0] Stateless MCP protocol support (protocol version `2026-07-28`). The server supports both stateful and stateless clients simultaneously. Stateless clients use `server/discover` instead of the `initialize`/`initialized` handshake. See xref:concepts-transports.adoc#_stateless_mode[Stateless Mode]. (https://github.com/quarkiverse/quarkus-mcp-server/issues/824[#824])
 * [2.0.0] New `McpConnection.isTransient()` method to check if a connection is transient (per-request, not tracked on the server).
@@ -65,6 +65,7 @@ include::./includes/attributes.adoc[]
 * [2.0.0] The generated tool arguments holder class now uses the effective argument name (from `@ToolArg` etc.) instead of the Java parameter name, fixing mismatches between schema property keys and argument binding. (https://github.com/quarkiverse/quarkus-mcp-server/issues/918[#918])
 * [2.0.0] Empty `icons` array is no longer included in JSON responses for programmatically added features. (https://github.com/quarkiverse/quarkus-mcp-server/issues/916[#916])
 * [2.0.0] The subsidiary SSE debug notification now respects the connection's current log level instead of being sent unconditionally. (https://github.com/quarkiverse/quarkus-mcp-server/issues/910[#910])
+* [2.0.0] Registering or removing a resource template programmatically via `ResourceTemplateManager` now sends the `notifications/resources/list_changed` notification, consistent with programmatic resource changes. (https://github.com/quarkiverse/quarkus-mcp-server/issues/944[#944])
 
 [[version-1-13]]
 == 1.13.x

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/resources/templates/ProgrammaticResourceTemplateTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/resources/templates/ProgrammaticResourceTemplateTest.java
@@ -23,6 +23,7 @@ import io.quarkiverse.mcp.server.test.McpAssured.McpSseTestClient;
 import io.quarkiverse.mcp.server.test.McpAssured.ResourceTemplateInfo;
 import io.quarkiverse.mcp.server.test.McpServerTest;
 import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.json.JsonObject;
 
 public class ProgrammaticResourceTemplateTest extends McpServerTest {
 
@@ -53,6 +54,9 @@ public class ProgrammaticResourceTemplateTest extends McpServerTest {
         assertThrows(IllegalStateException.class, () -> myTemplates.registerNoUriTemplate("alphas"));
         assertThrows(NullPointerException.class, () -> myTemplates.register(null));
 
+        List<JsonObject> notifications = client.waitForNotifications(1).notifications();
+        assertEquals("notifications/resources/list_changed", notifications.get(0).getString("method"));
+
         client.when()
                 .resourcesTemplatesList(p -> {
                     assertEquals(1, p.size());
@@ -71,7 +75,13 @@ public class ProgrammaticResourceTemplateTest extends McpServerTest {
                 .resourcesRead("file:///bravo/bim", r -> assertEquals("bim", r.contents().get(0).asText().text()))
                 .thenAssertResults();
 
+        assertEquals("notifications/resources/list_changed",
+                client.waitForNotifications(2).notifications().get(1).getString("method"));
+
         myTemplates.remove("alpha");
+
+        assertEquals("notifications/resources/list_changed",
+                client.waitForNotifications(3).notifications().get(2).getString("method"));
 
         client.when()
                 .resourcesTemplatesList(p -> assertEquals(1, p.size()))


### PR DESCRIPTION
- registering or removing a resource template programmatically via ResourceTemplateManager now sends the notifications/resources/list_changed notification
- also add a targeted notifyListChanged(Predicate<McpConnection>) to ResourceTemplateManager
- fixes #944