### PR TITLE
core: allow suppressing the automatic list_changed notification per feature

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/FeatureManager.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/FeatureManager.java
@@ -177,7 +177,24 @@ public interface FeatureManager<INFO extends FeatureInfo> extends Iterable<INFO>
         THIS setIcons(Icon... icons);
 
         /**
-         * Registers the resulting info and sends notifications to all connected clients.
+         * By default, {@link #register()} sends an automatic {@code list_changed} notification to the clients connected to the
+         * affected server(s), and the corresponding {@code remove} method of the feature manager does the same when this
+         * feature is later removed.
+         * <p>
+         * If set to {@code false}, both of these automatic notifications are suppressed for this feature and the caller becomes
+         * responsible for sending them, e.g. via {@link FeatureManager#notifyListChanged(java.util.function.Predicate)}. This
+         * is
+         * useful when a filter hides the feature for some connections, in which case an unconditional notification would be
+         * wasted.
+         *
+         * @param value
+         * @return self
+         */
+        THIS setNotifyListChanged(boolean value);
+
+        /**
+         * Registers the resulting info and, unless suppressed via {@link #setNotifyListChanged(boolean)}, sends a
+         * {@code list_changed} notification to the clients connected to the affected server(s).
          *
          * @return the info
          */

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/FeatureManagerBase.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/FeatureManagerBase.java
@@ -404,6 +404,18 @@ public abstract class FeatureManagerBase<RESULT, INFO extends FeatureManager.Fea
         }
     }
 
+    /**
+     * @param info the feature that was registered or removed
+     * @return {@code true} if the automatic {@code list_changed} notification should be sent for the given feature
+     * @see FeatureManager.FeatureDefinition#setNotifyListChanged(boolean)
+     */
+    protected static boolean shouldNotifyListChanged(FeatureManager.FeatureInfo info) {
+        if (info instanceof FeatureDefinitionInfoBase<?, ?> def) {
+            return def.notifyListChanged();
+        }
+        return true;
+    }
+
     protected void notifyConnections(McpMethod method, Predicate<McpConnection> filter) {
         Objects.requireNonNull(method);
         JsonObject notification = Messages.newNotification(method.jsonRpcName());
@@ -558,6 +570,7 @@ public abstract class FeatureManagerBase<RESULT, INFO extends FeatureManager.Fea
         protected Set<String> serverNames;
         protected List<Icon> icons = List.of();
         protected Map<TransportHint, Object> transportHints = Map.of();
+        protected boolean notifyListChanged = true;
 
         protected FeatureDefinitionBase(String name, Set<String> knownServerNames) {
             this.name = Objects.requireNonNull(name);
@@ -602,6 +615,11 @@ public abstract class FeatureManagerBase<RESULT, INFO extends FeatureManager.Fea
 
         public THIS setIcons(Icon... icons) {
             this.icons = List.of(icons);
+            return self();
+        }
+
+        public THIS setNotifyListChanged(boolean value) {
+            this.notifyListChanged = value;
             return self();
         }
 
@@ -654,10 +672,18 @@ public abstract class FeatureManagerBase<RESULT, INFO extends FeatureManager.Fea
         protected final Function<ARGUMENTS, Uni<RESPONSE>> asyncFun;
         protected final boolean runOnVirtualThread;
         protected final List<Icon> icons;
+        protected final boolean notifyListChanged;
 
         protected FeatureDefinitionInfoBase(String name, String description, Set<String> serverNames,
                 Function<ARGUMENTS, RESPONSE> fun,
                 Function<ARGUMENTS, Uni<RESPONSE>> asyncFun, boolean runOnVirtualThread, List<Icon> icons) {
+            this(name, description, serverNames, fun, asyncFun, runOnVirtualThread, icons, true);
+        }
+
+        protected FeatureDefinitionInfoBase(String name, String description, Set<String> serverNames,
+                Function<ARGUMENTS, RESPONSE> fun,
+                Function<ARGUMENTS, Uni<RESPONSE>> asyncFun, boolean runOnVirtualThread, List<Icon> icons,
+                boolean notifyListChanged) {
             this.name = name;
             this.description = description;
             this.serverNames = serverNames;
@@ -666,6 +692,11 @@ public abstract class FeatureManagerBase<RESULT, INFO extends FeatureManager.Fea
             this.asyncFun = asyncFun;
             this.runOnVirtualThread = runOnVirtualThread;
             this.icons = icons;
+            this.notifyListChanged = notifyListChanged;
+        }
+
+        public boolean notifyListChanged() {
+            return notifyListChanged;
         }
 
         @Override

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/PromptManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/PromptManagerImpl.java
@@ -119,7 +119,9 @@ public class PromptManagerImpl extends FeatureManagerBase<PromptResponse, Prompt
         prompts.computeIfPresent(key, (k, value) -> {
             if (!value.isMethod()) {
                 removed.set(value);
-                notifyConnections(McpMethod.NOTIFICATIONS_PROMPTS_LIST_CHANGED, Set.of(serverName));
+                if (shouldNotifyListChanged(value)) {
+                    notifyConnections(McpMethod.NOTIFICATIONS_PROMPTS_LIST_CHANGED, Set.of(serverName));
+                }
                 return null;
             }
             return value;
@@ -137,10 +139,11 @@ public class PromptManagerImpl extends FeatureManagerBase<PromptResponse, Prompt
             }
             return false;
         });
-        if (removed.get() != null) {
-            notifyConnections(McpMethod.NOTIFICATIONS_PROMPTS_LIST_CHANGED, removed.get().serverNames());
+        PromptInfo removedPrompt = removed.get();
+        if (removedPrompt != null && shouldNotifyListChanged(removedPrompt)) {
+            notifyConnections(McpMethod.NOTIFICATIONS_PROMPTS_LIST_CHANGED, removedPrompt.serverNames());
         }
-        return removed.get();
+        return removedPrompt;
     }
 
     @Override
@@ -282,7 +285,7 @@ public class PromptManagerImpl extends FeatureManagerBase<PromptResponse, Prompt
         public PromptInfo register() {
             validate();
             PromptDefinitionInfo ret = new PromptDefinitionInfo(name, title, description, serverNames, fun, asyncFun,
-                    runOnVirtualThread, arguments, metadata, icons, transportHints);
+                    runOnVirtualThread, arguments, metadata, icons, transportHints, notifyListChanged);
             List<FeatureKey> keys = FeatureKey.list(name, serverNames);
             registrationLock.lock();
             try {
@@ -297,7 +300,9 @@ public class PromptManagerImpl extends FeatureManagerBase<PromptResponse, Prompt
             } finally {
                 registrationLock.unlock();
             }
-            notifyConnections(McpMethod.NOTIFICATIONS_PROMPTS_LIST_CHANGED, ret.serverNames());
+            if (ret.notifyListChanged()) {
+                notifyConnections(McpMethod.NOTIFICATIONS_PROMPTS_LIST_CHANGED, ret.serverNames());
+            }
             return ret;
         }
     }
@@ -314,8 +319,8 @@ public class PromptManagerImpl extends FeatureManagerBase<PromptResponse, Prompt
                 Function<PromptArguments, PromptResponse> fun,
                 Function<PromptArguments, Uni<PromptResponse>> asyncFun, boolean runOnVirtualThread,
                 List<PromptArgument> arguments, Map<MetaKey, Object> metadata, List<Icon> icons,
-                Map<TransportHint, Object> transportHints) {
-            super(name, description, serverNames, fun, asyncFun, runOnVirtualThread, icons);
+                Map<TransportHint, Object> transportHints, boolean notifyListChanged) {
+            super(name, description, serverNames, fun, asyncFun, runOnVirtualThread, icons, notifyListChanged);
             this.title = title;
             this.arguments = List.copyOf(arguments);
             this.metadata = Map.copyOf(metadata);

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceManagerImpl.java
@@ -195,7 +195,9 @@ public class ResourceManagerImpl extends FeatureManagerBase<ResourceResponse, Re
             if (!value.isMethod()) {
                 removed.set(value);
                 resourceNames.remove(new FeatureKey(value.name(), serverName));
-                notifyConnections(McpMethod.NOTIFICATIONS_RESOURCES_LIST_CHANGED, Set.of(serverName));
+                if (shouldNotifyListChanged(value)) {
+                    notifyConnections(McpMethod.NOTIFICATIONS_RESOURCES_LIST_CHANGED, Set.of(serverName));
+                }
                 return null;
             }
             return value;
@@ -214,10 +216,11 @@ public class ResourceManagerImpl extends FeatureManagerBase<ResourceResponse, Re
             }
             return false;
         });
-        if (removed.get() != null) {
-            notifyConnections(McpMethod.NOTIFICATIONS_RESOURCES_LIST_CHANGED, removed.get().serverNames());
+        ResourceInfo removedResource = removed.get();
+        if (removedResource != null && shouldNotifyListChanged(removedResource)) {
+            notifyConnections(McpMethod.NOTIFICATIONS_RESOURCES_LIST_CHANGED, removedResource.serverNames());
         }
-        return removed.get();
+        return removedResource;
     }
 
     @Override
@@ -385,8 +388,8 @@ public class ResourceManagerImpl extends FeatureManagerBase<ResourceResponse, Re
                 Function<ResourceArguments, Uni<ResourceResponse>> asyncFun, boolean runOnVirtualThread, String uri,
                 String mimeType, int size, Content.Annotations annotations, CacheControl cacheControl,
                 Map<MetaKey, Object> metadata, List<Icon> icons,
-                Map<TransportHint, Object> transportHints) {
-            super(name, description, serverNames, fun, asyncFun, runOnVirtualThread, icons);
+                Map<TransportHint, Object> transportHints, boolean notifyListChanged) {
+            super(name, description, serverNames, fun, asyncFun, runOnVirtualThread, icons, notifyListChanged);
             this.title = title;
             this.uri = uri;
             this.mimeType = mimeType;
@@ -569,7 +572,8 @@ public class ResourceManagerImpl extends FeatureManagerBase<ResourceResponse, Re
                 throw new IllegalStateException("uri must be set");
             }
             ResourceDefinitionInfo ret = new ResourceDefinitionInfo(name, title, description, serverNames, fun, asyncFun,
-                    runOnVirtualThread, uri, mimeType, size, annotations, cacheControl, metadata, icons, transportHints);
+                    runOnVirtualThread, uri, mimeType, size, annotations, cacheControl, metadata, icons, transportHints,
+                    notifyListChanged);
             List<FeatureKey> nameKeys = FeatureKey.list(name, serverNames);
             List<FeatureKey> uriKeys = FeatureKey.list(uri, serverNames);
             registrationLock.lock();
@@ -591,7 +595,9 @@ public class ResourceManagerImpl extends FeatureManagerBase<ResourceResponse, Re
             } finally {
                 registrationLock.unlock();
             }
-            notifyConnections(McpMethod.NOTIFICATIONS_RESOURCES_LIST_CHANGED, ret.serverNames());
+            if (ret.notifyListChanged()) {
+                notifyConnections(McpMethod.NOTIFICATIONS_RESOURCES_LIST_CHANGED, ret.serverNames());
+            }
             return ret;
         }
     }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceTemplateManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ResourceTemplateManagerImpl.java
@@ -142,7 +142,9 @@ public class ResourceTemplateManagerImpl extends FeatureManagerBase<ResourceResp
         templates.computeIfPresent(key, (k, value) -> {
             if (!value.info().isMethod()) {
                 removed.set(value.info());
-                notifyConnections(McpMethod.NOTIFICATIONS_RESOURCES_LIST_CHANGED, Set.of(serverName));
+                if (shouldNotifyListChanged(value.info())) {
+                    notifyConnections(McpMethod.NOTIFICATIONS_RESOURCES_LIST_CHANGED, Set.of(serverName));
+                }
                 return null;
             }
             return value;
@@ -160,10 +162,11 @@ public class ResourceTemplateManagerImpl extends FeatureManagerBase<ResourceResp
             }
             return false;
         });
-        if (removed.get() != null) {
-            notifyConnections(McpMethod.NOTIFICATIONS_RESOURCES_LIST_CHANGED, removed.get().serverNames());
+        ResourceTemplateInfo removedTemplate = removed.get();
+        if (removedTemplate != null && shouldNotifyListChanged(removedTemplate)) {
+            notifyConnections(McpMethod.NOTIFICATIONS_RESOURCES_LIST_CHANGED, removedTemplate.serverNames());
         }
-        return removed.get();
+        return removedTemplate;
     }
 
     @Override
@@ -423,8 +426,8 @@ public class ResourceTemplateManagerImpl extends FeatureManagerBase<ResourceResp
                 Function<ResourceTemplateArguments, Uni<ResourceResponse>> asyncFun, boolean runOnVirtualThread, String uri,
                 String mimeType, Content.Annotations annotations, CacheControl cacheControl, Map<MetaKey, Object> metadata,
                 List<Icon> icons,
-                Map<TransportHint, Object> transportHints) {
-            super(name, description, serverNames, fun, asyncFun, runOnVirtualThread, icons);
+                Map<TransportHint, Object> transportHints, boolean notifyListChanged) {
+            super(name, description, serverNames, fun, asyncFun, runOnVirtualThread, icons, notifyListChanged);
             this.title = title;
             this.uriTemplate = uri;
             this.mimeType = mimeType;
@@ -599,7 +602,7 @@ public class ResourceTemplateManagerImpl extends FeatureManagerBase<ResourceResp
             }
             ResourceTemplateDefinitionInfo ret = new ResourceTemplateDefinitionInfo(name, title, description, serverNames,
                     fun, asyncFun, runOnVirtualThread, uriTemplate, mimeType, annotations, cacheControl, metadata, icons,
-                    transportHints);
+                    transportHints, notifyListChanged);
             VariableMatcher variableMatcher = createMatcherFromUriTemplate(uriTemplate);
             ResourceTemplateMetadata templateMetadata = new ResourceTemplateMetadata(variableMatcher, ret);
             List<FeatureKey> keys = FeatureKey.list(name, serverNames);
@@ -616,7 +619,9 @@ public class ResourceTemplateManagerImpl extends FeatureManagerBase<ResourceResp
             } finally {
                 registrationLock.unlock();
             }
-            notifyConnections(McpMethod.NOTIFICATIONS_RESOURCES_LIST_CHANGED, ret.serverNames());
+            if (ret.notifyListChanged()) {
+                notifyConnections(McpMethod.NOTIFICATIONS_RESOURCES_LIST_CHANGED, ret.serverNames());
+            }
             return ret;
         }
     }

--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ToolManagerImpl.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/ToolManagerImpl.java
@@ -181,7 +181,9 @@ public class ToolManagerImpl extends FeatureManagerBase<ToolResponse, ToolInfo> 
         tools.computeIfPresent(key, (k, value) -> {
             if (!value.isMethod()) {
                 removed.set(value);
-                notifyConnections(McpMethod.NOTIFICATIONS_TOOLS_LIST_CHANGED, Set.of(serverName));
+                if (shouldNotifyListChanged(value)) {
+                    notifyConnections(McpMethod.NOTIFICATIONS_TOOLS_LIST_CHANGED, Set.of(serverName));
+                }
                 return null;
             }
             return value;
@@ -205,7 +207,9 @@ public class ToolManagerImpl extends FeatureManagerBase<ToolResponse, ToolInfo> 
         });
         ToolInfo removedTool = removed.get();
         if (removedTool != null) {
-            notifyConnections(McpMethod.NOTIFICATIONS_TOOLS_LIST_CHANGED, removedTool.serverNames());
+            if (shouldNotifyListChanged(removedTool)) {
+                notifyConnections(McpMethod.NOTIFICATIONS_TOOLS_LIST_CHANGED, removedTool.serverNames());
+            }
             toolRemovedEvent.fire(new ToolRemoved(removedTool));
         }
         return removedTool;
@@ -682,7 +686,8 @@ public class ToolManagerImpl extends FeatureManagerBase<ToolResponse, ToolInfo> 
 
             ToolDefinitionInfo ret = new ToolDefinitionInfo(name, title, description, serverNames, fun, asyncFun,
                     runOnVirtualThread, arguments, annotations, outputSchema, inputSchema, metadata,
-                    initInputGuardrails(inputGuardrails), initOutputGuardrails(outputGuardrails), icons, transportHints);
+                    initInputGuardrails(inputGuardrails), initOutputGuardrails(outputGuardrails), icons, transportHints,
+                    notifyListChanged);
             List<FeatureKey> keys = FeatureKey.list(name, serverNames);
             registrationLock.lock();
             try {
@@ -697,7 +702,9 @@ public class ToolManagerImpl extends FeatureManagerBase<ToolResponse, ToolInfo> 
             } finally {
                 registrationLock.unlock();
             }
-            notifyConnections(McpMethod.NOTIFICATIONS_TOOLS_LIST_CHANGED, ret.serverNames());
+            if (ret.notifyListChanged()) {
+                notifyConnections(McpMethod.NOTIFICATIONS_TOOLS_LIST_CHANGED, ret.serverNames());
+            }
             toolAddedEvent.fire(new ToolAdded(ret));
             return ret;
         }
@@ -734,8 +741,9 @@ public class ToolManagerImpl extends FeatureManagerBase<ToolResponse, ToolInfo> 
                 Function<ToolArguments, Uni<ToolResponse>> asyncFun, boolean runOnVirtualThread, List<ToolArgument> arguments,
                 ToolAnnotations annotations,
                 Object outputSchema, Object inputSchema, Map<MetaKey, Object> metadata, List<ToolInputGuardrail> input,
-                List<ToolOutputGuardrail> output, List<Icon> icons, Map<TransportHint, Object> transportHints) {
-            super(name, description, serverNames, fun, asyncFun, runOnVirtualThread, icons);
+                List<ToolOutputGuardrail> output, List<Icon> icons, Map<TransportHint, Object> transportHints,
+                boolean notifyListChanged) {
+            super(name, description, serverNames, fun, asyncFun, runOnVirtualThread, icons, notifyListChanged);
             this.title = title;
             this.arguments = List.copyOf(arguments);
             this.annotations = Optional.ofNullable(annotations);

--- a/docs/modules/ROOT/pages/guides-multiple-servers.adoc
+++ b/docs/modules/ROOT/pages/guides-multiple-servers.adoc
@@ -355,6 +355,23 @@ Set it to `all` to restore the behavior of versions 2.0.0 and earlier, where the
 
 NOTE: This setting only affects the automatic notification sent on registration/removal. The `FeatureManager#notifyListChanged(Predicate)` method always uses the supplied filter and is not affected.
 
+=== Suppressing the automatic notification for a single feature
+
+The automatic notification can also be turned off per feature via `setNotifyListChanged(false)` on the definition builder. When disabled, no `list_changed` notification is sent when the feature is registered nor when it is later removed, and the caller becomes responsible for sending it — typically via `notifyListChanged(Predicate)`.
+
+[source,java]
+----
+toolManager.newTool("query")
+    .setServerName("bravo")
+    .setNotifyListChanged(false) // <1>
+    .setDescription("...")
+    .setHandler(...)
+    .register();
+----
+<1> No automatic `notifications/tools/list_changed` is sent on register or on the later `removeTool("query", "bravo")`.
+
+This is useful when a xref:guides-using-filters-and-checks.adoc[filter] hides the feature for some connections: an unconditional notification would be wasted for the connections that cannot see the feature anyway. The caller can then send a filter-aware notification with `notifyListChanged(conn -> ...)`.
+
 == Testing Multiple Servers
 
 Test each server independently using McpAssured:

--- a/docs/modules/ROOT/pages/release-notes.adoc
+++ b/docs/modules/ROOT/pages/release-notes.adoc
@@ -18,6 +18,11 @@ include::./includes/attributes.adoc[]
 
 * [2.1.0] The automatic `notifications/*_list_changed` notification sent when a tool, prompt, resource or resource template is registered or removed programmatically at runtime is now scoped to the server(s) the feature is bound to; only the clients connected to those servers are notified. Previously the notification was broadcast to all connections, regardless of the server they were connected to. Set `quarkus.mcp.server.auto-list-changed-strategy=all` to restore the previous behavior. See xref:guides-multiple-servers.adoc#list-changed-notification-scope[Scope of the automatic list-changed notification]. (https://github.com/quarkiverse/quarkus-mcp-server/issues/983[#983])
 
+[[version-2-1-features]]
+=== New Features
+
+* **Suppress the automatic list-changed notification per feature**: `FeatureDefinition#setNotifyListChanged(false)` disables the automatic `list_changed` notification for a programmatically registered feature, both on registration and removal, leaving the caller to notify explicitly via `notifyListChanged(Predicate)`. (https://github.com/quarkiverse/quarkus-mcp-server/issues/983[#983])
+
 [[version-2-0]]
 == 2.0.x
 

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/filter/SuppressAutoListChangedTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/filter/SuppressAutoListChangedTest.java
@@ -1,0 +1,145 @@
+package io.quarkiverse.mcp.server.test.filter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+
+import jakarta.inject.Inject;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.quarkiverse.mcp.server.PromptManager;
+import io.quarkiverse.mcp.server.PromptMessage;
+import io.quarkiverse.mcp.server.PromptResponse;
+import io.quarkiverse.mcp.server.ResourceManager;
+import io.quarkiverse.mcp.server.ResourceResponse;
+import io.quarkiverse.mcp.server.ResourceTemplateManager;
+import io.quarkiverse.mcp.server.TextResourceContents;
+import io.quarkiverse.mcp.server.ToolManager;
+import io.quarkiverse.mcp.server.ToolResponse;
+import io.quarkiverse.mcp.server.test.McpAssured;
+import io.quarkiverse.mcp.server.test.McpAssured.McpStreamableTestClient;
+import io.quarkiverse.mcp.server.test.McpServerTest;
+import io.quarkus.test.QuarkusUnitTest;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Verifies that {@code setNotifyListChanged(false)} suppresses the automatic {@code list_changed} notification both when a
+ * feature (tool, prompt, resource or resource template) is registered and when it is later removed, while the caller can still
+ * trigger notifications explicitly.
+ * <p>
+ * Each suppressed operation is followed by a normally-registered feature of a <em>different</em> type. Because notifications
+ * are delivered in order on the stream, if a suppressed operation had (wrongly) sent its notification, it would arrive before
+ * the control notification and be detected by the method assertion.
+ *
+ * @see <a href="https://github.com/quarkiverse/quarkus-mcp-server/issues/983">#983</a>
+ */
+public class SuppressAutoListChangedTest extends McpServerTest {
+
+    @RegisterExtension
+    static final QuarkusUnitTest config = defaultConfig().withEmptyApplication();
+
+    @Inject
+    ToolManager toolManager;
+
+    @Inject
+    PromptManager promptManager;
+
+    @Inject
+    ResourceManager resourceManager;
+
+    @Inject
+    ResourceTemplateManager resourceTemplateManager;
+
+    @Test
+    public void testSuppressedNotifications() {
+        McpStreamableTestClient client = McpAssured.newStreamableClient()
+                .setOpenSubsidiarySse(true)
+                .build()
+                .connect();
+
+        // Wait for the subsidiary SSE debug log notification
+        client.waitForNotifications(1);
+
+        // --- Registration: suppressed feature followed by a normal control feature of a different type ---
+
+        toolManager.newTool("quiet-tool")
+                .setDescription("quiet tool")
+                .setNotifyListChanged(false)
+                .setHandler(ta -> ToolResponse.success("ok"))
+                .register();
+        promptManager.newPrompt("loud-prompt")
+                .setDescription("loud prompt")
+                .setHandler(pa -> PromptResponse.withMessages(PromptMessage.withUserRole("ok")))
+                .register();
+        assertLastNotification(client, 2, "notifications/prompts/list_changed");
+
+        promptManager.newPrompt("quiet-prompt")
+                .setDescription("quiet prompt")
+                .setNotifyListChanged(false)
+                .setHandler(pa -> PromptResponse.withMessages(PromptMessage.withUserRole("ok")))
+                .register();
+        toolManager.newTool("loud-tool")
+                .setDescription("loud tool")
+                .setHandler(ta -> ToolResponse.success("ok"))
+                .register();
+        assertLastNotification(client, 3, "notifications/tools/list_changed");
+
+        resourceManager.newResource("quiet-res")
+                .setUri("file://quiet-res")
+                .setDescription("quiet resource")
+                .setNotifyListChanged(false)
+                .setHandler(ra -> new ResourceResponse(
+                        List.of(TextResourceContents.create(ra.requestUri().value(), "ok"))))
+                .register();
+        promptManager.newPrompt("loud-prompt-2")
+                .setDescription("loud prompt 2")
+                .setHandler(pa -> PromptResponse.withMessages(PromptMessage.withUserRole("ok")))
+                .register();
+        assertLastNotification(client, 4, "notifications/prompts/list_changed");
+
+        resourceTemplateManager.newResourceTemplate("quiet-rt")
+                .setUriTemplate("file://quiet-rt/{foo}")
+                .setDescription("quiet resource template")
+                .setNotifyListChanged(false)
+                .setHandler(args -> null)
+                .register();
+        toolManager.newTool("loud-tool-2")
+                .setDescription("loud tool 2")
+                .setHandler(ta -> ToolResponse.success("ok"))
+                .register();
+        assertLastNotification(client, 5, "notifications/tools/list_changed");
+
+        // The caller can still trigger a notification explicitly for a suppressed feature
+        toolManager.notifyListChanged(conn -> true);
+        assertLastNotification(client, 6, "notifications/tools/list_changed");
+
+        // --- Removal: removing a suppressed feature is silent; the control removal still notifies ---
+
+        assertNotNull(toolManager.removeTool("quiet-tool"));
+        assertNotNull(promptManager.removePrompt("loud-prompt"));
+        assertLastNotification(client, 7, "notifications/prompts/list_changed");
+
+        assertNotNull(promptManager.removePrompt("quiet-prompt"));
+        assertNotNull(toolManager.removeTool("loud-tool"));
+        assertLastNotification(client, 8, "notifications/tools/list_changed");
+
+        assertNotNull(resourceManager.removeResource("file://quiet-res"));
+        assertNotNull(promptManager.removePrompt("loud-prompt-2"));
+        assertLastNotification(client, 9, "notifications/prompts/list_changed");
+
+        assertNotNull(resourceTemplateManager.removeResourceTemplate("quiet-rt"));
+        assertNotNull(toolManager.removeTool("loud-tool-2"));
+        assertLastNotification(client, 10, "notifications/tools/list_changed");
+
+        client.disconnect();
+    }
+
+    private static void assertLastNotification(McpStreamableTestClient client, int expectedCount, String expectedMethod) {
+        List<JsonObject> notifications = client.waitForNotifications(expectedCount).notifications();
+        assertEquals(expectedCount, notifications.size());
+        assertEquals(expectedMethod, notifications.get(expectedCount - 1).getString("method"));
+    }
+}


### PR DESCRIPTION
- add FeatureDefinition#setNotifyListChanged(boolean) to opt a programmatic feature out of the automatic list_changed notification, on both register and remove
- callers can use notifyListChanged(Predicate) instead