### PR TITLE
core: return JSON-RPC error for completion/complete and logging/setLevel without params [2.0.x]

### DIFF
--- a/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpMessageHandler.java
+++ b/core/runtime/src/main/java/io/quarkiverse/mcp/server/runtime/McpMessageHandler.java
@@ -560,6 +560,9 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
     private Future<Void> setLogLevel(JsonObject message, MCP_REQUEST mcpRequest) {
         Object id = Messages.getId(message);
         JsonObject params = Messages.getParams(message);
+        if (params == null) {
+            return mcpRequest.sender().sendError(id, JsonRpcErrorCodes.INVALID_REQUEST, "Missing required params");
+        }
         String level = params.getString("level");
         if (level == null) {
             return mcpRequest.sender().sendError(id, JsonRpcErrorCodes.INVALID_REQUEST, "Log level not set");
@@ -579,6 +582,9 @@ public abstract class McpMessageHandler<MCP_REQUEST extends McpRequest> {
     private Future<Void> complete(JsonObject message, MCP_REQUEST mcpRequest, JsonObject responseMeta) {
         Object id = Messages.getId(message);
         JsonObject params = Messages.getParams(message);
+        if (params == null) {
+            return mcpRequest.sender().sendError(id, JsonRpcErrorCodes.INVALID_REQUEST, "Missing required params");
+        }
         JsonObject ref = params.getJsonObject("ref");
         if (ref == null) {
             return mcpRequest.sender().sendError(id, JsonRpcErrorCodes.INVALID_REQUEST, "Reference not found");

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/complete/InvalidPromptCompleteTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/complete/InvalidPromptCompleteTest.java
@@ -6,8 +6,11 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import io.quarkiverse.mcp.server.JsonRpcErrorCodes;
+import io.quarkiverse.mcp.server.McpMethod;
+import io.quarkiverse.mcp.server.runtime.Messages;
 import io.quarkiverse.mcp.server.test.McpAssured;
 import io.quarkiverse.mcp.server.test.McpAssured.McpSseTestClient;
+import io.quarkiverse.mcp.server.test.McpAssured.McpStreamableTestClient;
 import io.quarkiverse.mcp.server.test.McpServerTest;
 import io.quarkus.test.QuarkusUnitTest;
 
@@ -27,6 +30,19 @@ public class InvalidPromptCompleteTest extends McpServerTest {
                 .withErrorAssert(error -> {
                     assertEquals(JsonRpcErrorCodes.INVALID_PARAMS, error.code());
                     assertEquals("Prompt completion does not exist: bar_name", error.message());
+                })
+                .send()
+                .thenAssertResults();
+    }
+
+    @Test
+    public void testMissingParams() {
+        McpStreamableTestClient client = McpAssured.newConnectedStreamableClient();
+        client.when()
+                .message(Messages.newRequest(100, McpMethod.COMPLETION_COMPLETE.jsonRpcName()))
+                .withErrorAssert(error -> {
+                    assertEquals(JsonRpcErrorCodes.INVALID_REQUEST, error.code());
+                    assertEquals("Missing required params", error.message());
                 })
                 .send()
                 .thenAssertResults();

--- a/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/logging/LoggingSetLevelTest.java
+++ b/transports/http/deployment/src/test/java/io/quarkiverse/mcp/server/test/logging/LoggingSetLevelTest.java
@@ -30,6 +30,12 @@ public class LoggingSetLevelTest extends McpServerTest {
         McpSseTestClient client = McpAssured.newConnectedSseClient();
 
         client.when()
+                .message(client.newRequest(McpMethod.LOGGING_SET_LEVEL))
+                .withErrorAssert(error -> {
+                    assertEquals(JsonRpcErrorCodes.INVALID_REQUEST, error.code());
+                    assertEquals("Missing required params", error.message());
+                })
+                .send()
                 .message(client.newRequest(McpMethod.LOGGING_SET_LEVEL)
                         .put("params", new JsonObject()))
                 .withErrorAssert(error -> {


### PR DESCRIPTION
- fixes #993