### PR TITLE
core: fix flaky auto-init connection removal assertions in tests [1.13.x]

### DIFF
--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/dummyinit/AutoInitConfigFallbackTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/dummyinit/AutoInitConfigFallbackTest.java
@@ -6,6 +6,7 @@ import java.net.URI;
 
 import jakarta.inject.Inject;
 
+import org.awaitility.Awaitility;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -57,7 +58,7 @@ public class AutoInitConfigFallbackTest extends McpServerTest {
                 .extract().body().asString());
         String connectionId = response.getJsonObject("result").getJsonArray("content").getJsonObject(0).getString("text");
         // The auto-initialized connection should have been removed
-        assertFalse(connectionManager.has(connectionId));
+        Awaitility.await().until(() -> !connectionManager.has(connectionId));
         assertFalse(response.getJsonObject("result").getBoolean("isError"));
     }
 

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/dummyinit/AutoInitTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/dummyinit/AutoInitTest.java
@@ -57,7 +57,8 @@ public class AutoInitTest extends McpServerTest {
                 .statusCode(200)
                 .extract().body().asString());
         String connectionId = response.getJsonObject("result").getJsonArray("content").getJsonObject(0).getString("text");
-        assertFalse(connectionManager.has(connectionId));
+        // The auto-initialized connection should have been removed
+        Awaitility.await().until(() -> !connectionManager.has(connectionId));
         assertFalse(response.getJsonObject("result").getBoolean("isError"));
 
         response = new JsonObject(RestAssured.given()
@@ -100,7 +101,13 @@ public class AutoInitTest extends McpServerTest {
                 .statusCode(202);
 
         // Auto-initialized connection should have been removed
-        assertFalse(connectionManager.iterator().hasNext());
+        try {
+            Awaitility.await().until(() -> !connectionManager.iterator().hasNext());
+        } catch (ConditionTimeoutException e) {
+            fail("Some connections still exists: "
+                    + StreamSupport.stream(connectionManager.spliterator(), false)
+                            .map(c -> c.id() + "[" + c.initialRequest().implementation().name() + "]").toList());
+        }
     }
 
     private JsonObject notificationsInitialized() {


### PR DESCRIPTION
- auto-initialized connections are removed asynchronously in the handler's onComplete callback, after the HTTP response has been flushed
- wrap these removal checks in Awaitility.await()
- AutoInitTest.testNotificationsInitialized()
- AutoInitTest.testToolCall()
- AutoInitConfigFallbackTest.testOldConfigKeyStillWorks()