### PR TITLE
Use canonical `ai` instead of `artificial-intelligence` as category

### DIFF
--- a/core/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/core/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -5,6 +5,6 @@ metadata:
     - mcp
   guide: https://docs.quarkiverse.io/quarkus-mcp-server/dev/
   categories:
-    - "artificial-intelligence"
+    - "aigence"
   status: "stable"
   unlisted: true

--- a/core/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/core/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -5,6 +5,6 @@ metadata:
     - mcp
   guide: https://docs.quarkiverse.io/quarkus-mcp-server/dev/
   categories:
-    - "aigence"
+    - "ai"
   status: "stable"
   unlisted: true

--- a/hibernate-validator/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/hibernate-validator/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -5,5 +5,5 @@ metadata:
     - mcp, hibernate-validator
   guide: https://docs.quarkiverse.io/quarkus-mcp-server/dev/
   categories:
-    - "artificial-intelligence"
+    - "aigence"
   status: "stable"

--- a/hibernate-validator/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/hibernate-validator/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -5,5 +5,5 @@ metadata:
     - mcp, hibernate-validator
   guide: https://docs.quarkiverse.io/quarkus-mcp-server/dev/
   categories:
-    - "aigence"
+    - "ai"
   status: "stable"

--- a/schema-validator/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/schema-validator/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -5,5 +5,5 @@ metadata:
     - mcp, json-schema, validator
   guide: https://docs.quarkiverse.io/quarkus-mcp-server/dev/
   categories:
-    - "artificial-intelligence"
+    - "aigence"
   status: "stable"

--- a/schema-validator/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/schema-validator/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -5,5 +5,5 @@ metadata:
     - mcp, json-schema, validator
   guide: https://docs.quarkiverse.io/quarkus-mcp-server/dev/
   categories:
-    - "aigence"
+    - "ai"
   status: "stable"

--- a/transports/http/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/transports/http/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -5,5 +5,5 @@ metadata:
     - mcp
   guide: https://docs.quarkiverse.io/quarkus-mcp-server/dev/
   categories:
-    - "artificial-intelligence"
+    - "aigence"
   status: "stable"

--- a/transports/http/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/transports/http/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -5,5 +5,5 @@ metadata:
     - mcp
   guide: https://docs.quarkiverse.io/quarkus-mcp-server/dev/
   categories:
-    - "aigence"
+    - "ai"
   status: "stable"

--- a/transports/stdio/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/transports/stdio/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -5,5 +5,5 @@ metadata:
     - mcp
   guide: https://docs.quarkiverse.io/quarkus-mcp-server/dev/
   categories:
-    - "artificial-intelligence"
+    - "aigence"
   status: "stable"

--- a/transports/stdio/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/transports/stdio/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -5,5 +5,5 @@ metadata:
     - mcp
   guide: https://docs.quarkiverse.io/quarkus-mcp-server/dev/
   categories:
-    - "aigence"
+    - "ai"
   status: "stable"

--- a/transports/websocket/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/transports/websocket/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -5,5 +5,5 @@ metadata:
     - mcp
   guide: https://docs.quarkiverse.io/quarkus-mcp-server/dev/
   categories:
-    - "artificial-intelligence"
+    - "aigence"
   status: "stable"

--- a/transports/websocket/runtime/src/main/resources/META-INF/quarkus-extension.yaml
+++ b/transports/websocket/runtime/src/main/resources/META-INF/quarkus-extension.yaml
@@ -5,5 +5,5 @@ metadata:
     - mcp
   guide: https://docs.quarkiverse.io/quarkus-mcp-server/dev/
   categories:
-    - "aigence"
+    - "ai"
   status: "stable"


### PR DESCRIPTION
Resolves #978 