### PR TITLE
core: scope list-changed notifications to the affected servers

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/FeatureManagerBase.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/FeatureManagerBase.java
@@ -61,6 +61,7 @@ import io.quarkiverse.mcp.server.Sampling;
 import io.quarkiverse.mcp.server.TransportHint;
 import io.quarkiverse.mcp.server.runtime.ResultMappers.Result;
 import io.quarkiverse.mcp.server.runtime.config.McpServersRuntimeConfig;
+import io.quarkiverse.mcp.server.runtime.config.McpServersRuntimeConfig.AutoListChangedStrategy;
 import io.quarkiverse.mcp.server.runtime.config.McpServersRuntimeConfig.InvalidServerNameStrategy;
 import io.quarkiverse.mcp.server.runtime.mcpjava.McpJavaCancellationAdapter;
 import io.quarkiverse.mcp.server.runtime.mcpjava.McpJavaMcpRequestAdapter;
@@ -91,6 +92,9 @@ public abstract class FeatureManagerBase<RESULT, INFO extends FeatureManager.Fea
     // used to validate server name if InvalidServerNameStrategy.FAIL is set
     protected final Set<String> serverNames;
 
+    // determines which connections receive the automatic list_changed notification on register/remove
+    protected final AutoListChangedStrategy autoListChangedStrategy;
+
     // used to ensure atomic registration of features across multiple server keys
     protected final Lock registrationLock = new ReentrantLock();
 
@@ -111,6 +115,7 @@ public abstract class FeatureManagerBase<RESULT, INFO extends FeatureManager.Fea
         this.serverRequests = serverRequests;
         this.cancellationRequests = cancellationRequests;
         this.serverNames = config.invalidServerNameStrategy() == InvalidServerNameStrategy.FAIL ? metadata.serverNames() : null;
+        this.autoListChangedStrategy = config.autoListChangedStrategy();
         jakarta.enterprise.inject.Instance<McpTracing> mcpTracingInstance = Arc.container().select(McpTracing.class);
         this.mcpTracing = mcpTracingInstance.isResolvable() ? mcpTracingInstance.get() : null;
     }
@@ -381,8 +386,22 @@ public abstract class FeatureManagerBase<RESULT, INFO extends FeatureManager.Fea
         return metadata.feature().toString().toLowerCase() + ":" + metadata.info().name();
     }
 
-    protected void notifyConnections(McpMethod method) {
-        notifyConnections(method, null);
+    /**
+     * Notifies the connections affected by a change of the features registered for the specified servers.
+     * <p>
+     * Depending on {@link AutoListChangedStrategy}, this either notifies only the connections whose server name is in
+     * {@code serverNames} ({@link AutoListChangedStrategy#MATCHING_SERVER}) or all open connections
+     * ({@link AutoListChangedStrategy#ALL}).
+     *
+     * @param method the notification method
+     * @param serverNames the server names the affected feature is registered for
+     */
+    protected void notifyConnections(McpMethod method, Set<String> serverNames) {
+        if (autoListChangedStrategy == AutoListChangedStrategy.ALL) {
+            notifyConnections(method, (Predicate<McpConnection>) null);
+        } else {
+            notifyConnections(method, c -> serverNames.contains(c.serverName()));
+        }
     }
 
     protected void notifyConnections(McpMethod method, Predicate<McpConnection> filter) {

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/PromptManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/PromptManagerImpl.java
@@ -119,7 +119,7 @@ public class PromptManagerImpl extends FeatureManagerBase<PromptResponse, Prompt
         prompts.computeIfPresent(key, (k, value) -> {
             if (!value.isMethod()) {
                 removed.set(value);
-                notifyConnections(McpMethod.NOTIFICATIONS_PROMPTS_LIST_CHANGED);
+                notifyConnections(McpMethod.NOTIFICATIONS_PROMPTS_LIST_CHANGED, Set.of(serverName));
                 return null;
             }
             return value;
@@ -138,7 +138,7 @@ public class PromptManagerImpl extends FeatureManagerBase<PromptResponse, Prompt
             return false;
         });
         if (removed.get() != null) {
-            notifyConnections(McpMethod.NOTIFICATIONS_PROMPTS_LIST_CHANGED);
+            notifyConnections(McpMethod.NOTIFICATIONS_PROMPTS_LIST_CHANGED, removed.get().serverNames());
         }
         return removed.get();
     }
@@ -297,7 +297,7 @@ public class PromptManagerImpl extends FeatureManagerBase<PromptResponse, Prompt
             } finally {
                 registrationLock.unlock();
             }
-            notifyConnections(McpMethod.NOTIFICATIONS_PROMPTS_LIST_CHANGED);
+            notifyConnections(McpMethod.NOTIFICATIONS_PROMPTS_LIST_CHANGED, ret.serverNames());
             return ret;
         }
     }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceManagerImpl.java
@@ -195,7 +195,7 @@ public class ResourceManagerImpl extends FeatureManagerBase<ResourceResponse, Re
             if (!value.isMethod()) {
                 removed.set(value);
                 resourceNames.remove(new FeatureKey(value.name(), serverName));
-                notifyConnections(McpMethod.NOTIFICATIONS_RESOURCES_LIST_CHANGED);
+                notifyConnections(McpMethod.NOTIFICATIONS_RESOURCES_LIST_CHANGED, Set.of(serverName));
                 return null;
             }
             return value;
@@ -215,7 +215,7 @@ public class ResourceManagerImpl extends FeatureManagerBase<ResourceResponse, Re
             return false;
         });
         if (removed.get() != null) {
-            notifyConnections(McpMethod.NOTIFICATIONS_RESOURCES_LIST_CHANGED);
+            notifyConnections(McpMethod.NOTIFICATIONS_RESOURCES_LIST_CHANGED, removed.get().serverNames());
         }
         return removed.get();
     }
@@ -591,7 +591,7 @@ public class ResourceManagerImpl extends FeatureManagerBase<ResourceResponse, Re
             } finally {
                 registrationLock.unlock();
             }
-            notifyConnections(McpMethod.NOTIFICATIONS_RESOURCES_LIST_CHANGED);
+            notifyConnections(McpMethod.NOTIFICATIONS_RESOURCES_LIST_CHANGED, ret.serverNames());
             return ret;
         }
     }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceTemplateManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceTemplateManagerImpl.java
@@ -142,7 +142,7 @@ public class ResourceTemplateManagerImpl extends FeatureManagerBase<ResourceResp
         templates.computeIfPresent(key, (k, value) -> {
             if (!value.info().isMethod()) {
                 removed.set(value.info());
-                notifyConnections(McpMethod.NOTIFICATIONS_RESOURCES_LIST_CHANGED);
+                notifyConnections(McpMethod.NOTIFICATIONS_RESOURCES_LIST_CHANGED, Set.of(serverName));
                 return null;
             }
             return value;
@@ -161,7 +161,7 @@ public class ResourceTemplateManagerImpl extends FeatureManagerBase<ResourceResp
             return false;
         });
         if (removed.get() != null) {
-            notifyConnections(McpMethod.NOTIFICATIONS_RESOURCES_LIST_CHANGED);
+            notifyConnections(McpMethod.NOTIFICATIONS_RESOURCES_LIST_CHANGED, removed.get().serverNames());
         }
         return removed.get();
     }
@@ -616,7 +616,7 @@ public class ResourceTemplateManagerImpl extends FeatureManagerBase<ResourceResp
             } finally {
                 registrationLock.unlock();
             }
-            notifyConnections(McpMethod.NOTIFICATIONS_RESOURCES_LIST_CHANGED);
+            notifyConnections(McpMethod.NOTIFICATIONS_RESOURCES_LIST_CHANGED, ret.serverNames());
             return ret;
         }
     }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ToolManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ToolManagerImpl.java
@@ -181,7 +181,7 @@ public class ToolManagerImpl extends FeatureManagerBase<ToolResponse, ToolInfo> 
         tools.computeIfPresent(key, (k, value) -> {
             if (!value.isMethod()) {
                 removed.set(value);
-                notifyConnections(McpMethod.NOTIFICATIONS_TOOLS_LIST_CHANGED);
+                notifyConnections(McpMethod.NOTIFICATIONS_TOOLS_LIST_CHANGED, Set.of(serverName));
                 return null;
             }
             return value;
@@ -205,7 +205,7 @@ public class ToolManagerImpl extends FeatureManagerBase<ToolResponse, ToolInfo> 
         });
         ToolInfo removedTool = removed.get();
         if (removedTool != null) {
-            notifyConnections(McpMethod.NOTIFICATIONS_TOOLS_LIST_CHANGED);
+            notifyConnections(McpMethod.NOTIFICATIONS_TOOLS_LIST_CHANGED, removedTool.serverNames());
             toolRemovedEvent.fire(new ToolRemoved(removedTool));
         }
         return removedTool;
@@ -697,7 +697,7 @@ public class ToolManagerImpl extends FeatureManagerBase<ToolResponse, ToolInfo> 
             } finally {
                 registrationLock.unlock();
             }
-            notifyConnections(McpMethod.NOTIFICATIONS_TOOLS_LIST_CHANGED);
+            notifyConnections(McpMethod.NOTIFICATIONS_TOOLS_LIST_CHANGED, ret.serverNames());
             toolAddedEvent.fire(new ToolAdded(ret));
             return ret;
         }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/config/McpServersRuntimeConfig.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/config/McpServersRuntimeConfig.java
@@ -42,4 +42,24 @@ public interface McpServersRuntimeConfig {
         IGNORE,
     }
 
+    /**
+     * The strategy used to select the client connections that receive the automatic
+     * {@code notifications/*_list_changed} notification sent when a feature (tool, prompt, resource or resource template) is
+     * registered or removed programmatically at runtime.
+     */
+    @WithDefault("matching-server")
+    AutoListChangedStrategy autoListChangedStrategy();
+
+    enum AutoListChangedStrategy {
+        /**
+         * Only connections whose server name matches the server(s) the affected feature is registered for are notified.
+         */
+        MATCHING_SERVER,
+        /**
+         * All open connections are notified, regardless of the server they are connected to. This was the behavior in versions
+         * 2.0.0 and earlier.
+         */
+        ALL,
+    }
+
 }

--- a/docs/modules/ROOT/pages/guides-implementing-prompts.adoc
+++ b/docs/modules/ROOT/pages/guides-implementing-prompts.adoc
@@ -295,7 +295,7 @@ public class MyPrompts {
 <1> The injected manager can be used to obtain metadata and register a new prompt programmatically.
 <2> Ensure that `addPrompt` is executed when the application starts.
 <3> The `PromptManager#newPrompt(String)` method returns `PromptDefinition`, a builder-like API.
-<4> Registers the prompt definition and sends the `notifications/prompts/list_changed` notification to all connected clients.
+<4> Registers the prompt definition and sends the `notifications/prompts/list_changed` notification to the clients connected to the server(s) the prompt is bound to. See xref:guides-multiple-servers.adoc#list-changed-notification-scope[Scope of the automatic list-changed notification] for details.
 
 The programmatic API also allows you to remove existing prompts at runtime (using `removePrompt(String name)`), which is not possible with the annotation-based approach.
 

--- a/docs/modules/ROOT/pages/guides-implementing-resources.adoc
+++ b/docs/modules/ROOT/pages/guides-implementing-resources.adoc
@@ -467,7 +467,7 @@ public class MyResources {
 <1> The injected manager can be used to obtain metadata and register a new resource programmatically.
 <2> Ensure that `addResource` is executed when the application starts.
 <3> The `ResourceManager#newResource(String)` method returns `ResourceDefinition`, a builder-like API.
-<4> Registers the resource definition and sends the `notifications/resources/list_changed` notification to all connected clients.
+<4> Registers the resource definition and sends the `notifications/resources/list_changed` notification to the clients connected to the server(s) the resource is bound to. See xref:guides-multiple-servers.adoc#list-changed-notification-scope[Scope of the automatic list-changed notification] for details.
 
 The programmatic API also allows you to remove existing resources at runtime (using `removeResource(String uri)`), which is not possible with the annotation-based approach.
 
@@ -511,7 +511,7 @@ public class MyResourceTemplates {
 <1> The injected manager can be used to obtain metadata and register a new resource template programmatically.
 <2> Ensure that `addResourceTemplate` is executed when the application starts.
 <3> The `ResourceTemplateManager#newResourceTemplate(String)` method returns `ResourceTemplateDefinition`, a builder-like API.
-<4> Registers the resource template definition and sends the `notifications/resources/list_changed` notification to all connected clients.
+<4> Registers the resource template definition and sends the `notifications/resources/list_changed` notification to the clients connected to the server(s) the resource template is bound to. See xref:guides-multiple-servers.adoc#list-changed-notification-scope[Scope of the automatic list-changed notification] for details.
 
 The programmatic API also allows you to remove existing resource templates at runtime (using `removeResourceTemplate(String name)`, which also sends the `notifications/resources/list_changed` notification), which is not possible with the annotation-based approach.
 

--- a/docs/modules/ROOT/pages/guides-implementing-tools.adoc
+++ b/docs/modules/ROOT/pages/guides-implementing-tools.adoc
@@ -165,7 +165,7 @@ public class MyTools {
 <1> The injected manager can be used to obtain metadata and register a new tool programmatically.
 <2> Ensure that `addTool` is executed when the application starts.
 <3> The `ToolManager#newTool(String)` method returns `ToolDefinition`, a builder-like API.
-<4> Registers the tool definition and sends the `notifications/tools/list_changed` notification to all connected clients.
+<4> Registers the tool definition and sends the `notifications/tools/list_changed` notification to the clients connected to the server(s) the tool is bound to. See xref:guides-multiple-servers.adoc#list-changed-notification-scope[Scope of the automatic list-changed notification] for details.
 
 The programmatic API also allows you to remove existing tools at runtime (using `removeTool(String name)`), which is not possible with the annotation-based approach.
 

--- a/docs/modules/ROOT/pages/guides-multiple-servers.adoc
+++ b/docs/modules/ROOT/pages/guides-multiple-servers.adoc
@@ -322,6 +322,39 @@ public class MyFeatures {
 }
 ----
 
+[[list-changed-notification-scope]]
+== Scope of the automatic list-changed notification
+
+When a feature (tool, prompt, resource or resource template) is registered or removed programmatically at runtime, an automatic `notifications/*_list_changed` notification is sent to the affected clients.
+By default, this notification is scoped to the server(s) the feature is bound to; only the clients connected to those servers are notified.
+Clients connected to other servers are not notified, because their feature list did not change.
+
+For example, registering a tool bound to the `bravo` server only notifies the clients connected to `bravo`:
+
+[source,java]
+----
+toolManager.newTool("query")
+    .setServerName("bravo") // <1>
+    .setDescription("...")
+    .setHandler(...)
+    .register(); // <2>
+----
+<1> The tool is bound to the `bravo` server.
+<2> Only clients connected to `bravo` receive the `notifications/tools/list_changed` notification.
+
+This behavior is controlled by the `quarkus.mcp.server.auto-list-changed-strategy` configuration property:
+
+[source,properties]
+----
+# matching-server (default): notify only the clients connected to the affected server(s)
+# all: notify all connected clients, regardless of the server they are connected to
+quarkus.mcp.server.auto-list-changed-strategy=matching-server
+----
+
+Set it to `all` to restore the behavior of versions 2.0.0 and earlier, where the notification was broadcast to all connected clients.
+
+NOTE: This setting only affects the automatic notification sent on registration/removal. The `FeatureManager#notifyListChanged(Predicate)` method always uses the supplied filter and is not affected.
+
 == Testing Multiple Servers
 
 Test each server independently using McpAssured:

--- a/docs/modules/ROOT/pages/includes/quarkus-mcp-server-core.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-mcp-server-core.adoc
@@ -481,6 +481,27 @@ endif::add-copy-button-to-env-var[]
 a|`fail`, `ignore`
 |`+++fail+++`
 
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-auto-list-changed-strategy]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-auto-list-changed-strategy[`+++quarkus.mcp.server.auto-list-changed-strategy+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.auto-list-changed-strategy+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The strategy used to select the client connections that receive the automatic `notifications/++*++_list_changed` notification sent when a feature (tool, prompt, resource or resource template) is registered or removed programmatically at runtime.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_AUTO_LIST_CHANGED_STRATEGY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_AUTO_LIST_CHANGED_STRATEGY+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`matching-server`, `all`
+|`+++matching-server+++`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-mcp-server-core_quarkus-mcp-server-tools-name-max-length]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-tools-name-max-length[`+++quarkus.mcp.server.tools.name-max-length+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.mcp.server.tools.name-max-length+++[]

--- a/docs/modules/ROOT/pages/includes/quarkus-mcp-server-core_quarkus.mcp.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-mcp-server-core_quarkus.mcp.adoc
@@ -481,6 +481,27 @@ endif::add-copy-button-to-env-var[]
 a|`fail`, `ignore`
 |`+++fail+++`
 
+a| [[quarkus-mcp-server-core_quarkus-mcp-server-auto-list-changed-strategy]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-auto-list-changed-strategy[`+++quarkus.mcp.server.auto-list-changed-strategy+++`]##
+ifdef::add-copy-button-to-config-props[]
+config_property_copy_button:+++quarkus.mcp.server.auto-list-changed-strategy+++[]
+endif::add-copy-button-to-config-props[]
+
+
+[.description]
+--
+The strategy used to select the client connections that receive the automatic `notifications/++*++_list_changed` notification sent when a feature (tool, prompt, resource or resource template) is registered or removed programmatically at runtime.
+
+
+ifdef::add-copy-button-to-env-var[]
+Environment variable: env_var_with_copy_button:+++QUARKUS_MCP_SERVER_AUTO_LIST_CHANGED_STRATEGY+++[]
+endif::add-copy-button-to-env-var[]
+ifndef::add-copy-button-to-env-var[]
+Environment variable: `+++QUARKUS_MCP_SERVER_AUTO_LIST_CHANGED_STRATEGY+++`
+endif::add-copy-button-to-env-var[]
+--
+a|`matching-server`, `all`
+|`+++matching-server+++`
+
 a|icon:lock[title=Fixed at build time] [[quarkus-mcp-server-core_quarkus-mcp-server-tools-name-max-length]] [.property-path]##link:#quarkus-mcp-server-core_quarkus-mcp-server-tools-name-max-length[`+++quarkus.mcp.server.tools.name-max-length+++`]##
 ifdef::add-copy-button-to-config-props[]
 config_property_copy_button:+++quarkus.mcp.server.tools.name-max-length+++[]

--- a/docs/modules/ROOT/pages/release-notes.adoc
+++ b/docs/modules/ROOT/pages/release-notes.adoc
@@ -2,6 +2,22 @@
 
 include::./includes/attributes.adoc[]
 
+[[version-2-1]]
+== 2.1.x
+
+[cols="1,1"]
+|===
+|Version |Date
+
+|2.1.0
+|TBD
+|===
+
+[[version-2-1-breaking]]
+=== Breaking Changes
+
+* [2.1.0] The automatic `notifications/*_list_changed` notification sent when a tool, prompt, resource or resource template is registered or removed programmatically at runtime is now scoped to the server(s) the feature is bound to; only the clients connected to those servers are notified. Previously the notification was broadcast to all connections, regardless of the server they were connected to. Set `quarkus.mcp.server.auto-list-changed-strategy=all` to restore the previous behavior. See xref:guides-multiple-servers.adoc#list-changed-notification-scope[Scope of the automatic list-changed notification]. (https://github.com/quarkiverse/quarkus-mcp-server/issues/983[#983])
+
 [[version-2-0]]
 == 2.0.x
 

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/mcpservers/AutoListChangedAllStrategyTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/mcpservers/AutoListChangedAllStrategyTest.java
@@ -1,0 +1,83 @@
+package io.quarkiverse.mcp.server.test.mcpservers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.ToolManager;
+import io.quarkiverse.mcp.server.ToolResponse;
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkiverse.mcp.server.test.McpAssured.McpStreamableTestClient;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Verifies that {@code quarkus.mcp.server.auto-list-changed-strategy=all} restores the legacy behavior where the automatic
+ * {@code notifications/*_list_changed} notification is broadcast to all connections, regardless of the server they are
+ * connected to.
+ *
+ * @see <a href="https://github.com/quarkiverse/quarkus-mcp-server/issues/983">#983</a>
+ */
+public class AutoListChangedAllStrategyTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .withApplicationRoot(
+                    root -> root.addClasses(AutoListChangedAllStrategyTest.class))
+            .overrideConfigKey("quarkus.mcp.server.auto-list-changed-strategy", "all")
+            .overrideConfigKey("quarkus.mcp.server.http.root-path", "/alpha/mcp")
+            .overrideConfigKey("quarkus.mcp.server.bravo.http.root-path", "/bravo/mcp")
+            // Enable DEBUG for the bravo server too, so the subsidiary SSE debug log notification is sent
+            .overrideRuntimeConfigKey("quarkus.mcp.server.bravo.client-logging.default-level", "DEBUG");
+
+    @Inject
+    ToolManager toolManager;
+
+    @Test
+    public void testListChangedIsBroadcastToAllServers() {
+        McpStreamableTestClient alphaClient = McpAssured.newStreamableClient()
+                .setMcpPath("/alpha/mcp")
+                .setOpenSubsidiarySse(true)
+                .build()
+                .connect();
+        McpStreamableTestClient bravoClient = McpAssured.newStreamableClient()
+                .setMcpPath("/bravo/mcp")
+                .setOpenSubsidiarySse(true)
+                .build()
+                .connect();
+
+        // Wait for the subsidiary SSE debug log notification on both clients
+        alphaClient.waitForNotifications(1);
+        bravoClient.waitForNotifications(1);
+
+        // Register a tool on bravo only -> both clients are notified because the strategy is ALL
+        toolManager.newTool("t-bravo")
+                .setServerName("bravo")
+                .setDescription("bravo tool")
+                .setHandler(ta -> ToolResponse.success("ok"))
+                .register();
+        assertLastNotification(bravoClient, 2, "notifications/tools/list_changed");
+        assertLastNotification(alphaClient, 2, "notifications/tools/list_changed");
+
+        // Remove the tool from bravo -> both clients are notified as well
+        assertNotNull(toolManager.removeTool("t-bravo", "bravo"));
+        assertLastNotification(bravoClient, 3, "notifications/tools/list_changed");
+        assertLastNotification(alphaClient, 3, "notifications/tools/list_changed");
+
+        alphaClient.disconnect();
+        bravoClient.disconnect();
+    }
+
+    private static void assertLastNotification(McpStreamableTestClient client, int expectedCount, String expectedMethod) {
+        List<JsonObject> notifications = client.waitForNotifications(expectedCount).notifications();
+        assertEquals(expectedCount, notifications.size());
+        assertEquals(expectedMethod, notifications.get(expectedCount - 1).getString("method"));
+    }
+}

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/mcpservers/AutoListChangedServerScopeTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/mcpservers/AutoListChangedServerScopeTest.java
@@ -1,0 +1,163 @@
+package io.quarkiverse.mcp.server.test.mcpservers;
+
+import static io.quarkiverse.mcp.server.McpServer.DEFAULT;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.PromptManager;
+import io.quarkiverse.mcp.server.PromptMessage;
+import io.quarkiverse.mcp.server.PromptResponse;
+import io.quarkiverse.mcp.server.ResourceManager;
+import io.quarkiverse.mcp.server.ResourceResponse;
+import io.quarkiverse.mcp.server.ResourceTemplateManager;
+import io.quarkiverse.mcp.server.TextResourceContents;
+import io.quarkiverse.mcp.server.ToolManager;
+import io.quarkiverse.mcp.server.ToolResponse;
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkiverse.mcp.server.test.McpAssured.McpStreamableTestClient;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Verifies that the automatic {@code notifications/*_list_changed} notification sent when a feature is registered or removed
+ * programmatically is scoped to the connections of the affected server(s) only, which is the default
+ * {@code MATCHING_SERVER} strategy.
+ *
+ * @see <a href="https://github.com/quarkiverse/quarkus-mcp-server/issues/983">#983</a>
+ */
+public class AutoListChangedServerScopeTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig()
+            .withApplicationRoot(
+                    root -> root.addClasses(AutoListChangedServerScopeTest.class))
+            .overrideConfigKey("quarkus.mcp.server.http.root-path", "/alpha/mcp")
+            .overrideConfigKey("quarkus.mcp.server.bravo.http.root-path", "/bravo/mcp")
+            // Enable DEBUG for the bravo server too, so the subsidiary SSE debug log notification is sent
+            .overrideRuntimeConfigKey("quarkus.mcp.server.bravo.client-logging.default-level", "DEBUG");
+
+    @Inject
+    ToolManager toolManager;
+
+    @Inject
+    PromptManager promptManager;
+
+    @Inject
+    ResourceManager resourceManager;
+
+    @Inject
+    ResourceTemplateManager resourceTemplateManager;
+
+    @Test
+    public void testListChangedIsScopedToServer() {
+        McpStreamableTestClient alphaClient = McpAssured.newStreamableClient()
+                .setMcpPath("/alpha/mcp")
+                .setOpenSubsidiarySse(true)
+                .build()
+                .connect();
+        McpStreamableTestClient bravoClient = McpAssured.newStreamableClient()
+                .setMcpPath("/bravo/mcp")
+                .setOpenSubsidiarySse(true)
+                .build()
+                .connect();
+
+        // Wait for the subsidiary SSE debug log notification on both clients
+        alphaClient.waitForNotifications(1);
+        bravoClient.waitForNotifications(1);
+        // Notification counts tracked per client (start at 1 because of the debug log notification)
+        int alpha = 1;
+        int bravo = 1;
+
+        // --- Tools ---
+
+        // Register a tool on bravo only -> only the bravo client is notified
+        toolManager.newTool("t-bravo")
+                .setServerName("bravo")
+                .setDescription("bravo tool")
+                .setHandler(ta -> ToolResponse.success("ok"))
+                .register();
+        assertLastNotification(bravoClient, ++bravo, "notifications/tools/list_changed");
+        assertEquals(alpha, alphaClient.snapshot().notifications().size());
+
+        // Register a tool on the default (alpha) server -> only the alpha client is notified
+        toolManager.newTool("t-alpha")
+                .setServerName(DEFAULT)
+                .setDescription("alpha tool")
+                .setHandler(ta -> ToolResponse.success("ok"))
+                .register();
+        assertLastNotification(alphaClient, ++alpha, "notifications/tools/list_changed");
+        assertEquals(bravo, bravoClient.snapshot().notifications().size());
+
+        // Remove the alpha tool -> only the alpha client is notified
+        assertNotNull(toolManager.removeTool("t-alpha", DEFAULT));
+        assertLastNotification(alphaClient, ++alpha, "notifications/tools/list_changed");
+        assertEquals(bravo, bravoClient.snapshot().notifications().size());
+
+        // Remove the bravo tool -> only the bravo client is notified
+        assertNotNull(toolManager.removeTool("t-bravo", "bravo"));
+        assertLastNotification(bravoClient, ++bravo, "notifications/tools/list_changed");
+        assertEquals(alpha, alphaClient.snapshot().notifications().size());
+
+        // --- Prompts ---
+
+        promptManager.newPrompt("p-bravo")
+                .setServerName("bravo")
+                .setDescription("bravo prompt")
+                .setHandler(pa -> PromptResponse.withMessages(PromptMessage.withUserRole("ok")))
+                .register();
+        assertLastNotification(bravoClient, ++bravo, "notifications/prompts/list_changed");
+        assertEquals(alpha, alphaClient.snapshot().notifications().size());
+
+        assertNotNull(promptManager.removePrompt("p-bravo", "bravo"));
+        assertLastNotification(bravoClient, ++bravo, "notifications/prompts/list_changed");
+        assertEquals(alpha, alphaClient.snapshot().notifications().size());
+
+        // --- Resources ---
+
+        resourceManager.newResource("r-bravo")
+                .setServerName("bravo")
+                .setUri("file://r-bravo")
+                .setDescription("bravo resource")
+                .setHandler(ra -> new ResourceResponse(
+                        List.of(TextResourceContents.create(ra.requestUri().value(), "ok"))))
+                .register();
+        assertLastNotification(bravoClient, ++bravo, "notifications/resources/list_changed");
+        assertEquals(alpha, alphaClient.snapshot().notifications().size());
+
+        assertNotNull(resourceManager.removeResource("file://r-bravo", "bravo"));
+        assertLastNotification(bravoClient, ++bravo, "notifications/resources/list_changed");
+        assertEquals(alpha, alphaClient.snapshot().notifications().size());
+
+        // --- Resource templates ---
+
+        resourceTemplateManager.newResourceTemplate("rt-bravo")
+                .setServerName("bravo")
+                .setUriTemplate("file://rt-bravo/{foo}")
+                .setDescription("bravo resource template")
+                .setHandler(args -> null)
+                .register();
+        assertLastNotification(bravoClient, ++bravo, "notifications/resources/list_changed");
+        assertEquals(alpha, alphaClient.snapshot().notifications().size());
+
+        assertNotNull(resourceTemplateManager.removeResourceTemplate("rt-bravo", "bravo"));
+        assertLastNotification(bravoClient, ++bravo, "notifications/resources/list_changed");
+        assertEquals(alpha, alphaClient.snapshot().notifications().size());
+
+        alphaClient.disconnect();
+        bravoClient.disconnect();
+    }
+
+    private static void assertLastNotification(McpStreamableTestClient client, int expectedCount, String expectedMethod) {
+        List<JsonObject> notifications = client.waitForNotifications(expectedCount).notifications();
+        assertEquals(expectedCount, notifications.size());
+        assertEquals(expectedMethod, notifications.get(expectedCount - 1).getString("method"));
+    }
+}


### PR DESCRIPTION
- registering or removing a tool, prompt, resource or resource template programmatically broadcast notifications/*_list_changed to every open connection in the process, regardless of the server the connection was bound to
- in multi-server deployments this caused wasted round trips and leaked cross-server activity signals
- the automatic notification is now scoped to the connections of the servers the affected feature is bound to
- a new config property quarkus.mcp.server.auto-list-changed-strategy can be used to restore the previous behavior
- fixes #983