### PR TITLE
docs: document enriching the structured-content output schema

### DIFF
--- a/docs/modules/ROOT/pages/guides-implementing-tools.adoc
+++ b/docs/modules/ROOT/pages/guides-implementing-tools.adoc
@@ -215,9 +215,10 @@ For example, `void` methods are not supported.
 
 TIP: The default behavior can be changed with `quarkus.mcp.server.support-langchain4j-annotations=false`.
 
+[[customizing-json-schema-generation]]
 == Customizing JSON Schema Generation
 
-By default, the MCP server uses the `com.github.victools:jsonschema-generator` library to generate JSON schemas for tool inputs.
+By default, the MCP server uses the `com.github.victools:jsonschema-generator` library to generate JSON schemas for tool inputs and, when structured content is enabled, tool outputs.
 This library is configurable through modules that process various annotations (e.g., Jackson, Bean Validation) to enrich the generated schemas.
 
 By defining a dependency on `com.github.victools:jsonschema-module-jackson`, the schema generator will be automatically configured to use the Jackson module.

--- a/docs/modules/ROOT/pages/guides-using-structured-content.adoc
+++ b/docs/modules/ROOT/pages/guides-using-structured-content.adoc
@@ -135,6 +135,60 @@ Product getProduct(String productId) {
 
 The generated schema will include type information for all fields in the `Product` class.
 
+==== Enriching the Output Schema
+
+By default, the generated output schema only contains type information; extra metadata such as field descriptions or constraints is not included.
+Just like for input schemas, the output schema can be enriched by adding one of the optional Victools schema generator modules to the classpath, so that the corresponding annotations are taken into account:
+
+* `com.github.victools:jsonschema-module-jackson` - Jackson annotations, e.g. `@JsonPropertyDescription` or `@JsonProperty`
+* `com.github.victools:jsonschema-module-jakarta-validation` - Jakarta Validation constraints, e.g. `@NotNull` or `@Size`
+* `com.github.victools:jsonschema-module-swagger-2` - Swagger 2 annotations, e.g. `@Schema`
+
+IMPORTANT: The relevant annotations are only taken into account when the corresponding module dependency is present on the classpath. For example, the `quarkus.mcp.server.schema-generator.jackson.enabled` configuration property (enabled by default) has _no effect_ unless the `jsonschema-module-jackson` dependency is present.
+
+For example, with the `jsonschema-module-jackson` dependency on the classpath, `@JsonPropertyDescription` adds a `description` to the corresponding output schema field:
+
+[source,java]
+----
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
+public record Parameter(
+    @JsonPropertyDescription("Identifier of the parameter.") // <1>
+    String paramId,
+
+    @JsonPropertyDescription("Description of the parameter.")
+    String description) {
+}
+
+public class MyTools {
+
+    @Tool(description = "Returns the list of available parameters", structuredContent = true)
+    List<Parameter> getParameters() { // <2>
+        return List.of(new Parameter("id", "A parameter"));
+    }
+}
+----
+<1> The description is added to the corresponding field in the generated output schema.
+<2> Metadata is also generated for nested types, e.g. for the item type of a `List`.
+
+The generated output schema looks like this:
+
+[source,json]
+----
+{
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "paramId": { "type": "string", "description": "Identifier of the parameter." },
+      "description": { "type": "string", "description": "Description of the parameter." }
+    }
+  }
+}
+----
+
+TIP: See xref:guides-implementing-tools.adoc#customizing-json-schema-generation[Customizing JSON Schema Generation] for more details about the schema generator modules and relevant configuration properties.
+
 === Explicit Schema Source
 
 Use `@OutputSchema(from = ...)` to specify which class to generate the schema from:

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/structcontent/OutputSchemaPropertyDescriptionTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/tools/structcontent/OutputSchemaPropertyDescriptionTest.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
+import java.util.List;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -30,7 +32,7 @@ public class OutputSchemaPropertyDescriptionTest extends McpServerTest {
 
         client.when()
                 .toolsList(page -> {
-                    assertEquals(2, page.tools().size());
+                    assertEquals(3, page.tools().size());
 
                     // Verify output schema for tool returning a class with @JsonPropertyDescription on a field
                     JsonObject fooSchema = page.findByName("fooTool").outputSchema();
@@ -51,6 +53,19 @@ public class OutputSchemaPropertyDescriptionTest extends McpServerTest {
                     assertNotNull(valueProp);
                     assertEquals("string", valueProp.getString("type"));
                     assertEquals("value description", valueProp.getString("description"));
+
+                    // Verify output schema for tool returning a List of records with @JsonPropertyDescription
+                    JsonObject barsSchema = page.findByName("barsTool").outputSchema();
+                    assertNotNull(barsSchema, "Output schema for barsTool should not be null");
+                    assertEquals("array", barsSchema.getString("type"));
+                    JsonObject itemsSchema = barsSchema.getJsonObject("items");
+                    assertNotNull(itemsSchema);
+                    JsonObject itemsProperties = itemsSchema.getJsonObject("properties");
+                    assertNotNull(itemsProperties);
+                    JsonObject itemValueProp = itemsProperties.getJsonObject("value");
+                    assertNotNull(itemValueProp);
+                    assertEquals("string", itemValueProp.getString("type"));
+                    assertEquals("value description", itemValueProp.getString("description"));
                 })
                 .toolsCall("fooTool", toolResponse -> {
                     assertEquals(0, toolResponse.content().size());
@@ -69,6 +84,10 @@ public class OutputSchemaPropertyDescriptionTest extends McpServerTest {
                     } else {
                         fail("Not a JsonObject");
                     }
+                })
+                .toolsCall("barsTool", toolResponse -> {
+                    assertEquals(0, toolResponse.content().size());
+                    assertNotNull(toolResponse.structuredContent());
                 })
                 .thenAssertResults();
     }
@@ -95,6 +114,11 @@ public class OutputSchemaPropertyDescriptionTest extends McpServerTest {
         @Tool(description = "Returns a Bar", structuredContent = true)
         Bar barTool() {
             return new Bar("world");
+        }
+
+        @Tool(description = "Returns a list of Bar", structuredContent = true)
+        List<Bar> barsTool() {
+            return List.of(new Bar("world"));
         }
     }
 }


### PR DESCRIPTION
- output schema metadata (e.g. @JsonPropertyDescription) is only honored when the matching Victools module is on the classpath
- add an "Enriching the Output Schema" subsection
- also extend OutputSchemaPropertyDescriptionTest with a List<record> case
- related to #980